### PR TITLE
fix(build): add base path for GitHub Pages deployment

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,7 @@ import { resolve } from 'path'
 
 export default defineConfig({
   root: 'public',
+  base: '/trucker/',
   build: {
     outDir: 'dist',
     emptyOutDir: true,


### PR DESCRIPTION
## Summary
- Added `base: '/trucker/'` to `vite.config.ts`
- Fixes asset paths from `/assets/*` to `/trucker/assets/*`
- Production site will load JS/CSS correctly on GitHub Pages

## Problem
Production site was completely broken. Assets returned 404:
```
Failed to load resource: 404 @ https://alexoq.github.io/assets/main-BC-Xmy9A.js
```

## Solution
Single line change - add `base: '/trucker/'` to Vite config.

## Verification
- [x] Build succeeds
- [x] Built HTML references `/trucker/assets/*` paths
- [x] All 39 tests pass
- [x] Lint: 0 errors

## Test Plan
1. Merge this PR
2. Wait for GitHub Pages deploy
3. Verify https://alexoq.github.io/trucker/ loads correctly

Closes #60