### PR TITLE
feat(a11y): add ARIA labels and skip navigation

### DIFF
--- a/public/cargo.html
+++ b/public/cargo.html
@@ -7,6 +7,7 @@
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
+  <a href="#main-content" class="skip-link">Skip to main content</a>
   <div class="container">
     <header>
       <div class="header-title">
@@ -21,8 +22,9 @@
       </nav>
     </header>
 
+    <main id="main-content">
     <div class="search-box">
-      <input type="text" id="search" placeholder="Search cargo...">
+      <input type="text" id="search" placeholder="Search cargo..." aria-label="Search cargo">
     </div>
 
     <div id="content">
@@ -33,6 +35,7 @@
       <a href="#" class="back-link" id="back-link">← Back to cargo</a>
       <div id="detail-content"></div>
     </div>
+    </main>
   </div>
 
   <script type="module" src="/src/frontend/cargo.ts"></script>

--- a/public/cities.html
+++ b/public/cities.html
@@ -7,6 +7,7 @@
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
+  <a href="#main-content" class="skip-link">Skip to main content</a>
   <div class="container">
     <header>
       <div class="header-title">
@@ -21,8 +22,9 @@
       </nav>
     </header>
 
+    <main id="main-content">
     <div class="search-box">
-      <input type="text" id="search" placeholder="Search cities...">
+      <input type="text" id="search" placeholder="Search cities..." aria-label="Search cities">
     </div>
 
     <div id="content">
@@ -33,6 +35,7 @@
       <a href="#" class="back-link" id="back-link">← Back to cities</a>
       <div id="detail-content"></div>
     </div>
+    </main>
   </div>
 
   <script type="module" src="/src/frontend/cities.ts"></script>

--- a/public/companies.html
+++ b/public/companies.html
@@ -7,6 +7,7 @@
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
+  <a href="#main-content" class="skip-link">Skip to main content</a>
   <div class="container">
     <header>
       <div class="header-title">
@@ -21,8 +22,9 @@
       </nav>
     </header>
 
+    <main id="main-content">
     <div class="search-box">
-      <input type="text" id="search" placeholder="Search companies...">
+      <input type="text" id="search" placeholder="Search companies..." aria-label="Search companies">
     </div>
 
     <div id="content">
@@ -33,6 +35,7 @@
       <a href="#" class="back-link" id="back-link">← Back to companies</a>
       <div id="detail-content"></div>
     </div>
+    </main>
   </div>
 
   <script type="module" src="/src/frontend/companies.ts"></script>

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -18,6 +18,23 @@ body {
   min-height: 100vh;
 }
 
+.skip-link {
+  position: absolute;
+  top: -40px;
+  left: 0;
+  background: #f39c12;
+  color: #1a1a2e;
+  padding: 0.5rem 1rem;
+  z-index: 1000;
+  font-weight: bold;
+  text-decoration: none;
+  border-radius: 0 0 4px 0;
+}
+
+.skip-link:focus {
+  top: 0;
+}
+
 .container {
   max-width: 1400px;
   margin: 0 auto;

--- a/public/index.html
+++ b/public/index.html
@@ -7,6 +7,7 @@
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
+  <a href="#main-content" class="skip-link">Skip to main content</a>
   <div class="container">
     <header>
       <div class="header-title">
@@ -21,6 +22,7 @@
       </nav>
     </header>
 
+    <main id="main-content">
     <div class="onboarding">
       <h2>Getting Started</h2>
       <p class="onboarding-intro">
@@ -165,7 +167,7 @@
           <p class="slider-description">Choose between high-value jobs or covering more cargo types</p>
           <div class="slider-container">
             <span class="slider-label">High €/km</span>
-            <input type="range" id="scoring-slider" min="0" max="100" value="50">
+            <input type="range" id="scoring-slider" min="0" max="100" value="50" aria-label="Value versus Coverage balance">
             <span class="slider-label right">Variety</span>
           </div>
         </div>
@@ -178,7 +180,7 @@
           <p class="slider-description">Set how many trailer parking spots you have</p>
           <div class="slider-container">
             <span class="slider-label">1</span>
-            <input type="range" id="trailers-slider" min="1" max="20" value="10">
+            <input type="range" id="trailers-slider" min="1" max="20" value="10" aria-label="Garage size">
             <span class="slider-label right">20</span>
           </div>
         </div>
@@ -191,7 +193,7 @@
           <p class="slider-description">Balance between buying duplicate trailers vs. different types</p>
           <div class="slider-container">
             <span class="slider-label">Same types OK</span>
-            <input type="range" id="diminishing-slider" min="0" max="100" value="50">
+            <input type="range" id="diminishing-slider" min="0" max="100" value="50" aria-label="Diversity pressure">
             <span class="slider-label right">Prefer different</span>
           </div>
         </div>
@@ -199,7 +201,7 @@
     </div>
 
     <div class="search-box">
-      <input type="text" id="city-search" placeholder="Search cities...">
+      <input type="text" id="city-search" placeholder="Search cities..." aria-label="Search cities">
     </div>
 
     <div class="country-filter">
@@ -236,9 +238,10 @@
     </div>
 
     <div id="city-view" style="display: none;">
-      <span class="back-link" id="back-link">← Back to rankings</span>
+      <button class="back-link" id="back-link" type="button">← Back to rankings</button>
       <div id="city-content"></div>
     </div>
+    </main>
   </div>
 
   <script type="module" src="/src/frontend/main.ts"></script>


### PR DESCRIPTION
## Summary
- Added skip-to-content link on all 4 pages for keyboard navigation
- Wrapped page content in `<main id="main-content">` landmark on all pages
- Added `aria-label` attributes to search inputs and range sliders
- Changed back-link from `<span>` to `<button>` on index.html for proper semantics
- Added `.skip-link` CSS styles (hidden until focused)

Closes #103

## Test plan
- [ ] Tab through each page — skip link appears on focus and jumps to main content
- [ ] Screen reader announces main landmark on all pages
- [ ] Search inputs have accessible names
- [ ] Range sliders have accessible names
- [ ] Build passes