### PR TITLE
Add tooltips to Algorithm Settings sliders

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -29,7 +29,7 @@
       <div class="controls-grid">
         <div class="control-group">
           <div class="control-label">
-            <span class="tooltip" tabindex="0" data-tooltip="Left = prioritize high-paying cargo. Right = prioritize covering more cargo types. Middle = balanced.">Scoring Balance</span>
+            <span class="tooltip" tabindex="0" data-tooltip="Left = prioritize high-paying cargo. Right = prioritize covering more cargo types.">Scoring Balance</span>
             <span class="control-value" id="scoring-value">50</span>
           </div>
           <div class="slider-container">
@@ -41,7 +41,7 @@
 
         <div class="control-group">
           <div class="control-label">
-            <span class="tooltip" tabindex="0" data-tooltip="Number of trailer slots in your garage. More slots = more trailer recommendations.">Garage Size</span>
+            <span class="tooltip" tabindex="0" data-tooltip="Number of trailer slots in your garage (1-20)">Garage Size</span>
             <span class="control-value" id="trailers-value">10</span>
           </div>
           <div class="slider-container">
@@ -53,7 +53,7 @@
 
         <div class="control-group">
           <div class="control-label">
-            <span class="tooltip" tabindex="0" data-tooltip="Controls whether to recommend multiple copies of top trailers or spread across different types. More variety = more cargo types covered, but may reduce average €/km.">Trailer Variety</span>
+            <span class="tooltip" tabindex="0" data-tooltip="Left = allow duplicate trailers if profitable. Right = force different trailer types.">Trailer Variety</span>
             <span class="control-value" id="diminishing-value">50</span>
           </div>
           <div class="slider-container">


### PR DESCRIPTION
## Summary
- Updated tooltip text for all three Algorithm Settings sliders to provide clearer explanations
- **Garage Size**: "Number of trailer slots in your garage (1-20)"
- **Scoring Balance**: "Left = prioritize high-paying cargo. Right = prioritize covering more cargo types."
- **Trailer Variety**: "Left = allow duplicate trailers if profitable. Right = force different trailer types."

## Test plan
- [ ] Hover over each slider label to verify tooltip displays
- [ ] Tab to each slider label to verify tooltip displays on keyboard focus
- [ ] Verify tooltip text matches the requirements above

Fixes #28