### PR TITLE
fix(storage): unify country filter into AppState and fix reset

### DIFF
--- a/public/js/storage.test.js
+++ b/public/js/storage.test.js
@@ -41,6 +41,7 @@ describe('storage', () => {
         },
         ownedGarages: [],
         garageFilterMode: 'all',
+        selectedCountries: [],
         ownedTrailers: {},
       });
     });

--- a/src/frontend/main.ts
+++ b/src/frontend/main.ts
@@ -771,6 +771,8 @@ async function init() {
       scoringSlider.value = defaults.scoringBalance.toString();
       trailersSlider.value = defaults.maxTrailers.toString();
       diminishingSlider.value = defaults.diminishingFactor.toString();
+      renderCountryCheckboxes();
+      updateCountryButtonText();
       onSliderChange();
     });
 

--- a/src/frontend/storage.ts
+++ b/src/frontend/storage.ts
@@ -15,8 +15,11 @@ interface AppState {
   settings: Settings;
   ownedGarages: number[];
   garageFilterMode: string;
+  selectedCountries: string[];
   ownedTrailers: Record<string, any>;
 }
+
+const LEGACY_COUNTRIES_KEY = 'ets2-selected-countries';
 
 const defaultState: AppState = {
   settings: {
@@ -24,10 +27,9 @@ const defaultState: AppState = {
     maxTrailers: 10,
     diminishingFactor: 50,
   },
-  // Garage management
   ownedGarages: [],
   garageFilterMode: 'all',
-  // Future expansion
+  selectedCountries: [],
   ownedTrailers: {},
 };
 
@@ -39,8 +41,7 @@ export function loadState(): AppState {
     const stored = localStorage.getItem(STORAGE_KEY);
     if (stored) {
       const parsed = JSON.parse(stored);
-      // Merge with defaults to handle new fields
-      return {
+      const state = {
         ...defaultState,
         ...parsed,
         settings: {
@@ -48,6 +49,16 @@ export function loadState(): AppState {
           ...parsed.settings,
         },
       };
+      // Migrate legacy country filter key into unified state
+      if (!parsed.selectedCountries) {
+        const legacy = localStorage.getItem(LEGACY_COUNTRIES_KEY);
+        if (legacy) {
+          state.selectedCountries = JSON.parse(legacy);
+          localStorage.removeItem(LEGACY_COUNTRIES_KEY);
+          saveState(state);
+        }
+      }
+      return state;
     }
   } catch (e) {
     console.warn('Failed to load state from localStorage:', e);
@@ -89,6 +100,7 @@ export function getSettings(): Settings {
 export function resetToDefaults(): Settings {
   const state = loadState();
   state.settings = { ...defaultState.settings };
+  state.selectedCountries = [];
   saveState(state);
   return defaultState.settings;
 }
@@ -174,22 +186,14 @@ export function setFilterMode(mode: string): string {
  * Get list of selected countries
  */
 export function getSelectedCountries(): string[] {
-  try {
-    const saved = localStorage.getItem('ets2-selected-countries');
-    return saved ? JSON.parse(saved) : [];
-  } catch (e) {
-    console.warn('Failed to load selected countries:', e);
-    return [];
-  }
+  return loadState().selectedCountries || [];
 }
 
 /**
  * Set selected countries list
  */
 export function setSelectedCountries(countries: string[]): void {
-  try {
-    localStorage.setItem('ets2-selected-countries', JSON.stringify(countries));
-  } catch (e) {
-    console.warn('Failed to save selected countries:', e);
-  }
+  const state = loadState();
+  state.selectedCountries = countries;
+  saveState(state);
 }


### PR DESCRIPTION
## Summary
- Move `selectedCountries` from separate localStorage key into unified `AppState`
- `resetToDefaults()` now clears country filter selection
- Graceful migration: reads old `ets2-selected-countries` key, merges into state, deletes old key
- Reset button handler refreshes country filter UI (checkboxes + button text)

## Testing
- All 65 tests pass
- TypeScript type check clean

Closes #100