### PR TITLE
Fix: Reset to Defaults preserves garage selections

### DIFF
--- a/public/js/storage.js
+++ b/public/js/storage.js
@@ -74,7 +74,9 @@ export function getSettings() {
  * Reset to defaults
  */
 export function resetToDefaults() {
-  saveState({ ...defaultState })
+  const state = loadState()
+  state.settings = { ...defaultState.settings }
+  saveState(state)
   return defaultState.settings
 }
 


### PR DESCRIPTION
## Summary
- Fixes #20
- `resetToDefaults()` now uses load-modify-save pattern to preserve `ownedGarages` and `garageFilterMode`

## Test
1. Add cities to My Garages
2. Change slider values
3. Click Reset to Defaults
4. ✅ Sliders reset, garages preserved