### PR TITLE
P2: Add CSV/JSON export for trailer recommendations

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -365,6 +365,24 @@ input[type="range"]::-moz-range-thumb {
   margin-bottom: 0;
 }
 
+.export-buttons {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.export-btn {
+  background: transparent;
+  border: 1px solid #3498db;
+  color: #3498db;
+}
+
+.export-btn:hover {
+  background: rgba(52, 152, 219, 0.1);
+  border-color: #5dade2;
+  color: #5dade2;
+}
+
 /* Stats Row */
 .stats {
   display: flex;

--- a/src/frontend/main.ts
+++ b/src/frontend/main.ts
@@ -394,7 +394,11 @@ function renderCity(cityId: number) {
     <div class="table-section">
       <div class="section-header">
         <h2>Recommended Trailers</h2>
-        <button class="btn copy-btn" id="copy-trailers-btn">Copy to clipboard</button>
+        <div class="export-buttons">
+          <button class="btn copy-btn" id="copy-trailers-btn">Copy to clipboard</button>
+          <button class="btn export-btn" id="export-csv-btn">Export CSV</button>
+          <button class="btn export-btn" id="export-json-btn">Export JSON</button>
+        </div>
       </div>
       <table>
         <thead>
@@ -437,6 +441,21 @@ function renderCity(cityId: number) {
     const text = `${city.name} (${totalTrailers} trailers): ${trailerList}`;
 
     copyToClipboard(text, copyBtn);
+  });
+
+  // Add export button handlers
+  document.getElementById('export-csv-btn')!.addEventListener('click', () => {
+    exportToCSV(city.name, result.recommendations);
+  });
+
+  document.getElementById('export-json-btn')!.addEventListener('click', () => {
+    exportToJSON(
+      city.name,
+      result.recommendations,
+      result.totalDepots,
+      result.totalCargoInstances,
+      result.totalValue
+    );
   });
 
   // Add garage toggle handler
@@ -514,6 +533,86 @@ function fallbackCopy(text: string): boolean {
     document.body.removeChild(textarea);
     return false;
   }
+}
+
+// Download file helper
+function downloadFile(content: string, filename: string, mimeType: string) {
+  const blob = new Blob([content], { type: mimeType });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}
+
+// Export recommendations to CSV
+function exportToCSV(
+  cityName: string,
+  recommendations: Array<{
+    trailerName: string;
+    count: number;
+    coveragePct: number;
+    avgValue: number;
+    score: number;
+    topCargoes: string[];
+  }>
+) {
+  const headers = ['Trailer', 'Copies', 'Coverage %', 'Avg Value (€/Job)', 'Score', 'Top Cargoes'];
+  const rows = recommendations.map((r) => [
+    `"${r.trailerName}"`,
+    r.count,
+    r.coveragePct,
+    r.avgValue.toFixed(2),
+    r.score.toFixed(3),
+    `"${r.topCargoes.join(', ')}"`,
+  ]);
+
+  const csv = [headers.join(','), ...rows.map((row) => row.join(','))].join('\n');
+  const safeCityName = cityName.replace(/[^a-zA-Z0-9]/g, '_');
+  downloadFile(csv, `${safeCityName}_trailers.csv`, 'text/csv;charset=utf-8');
+}
+
+// Export recommendations to JSON
+function exportToJSON(
+  cityName: string,
+  recommendations: Array<{
+    trailerName: string;
+    count: number;
+    coveragePct: number;
+    avgValue: number;
+    score: number;
+    topCargoes: string[];
+  }>,
+  totalDepots: number,
+  totalCargoInstances: number,
+  totalValue: number
+) {
+  const exportData = {
+    city: cityName,
+    exportedAt: new Date().toISOString(),
+    summary: {
+      totalDepots,
+      totalCargoInstances,
+      totalValue,
+      totalTrailers: recommendations.reduce((sum, r) => sum + r.count, 0),
+      trailerTypes: recommendations.length,
+    },
+    recommendations: recommendations.map((r) => ({
+      trailer: r.trailerName,
+      copies: r.count,
+      coveragePercent: r.coveragePct,
+      avgValuePerJob: r.avgValue,
+      score: r.score,
+      topCargoes: r.topCargoes,
+    })),
+  };
+
+  const json = JSON.stringify(exportData, null, 2);
+  const safeCityName = cityName.replace(/[^a-zA-Z0-9]/g, '_');
+  downloadFile(json, `${safeCityName}_trailers.json`, 'application/json');
 }
 
 // Show city detail view


### PR DESCRIPTION
## Summary
- Adds "Export CSV" and "Export JSON" buttons to the city detail view alongside the existing "Copy to clipboard" button
- CSV format includes all recommendation columns: trailer name, copies, coverage %, avg value, score, and top cargoes
- JSON format includes full metadata: city name, export timestamp, summary stats, and structured recommendations data

## Changes
- `src/frontend/main.ts`: Added export buttons, `downloadFile()` helper, `exportToCSV()` and `exportToJSON()` functions
- `public/css/style.css`: Added `.export-buttons` container and `.export-btn` styling (blue theme)

## Test plan
- [x] TypeScript compiles without errors
- [x] All 65 existing tests pass
- [x] Frontend build succeeds
- [ ] Manual test: navigate to city, click Export CSV, verify file downloads
- [ ] Manual test: navigate to city, click Export JSON, verify file downloads with metadata

Closes #49