### PR TITLE
Add unit tests for data.js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@types/express": "^4.17.21",
         "@types/node": "^20.10.0",
         "@types/pg": "^8.10.9",
+        "@vitest/coverage-v8": "^4.0.18",
         "eslint": "^9.39.2",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-no-unsanitized": "^4.1.4",
@@ -26,6 +27,66 @@
         "typescript": "^5.3.2",
         "vite": "^7.3.1",
         "vitest": "^4.0.18"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.6.tgz",
+      "integrity": "sha512-TeR9zWR18BvbfPmGbLampPMW+uW1NZnJlRuuHso8i87QZNq2JRF9i6RgxRqtEq+wQGsS19NNTWr2duhnE49mfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.6"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.6.tgz",
+      "integrity": "sha512-0ZrskXVEHSWIqZM/sQZ4EV3jZJXRkio/WCxaqKZP1g//CEWEPSfeZFcms4XeKBCHU0ZKnIkdJeU/kF+eRp5lBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -716,12 +777,33 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
     },
     "node_modules/@playwright/test": {
       "version": "1.58.0",
@@ -1258,6 +1340,37 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.0.18.tgz",
+      "integrity": "sha512-7i+N2i0+ME+2JFZhfuz7Tg/FqKtilHjGyGvoHYQ6iLV0zahbsJ9sljC9OcFcPDbhYKCet+sG8SsVqlyGvPflZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.0.18",
+        "ast-v8-to-istanbul": "^0.3.10",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.1",
+        "obug": "^2.1.1",
+        "std-env": "^3.10.0",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.0.18",
+        "vitest": "4.0.18"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "4.0.18",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.18.tgz",
@@ -1432,6 +1545,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.10",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.10.tgz",
+      "integrity": "sha512-p4K7vMz2ZSk3wN8l5o3y2bJAoZXT3VuJI5OLTATY/01CYWumWvwkUw0SqDBnNq6IiTO3qDa1eSQDibAV8g7XOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^9.0.1"
       }
     },
     "node_modules/balanced-match": {
@@ -2343,6 +2468,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/http-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
@@ -2457,6 +2589,52 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/js-yaml": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
@@ -2555,6 +2733,34 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.1.tgz",
+      "integrity": "sha512-xrHS24IxaLrvuo613F719wvOIv9xPHFWQHuvGUBmPnCA/3MQxKI3b+r7n1jAoDHmsbC5bRhTZYR77invLAxVnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.28.5",
+        "@babel/types": "^7.28.5",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/math-intrinsics": {
@@ -3222,6 +3428,19 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/send": {
       "version": "0.19.2",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@types/express": "^4.17.21",
     "@types/node": "^20.10.0",
     "@types/pg": "^8.10.9",
+    "@vitest/coverage-v8": "^4.0.18",
     "eslint": "^9.39.2",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-no-unsanitized": "^4.1.4",

--- a/public/js/data.test.js
+++ b/public/js/data.test.js
@@ -1,0 +1,407 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Mock fetch
+const fetchMock = vi.fn();
+vi.stubGlobal('fetch', fetchMock);
+
+// Dynamic import after mocking
+const data = await import('./data.js');
+
+// Sample test data
+const sampleCities = [
+  { id: 1, name: 'Berlin', country: 'Germany' },
+  { id: 2, name: 'Paris', country: 'France' },
+];
+
+const sampleCompanies = [
+  { id: 1, name: 'EuroGoodies' },
+  { id: 2, name: 'Posped' },
+];
+
+const sampleCargo = [
+  { id: 1, name: 'Electronics', value: 100, fragile: false, high_value: true, excluded: false },
+  { id: 2, name: 'Glass', value: 80, fragile: true, high_value: false, excluded: false },
+  { id: 3, name: 'Excluded Cargo', value: 50, fragile: false, high_value: false, excluded: true },
+  { id: 4, name: 'Premium Glass', value: 120, fragile: true, high_value: true, excluded: false },
+];
+
+const sampleTrailers = [
+  { id: 1, name: 'Curtainsider', ownable: true },
+  { id: 2, name: 'Refrigerated', ownable: true },
+  { id: 3, name: 'Special Trailer', ownable: false },
+];
+
+const sampleCityCompanies = [
+  { cityId: 1, companyId: 1, count: 2 },
+  { cityId: 1, companyId: 2, count: 1 },
+  { cityId: 2, companyId: 1, count: 1 },
+];
+
+const sampleCompanyCargo = [
+  { companyId: 1, cargoId: 1 },
+  { companyId: 1, cargoId: 2 },
+  { companyId: 2, cargoId: 3 },
+  { companyId: 2, cargoId: 4 },
+];
+
+const sampleCargoTrailers = [
+  { cargoId: 1, trailerId: 1 },
+  { cargoId: 1, trailerId: 2 },
+  { cargoId: 2, trailerId: 1 },
+  { cargoId: 4, trailerId: 2 },
+];
+
+function createFetchResponse(data, ok = true, status = 200) {
+  return Promise.resolve({
+    ok,
+    status,
+    json: () => Promise.resolve(data),
+  });
+}
+
+describe('data.js', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Reset the module cache by clearing dataCache (if accessible)
+    // Since dataCache is internal, we reload the module for fresh state
+  });
+
+  describe('loadAllData', () => {
+    it('loads all data files and returns combined object', async () => {
+      fetchMock
+        .mockResolvedValueOnce(createFetchResponse(sampleCities))
+        .mockResolvedValueOnce(createFetchResponse(sampleCompanies))
+        .mockResolvedValueOnce(createFetchResponse(sampleCargo))
+        .mockResolvedValueOnce(createFetchResponse(sampleTrailers))
+        .mockResolvedValueOnce(createFetchResponse(sampleCityCompanies))
+        .mockResolvedValueOnce(createFetchResponse(sampleCompanyCargo))
+        .mockResolvedValueOnce(createFetchResponse(sampleCargoTrailers));
+
+      // Need fresh import to test without cache
+      vi.resetModules();
+      vi.stubGlobal('fetch', fetchMock);
+      const freshData = await import('./data.js');
+      const result = await freshData.loadAllData();
+
+      expect(result.cities).toEqual(sampleCities);
+      expect(result.companies).toEqual(sampleCompanies);
+      expect(result.cargo).toEqual(sampleCargo);
+      expect(result.trailers).toEqual(sampleTrailers);
+      expect(result.cityCompanies).toEqual(sampleCityCompanies);
+      expect(result.companyCargo).toEqual(sampleCompanyCargo);
+      expect(result.cargoTrailers).toEqual(sampleCargoTrailers);
+      expect(fetchMock).toHaveBeenCalledTimes(7);
+    });
+
+    it('throws error on HTTP failure', async () => {
+      fetchMock.mockResolvedValueOnce(createFetchResponse(null, false, 404));
+
+      vi.resetModules();
+      vi.stubGlobal('fetch', fetchMock);
+      const freshData = await import('./data.js');
+
+      await expect(freshData.loadAllData()).rejects.toThrow('HTTP 404');
+    });
+
+    it('throws error on network failure', async () => {
+      fetchMock.mockRejectedValueOnce(new Error('Network error'));
+
+      vi.resetModules();
+      vi.stubGlobal('fetch', fetchMock);
+      const freshData = await import('./data.js');
+
+      await expect(freshData.loadAllData()).rejects.toThrow('Network error');
+    });
+
+    it('throws error on malformed JSON', async () => {
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.reject(new SyntaxError('Unexpected token')),
+      });
+
+      vi.resetModules();
+      vi.stubGlobal('fetch', fetchMock);
+      const freshData = await import('./data.js');
+
+      await expect(freshData.loadAllData()).rejects.toThrow();
+    });
+
+    it('caches loaded data and does not refetch', async () => {
+      fetchMock
+        .mockResolvedValueOnce(createFetchResponse(sampleCities))
+        .mockResolvedValueOnce(createFetchResponse(sampleCompanies))
+        .mockResolvedValueOnce(createFetchResponse(sampleCargo))
+        .mockResolvedValueOnce(createFetchResponse(sampleTrailers))
+        .mockResolvedValueOnce(createFetchResponse(sampleCityCompanies))
+        .mockResolvedValueOnce(createFetchResponse(sampleCompanyCargo))
+        .mockResolvedValueOnce(createFetchResponse(sampleCargoTrailers));
+
+      vi.resetModules();
+      vi.stubGlobal('fetch', fetchMock);
+      const freshData = await import('./data.js');
+
+      // First call
+      await freshData.loadAllData();
+      expect(fetchMock).toHaveBeenCalledTimes(7);
+
+      // Second call should use cache
+      await freshData.loadAllData();
+      expect(fetchMock).toHaveBeenCalledTimes(7); // No additional calls
+    });
+  });
+
+  describe('buildLookups', () => {
+    const testData = {
+      cities: sampleCities,
+      companies: sampleCompanies,
+      cargo: sampleCargo,
+      trailers: sampleTrailers,
+      cityCompanies: sampleCityCompanies,
+      companyCargo: sampleCompanyCargo,
+      cargoTrailers: sampleCargoTrailers,
+    };
+
+    it('creates citiesById map correctly', () => {
+      const lookups = data.buildLookups(testData);
+
+      expect(lookups.citiesById.get(1)).toEqual({ id: 1, name: 'Berlin', country: 'Germany' });
+      expect(lookups.citiesById.get(2)).toEqual({ id: 2, name: 'Paris', country: 'France' });
+      expect(lookups.citiesById.get(999)).toBeUndefined();
+    });
+
+    it('creates companiesById map correctly', () => {
+      const lookups = data.buildLookups(testData);
+
+      expect(lookups.companiesById.get(1)).toEqual({ id: 1, name: 'EuroGoodies' });
+      expect(lookups.companiesById.get(2)).toEqual({ id: 2, name: 'Posped' });
+    });
+
+    it('creates cargoById map correctly', () => {
+      const lookups = data.buildLookups(testData);
+
+      expect(lookups.cargoById.get(1).name).toBe('Electronics');
+      expect(lookups.cargoById.get(2).name).toBe('Glass');
+      expect(lookups.cargoById.size).toBe(4);
+    });
+
+    it('creates trailersById map correctly', () => {
+      const lookups = data.buildLookups(testData);
+
+      expect(lookups.trailersById.get(1).name).toBe('Curtainsider');
+      expect(lookups.trailersById.get(3).ownable).toBe(false);
+    });
+
+    it('creates cityCompanyMap with company counts', () => {
+      const lookups = data.buildLookups(testData);
+
+      const berlinCompanies = lookups.cityCompanyMap.get(1);
+      expect(berlinCompanies).toHaveLength(2);
+      expect(berlinCompanies).toContainEqual({ companyId: 1, count: 2 });
+      expect(berlinCompanies).toContainEqual({ companyId: 2, count: 1 });
+
+      const parisCompanies = lookups.cityCompanyMap.get(2);
+      expect(parisCompanies).toHaveLength(1);
+      expect(parisCompanies[0]).toEqual({ companyId: 1, count: 1 });
+    });
+
+    it('creates companyCargoMap correctly', () => {
+      const lookups = data.buildLookups(testData);
+
+      const euroGoodiesCargo = lookups.companyCargoMap.get(1);
+      expect(euroGoodiesCargo).toContain(1);
+      expect(euroGoodiesCargo).toContain(2);
+
+      const pospedCargo = lookups.companyCargoMap.get(2);
+      expect(pospedCargo).toContain(3);
+      expect(pospedCargo).toContain(4);
+    });
+
+    it('creates trailerCargoMap as Set', () => {
+      const lookups = data.buildLookups(testData);
+
+      const curtainsiderCargo = lookups.trailerCargoMap.get(1);
+      expect(curtainsiderCargo).toBeInstanceOf(Set);
+      expect(curtainsiderCargo.has(1)).toBe(true);
+      expect(curtainsiderCargo.has(2)).toBe(true);
+
+      const refrigeratedCargo = lookups.trailerCargoMap.get(2);
+      expect(refrigeratedCargo.has(1)).toBe(true);
+      expect(refrigeratedCargo.has(4)).toBe(true);
+    });
+
+    it('creates cargoTrailerMap as Set', () => {
+      const lookups = data.buildLookups(testData);
+
+      const electronicsTrailers = lookups.cargoTrailerMap.get(1);
+      expect(electronicsTrailers).toBeInstanceOf(Set);
+      expect(electronicsTrailers.has(1)).toBe(true);
+      expect(electronicsTrailers.has(2)).toBe(true);
+
+      const glassTrailers = lookups.cargoTrailerMap.get(2);
+      expect(glassTrailers.has(1)).toBe(true);
+      expect(glassTrailers.size).toBe(1);
+    });
+
+    it('handles empty data arrays', () => {
+      const emptyData = {
+        cities: [],
+        companies: [],
+        cargo: [],
+        trailers: [],
+        cityCompanies: [],
+        companyCargo: [],
+        cargoTrailers: [],
+      };
+
+      const lookups = data.buildLookups(emptyData);
+
+      expect(lookups.citiesById.size).toBe(0);
+      expect(lookups.companiesById.size).toBe(0);
+      expect(lookups.cargoById.size).toBe(0);
+      expect(lookups.trailersById.size).toBe(0);
+      expect(lookups.cityCompanyMap.size).toBe(0);
+      expect(lookups.companyCargoMap.size).toBe(0);
+      expect(lookups.trailerCargoMap.size).toBe(0);
+      expect(lookups.cargoTrailerMap.size).toBe(0);
+    });
+  });
+
+  describe('getCityCargoPool', () => {
+    const testData = {
+      cities: sampleCities,
+      companies: sampleCompanies,
+      cargo: sampleCargo,
+      trailers: sampleTrailers,
+      cityCompanies: sampleCityCompanies,
+      companyCargo: sampleCompanyCargo,
+      cargoTrailers: sampleCargoTrailers,
+    };
+
+    it('returns cargo pool for a city', () => {
+      const lookups = data.buildLookups(testData);
+      const pool = data.getCityCargoPool(1, testData, lookups);
+
+      // Berlin has EuroGoodies (count 2) with Electronics and Glass
+      // and Posped (count 1) with Excluded Cargo and Premium Glass
+      // Excluded cargo should not appear
+      expect(pool.length).toBe(3); // Electronics, Glass, Premium Glass
+
+      const cargoNames = pool.map((p) => p.cargoName);
+      expect(cargoNames).toContain('Electronics');
+      expect(cargoNames).toContain('Glass');
+      expect(cargoNames).toContain('Premium Glass');
+      expect(cargoNames).not.toContain('Excluded Cargo');
+    });
+
+    it('excludes cargo marked as excluded', () => {
+      const lookups = data.buildLookups(testData);
+      const pool = data.getCityCargoPool(1, testData, lookups);
+
+      const excludedCargo = pool.find((p) => p.cargoName === 'Excluded Cargo');
+      expect(excludedCargo).toBeUndefined();
+    });
+
+    it('applies 30% bonus for high_value cargo', () => {
+      const lookups = data.buildLookups(testData);
+      const pool = data.getCityCargoPool(1, testData, lookups);
+
+      const electronics = pool.find((p) => p.cargoName === 'Electronics');
+      // Electronics: value 100, high_value=true -> 100 * 1.3 = 130
+      expect(electronics.value).toBe(130);
+    });
+
+    it('applies 30% bonus for fragile cargo', () => {
+      const lookups = data.buildLookups(testData);
+      const pool = data.getCityCargoPool(1, testData, lookups);
+
+      const glass = pool.find((p) => p.cargoName === 'Glass');
+      // Glass: value 80, fragile=true -> 80 * 1.3 = 104
+      expect(glass.value).toBe(104);
+    });
+
+    it('stacks bonuses for fragile AND high_value cargo (60%)', () => {
+      const lookups = data.buildLookups(testData);
+      const pool = data.getCityCargoPool(1, testData, lookups);
+
+      const premiumGlass = pool.find((p) => p.cargoName === 'Premium Glass');
+      // Premium Glass: value 120, fragile=true, high_value=true -> 120 * 1.6 = 192
+      expect(premiumGlass.value).toBe(192);
+    });
+
+    it('includes depot count in pool entries', () => {
+      const lookups = data.buildLookups(testData);
+      const pool = data.getCityCargoPool(1, testData, lookups);
+
+      // EuroGoodies has count 2 in Berlin
+      const electronics = pool.find((p) => p.cargoName === 'Electronics');
+      expect(electronics.depotCount).toBe(2);
+
+      // Posped has count 1 in Berlin
+      const premiumGlass = pool.find((p) => p.cargoName === 'Premium Glass');
+      expect(premiumGlass.depotCount).toBe(1);
+    });
+
+    it('returns empty array for city with no companies', () => {
+      const lookups = data.buildLookups(testData);
+      const pool = data.getCityCargoPool(999, testData, lookups);
+
+      expect(pool).toEqual([]);
+    });
+
+    it('returns empty array for city with companies but no cargo', () => {
+      const dataWithEmptyCargo = {
+        ...testData,
+        companyCargo: [],
+      };
+      const lookups = data.buildLookups(dataWithEmptyCargo);
+      const pool = data.getCityCargoPool(1, dataWithEmptyCargo, lookups);
+
+      expect(pool).toEqual([]);
+    });
+  });
+
+  describe('getOwnableTrailers', () => {
+    const testData = {
+      trailers: sampleTrailers,
+    };
+
+    it('returns only ownable trailers', () => {
+      const ownable = data.getOwnableTrailers(testData);
+
+      expect(ownable).toHaveLength(2);
+      expect(ownable.every((t) => t.ownable)).toBe(true);
+    });
+
+    it('excludes non-ownable trailers', () => {
+      const ownable = data.getOwnableTrailers(testData);
+
+      const specialTrailer = ownable.find((t) => t.name === 'Special Trailer');
+      expect(specialTrailer).toBeUndefined();
+    });
+
+    it('returns empty array when no trailers are ownable', () => {
+      const dataWithNoOwnable = {
+        trailers: [
+          { id: 1, name: 'Trailer A', ownable: false },
+          { id: 2, name: 'Trailer B', ownable: false },
+        ],
+      };
+
+      const ownable = data.getOwnableTrailers(dataWithNoOwnable);
+      expect(ownable).toEqual([]);
+    });
+
+    it('returns all trailers when all are ownable', () => {
+      const dataWithAllOwnable = {
+        trailers: [
+          { id: 1, name: 'Trailer A', ownable: true },
+          { id: 2, name: 'Trailer B', ownable: true },
+        ],
+      };
+
+      const ownable = data.getOwnableTrailers(dataWithAllOwnable);
+      expect(ownable).toHaveLength(2);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds comprehensive unit tests for `public/js/data.js` (data loading module)
- Tests cover all exported functions: `loadAllData`, `buildLookups`, `getCityCargoPool`, `getOwnableTrailers`
- Includes error condition tests: HTTP failures, network errors, malformed JSON
- Adds `@vitest/coverage-v8` for coverage reporting

## Test Coverage
- **data.js: 100%** (statements, branches, functions, lines)
- 26 new tests added

## Acceptance Criteria
- [x] Tests for loadData() fetch and caching
- [x] Tests for buildLookups() map creation
- [x] Tests for error conditions (network failure, malformed JSON)
- [x] Coverage >80% for data.js (achieved: 100%)

Closes #46