### PR TITLE
Fix mobile horizontal overflow

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -6,6 +6,11 @@
   padding: 0;
 }
 
+html, body {
+  overflow-x: hidden;
+  max-width: 100vw;
+}
+
 body {
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
   background: #1a1a2e;


### PR DESCRIPTION
## Summary
- Add `overflow-x: hidden` and `max-width: 100vw` to html and body elements
- Prevents unwanted horizontal scrolling on mobile viewports (375px width)

## Test plan
- [x] Open site on mobile viewport (375x667)
- [x] Verify no horizontal scroll is available

Closes #90