### PR TITLE
perf(optimizer): decouple city scoring from full optimization and add debouncing

### DIFF
--- a/src/frontend/main.ts
+++ b/src/frontend/main.ts
@@ -1,5 +1,5 @@
 import { loadAllData, buildLookups } from './data.js';
-import { optimizeTrailerSet, calculateCityRankings } from './optimizer.js';
+import { optimizeTrailerSet, calculateCityRankings, type CityRanking } from './optimizer.js';
 import {
   getSettings,
   updateSettings,
@@ -17,7 +17,16 @@ import type { AllData, Lookups } from './data.js';
 let data: AllData | null = null;
 let lookups: Lookups | null = null;
 let currentCityId: number | null = null;
-let cachedRankings: any[] | null = null;
+let cachedRankings: CityRanking[] | null = null;
+
+// Debounce utility
+function debounce(fn: () => void, ms: number): () => void {
+  let timer: ReturnType<typeof setTimeout>;
+  return () => {
+    clearTimeout(timer);
+    timer = setTimeout(fn, ms);
+  };
+}
 
 // Extract unique countries from data, sorted alphabetically
 function getUniqueCountries(): string[] {
@@ -693,15 +702,21 @@ function handleHashNavigation(): boolean {
   return false;
 }
 
-// Handle slider changes
-function onSliderChange() {
-  updateDisplayValues();
-  saveSettings();
+// Debounced computation after slider changes
+const debouncedRender = debounce(() => {
   if (currentCityId) {
     renderCity(currentCityId);
   } else {
     renderRankings();
   }
+}, 150);
+
+// Handle slider changes (display updates immediate, computation debounced)
+function onSliderChange() {
+  updateDisplayValues();
+  saveSettings();
+  cachedRankings = null;
+  debouncedRender();
 }
 
 // Show loading state
@@ -757,7 +772,7 @@ async function init() {
     scoringSlider.addEventListener('input', onSliderChange);
     trailersSlider.addEventListener('input', onSliderChange);
     diminishingSlider.addEventListener('input', onSliderChange);
-    citySearch.addEventListener('input', renderRankings);
+    citySearch.addEventListener('input', debounce(renderRankings, 150));
 
     backLink.addEventListener('click', showRankings);
     window.addEventListener('hashchange', () => {

--- a/src/frontend/optimizer.ts
+++ b/src/frontend/optimizer.ts
@@ -50,7 +50,7 @@ interface OptimizationResult {
   options: Required<OptimizationOptions>;
 }
 
-interface CityRanking {
+export interface CityRanking {
   id: number;
   name: string;
   country: string;
@@ -255,6 +255,32 @@ export function optimizeTrailerSet(
 }
 
 /**
+ * Lightweight city stats for rankings (skips greedy trailer selection)
+ */
+export function calculateCityStats(
+  cityId: number,
+  data: AllData,
+  lookups: Lookups
+): { totalDepots: number; totalCargoInstances: number; totalValue: number } {
+  const cargoPool = getCityCargoPool(cityId, data, lookups);
+
+  let totalCargoInstances = 0;
+  let totalValue = 0;
+  for (const entry of cargoPool) {
+    totalCargoInstances += entry.depotCount;
+    totalValue += entry.value * entry.depotCount;
+  }
+
+  const cityCompanies = lookups.cityCompanyMap.get(cityId) || [];
+  let totalDepots = 0;
+  for (const { count } of cityCompanies) {
+    totalDepots += count;
+  }
+
+  return { totalDepots, totalCargoInstances, totalValue };
+}
+
+/**
  * Calculate city rankings based on profitability
  */
 export function calculateCityRankings(
@@ -265,7 +291,7 @@ export function calculateCityRankings(
   const rankings: CityRanking[] = [];
 
   for (const city of data.cities) {
-    const result = optimizeTrailerSet(city.id, data, lookups, options);
+    const result = calculateCityStats(city.id, data, lookups);
 
     if (result.totalCargoInstances === 0) continue;
 


### PR DESCRIPTION
## Summary
- Add lightweight `calculateCityStats()` that computes depot/cargo/value stats without running greedy trailer selection
- `calculateCityRankings()` now uses the stats-only path (skips ~54K iterations per render)
- Add 150ms debounce on search input and slider computation (display values update immediately)
- Export `CityRanking` type and use it for `cachedRankings` instead of `any[]`

## Testing
- All 65 tests pass
- Rankings order unchanged (same scoring formula)

Closes #101