### PR TITLE
fix(ui): garage filter count and rank display bugs

### DIFF
--- a/src/frontend/main.ts
+++ b/src/frontend/main.ts
@@ -158,9 +158,38 @@ function formatRank(rank: number, total: number, score: number | null = null): s
   return `<span class="${className}"${tooltipAttrs}><span class="rank">#${rank}</span> of ${total}</span>`;
 }
 
-// Update garage count badge
+// Update garage count badge (reflects current filters)
 function updateGarageCount() {
-  const count = getOwnedGarages().length;
+  const ownedGarages = getOwnedGarages();
+
+  // If data not loaded yet, show total count
+  if (!data || !lookups) {
+    document.getElementById('garage-count')!.textContent = ownedGarages.length.toString();
+    return;
+  }
+
+  // Apply current filters to owned garages
+  const searchTerm = normalize(citySearch.value);
+  const selectedCountries = getSelectedCountries();
+
+  let count = 0;
+  for (const cityId of ownedGarages) {
+    const city = lookups.citiesById.get(cityId);
+    if (!city) continue;
+
+    // Check search filter
+    if (searchTerm && !normalize(city.name).includes(searchTerm) && !normalize(city.country).includes(searchTerm)) {
+      continue;
+    }
+
+    // Check country filter
+    if (selectedCountries.length > 0 && !selectedCountries.includes(city.country)) {
+      continue;
+    }
+
+    count++;
+  }
+
   document.getElementById('garage-count')!.textContent = count.toString();
 }
 
@@ -327,10 +356,24 @@ function renderRankings() {
       }
     });
   });
+
+  // Update garage count badge to reflect current filters
+  updateGarageCount();
+}
+
+// Ensure rankings are cached (for city rank lookup)
+function ensureRankingsCached() {
+  if (cachedRankings === null && data && lookups) {
+    const options = getOptions();
+    cachedRankings = calculateCityRankings(data, lookups, options);
+  }
 }
 
 // Render city detail view
 function renderCity(cityId: number) {
+  // Ensure rankings are cached for rank display
+  ensureRankingsCached();
+
   const options = getOptions();
   const result = optimizeTrailerSet(cityId, data!, lookups!, options);
   const city = lookups!.citiesById.get(cityId);


### PR DESCRIPTION
## Summary
- Fix My Garages filter showing incorrect count - badge now reflects current search/country filters
- Fix rank display showing '-' when navigating via URL hash - cache rankings before rendering city detail

## Changes
- `updateGarageCount()` now applies the same filters used in the rankings table
- Added `ensureRankingsCached()` helper to ensure rankings are available for city rank lookup
- Called `updateGarageCount()` after rendering rankings to keep badge in sync

## Testing
- Toggle "My Garages" with search/country filters active → count shows filtered matches
- Navigate directly to a city URL → rank displays correctly

Closes #88
Closes #89