### PR TITLE
Cargo DLC awareness: 9 cargo packs with wiki-verified mapping

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -153,6 +153,11 @@ nav {
   font-size: 0.85rem;
   color: #f39c12;
 }
+.dlc-section-sep {
+  margin-top: 0.5rem;
+  padding-top: 0.5rem;
+  border-top: 1px solid #2a3a5a;
+}
 .dlc-actions button {
   background: none;
   border: none;

--- a/scripts/parse-game-defs.ts
+++ b/scripts/parse-game-defs.ts
@@ -19,6 +19,7 @@ interface ParsedUnit {
   type: string;       // e.g. "cargo_data", "trailer_def", "city_data"
   name: string;       // e.g. "cargo.almond", "trailer_def.feldbinder..."
   props: Record<string, string | string[] | number | boolean>;
+  sourceFile?: string; // filename this unit was parsed from (for DLC tracking)
 }
 
 function parseSiiFile(content: string): ParsedUnit[] {
@@ -126,7 +127,9 @@ function readAllSiiFiles(dir: string, ext = '.sui'): ParsedUnit[] {
   for (const file of readdirSync(dir)) {
     if (file.endsWith(ext) || file.endsWith('.sii')) {
       const content = readFileSync(join(dir, file), 'utf-8');
-      units.push(...parseSiiFile(content));
+      const parsed = parseSiiFile(content);
+      for (const unit of parsed) unit.sourceFile = file;
+      units.push(...parsed);
     }
   }
   return units;
@@ -152,7 +155,44 @@ interface CargoData {
   overweight: boolean;
   excluded: boolean;
   unit_load_time: number;
+  dlc?: string;          // cargo DLC pack ID (see CARGO_DLC_MAP below)
 }
+
+// Cargo DLC mapping — verified against trucksimulator.wiki.gg/wiki/Cargo_types
+// Source: https://trucksimulator.wiki.gg/wiki/Cargo_types/Euro_Truck_Simulator_2
+const CARGO_DLC_MAP: Record<string, string> = {
+  // High Power Cargo Pack (8 cargo types)
+  aircond: 'high_power', hvac: 'high_power', crawler: 'high_power', driller: 'high_power',
+  tube: 'high_power', helicopter: 'high_power', roller: 'high_power', tracks: 'high_power', yacht: 'high_power',
+  // Heavy Cargo Pack (11 cargo types)
+  asph_miller: 'heavy_cargo', concr_beams: 'heavy_cargo', concr_beams2: 'heavy_cargo',
+  dozer: 'heavy_cargo', cable_reel: 'heavy_cargo', locomotive: 'heavy_cargo',
+  metal_center: 'heavy_cargo', mobile_crane: 'heavy_cargo', mob_crusher: 'heavy_cargo',
+  mob_screener: 'heavy_cargo', mob_stacker: 'heavy_cargo', transformat: 'heavy_cargo',
+  // Special Transport (14 cargo types, most escort-only; only CZLoko has regular body types)
+  czl_es300: 'special_transport', czl_muv75: 'special_transport',
+  // Volvo Construction Equipment (7 cargo types)
+  volvo_a25g: 'volvo_ce', volvo_bucket: 'volvo_ce', volvo_sd160b: 'volvo_ce',
+  volvo_ec220e: 'volvo_ce', volvo_l250h: 'volvo_ce', volvo_rims: 'volvo_ce', vol_ew240emh: 'volvo_ce',
+  // JCB Equipment Pack (10 cargo types)
+  jcb_bhl4cx: 'jcb', jcb_g100rs: 'jcb', jcb_dmphtd5e: 'jcb', jcb_mexc19ce: 'jcb',
+  jcb_exc245xr: 'jcb', jcb_pw125qe: 'jcb', jcb_dmp6t2: 'jcb', jcb_th540180: 'jcb',
+  jcb_ft4220: 'jcb', jcb_wload457: 'jcb',
+  // Bobcat Cargo Pack (7 cargo types)
+  bob_tl3070a: 'bobcat', bob_pa127v: 'bobcat', bob_e60: 'bobcat', bob_d30: 'bobcat',
+  bob_e10e: 'bobcat', bob_s86: 'bobcat', bob_l95: 'bobcat',
+  // KRONE Agriculture Equipment (7 cargo types)
+  kr_ecb880cv: 'krone_agri', kr_bigx1180: 'krone_agri', kr_bigm450: 'krone_agri',
+  kr_stc1370: 'krone_agri', kr_vpv190xc: 'krone_agri', kr_bigp1290: 'krone_agri', kr_gx520: 'krone_agri',
+  // Farm Machinery (9 cargo types)
+  auger_wag: 'farm_machinery', tractor_au: 'farm_machinery', tractor_c: 'farm_machinery',
+  disc_harrows: 'farm_machinery', fert_spread: 'farm_machinery', forage_harv: 'farm_machinery',
+  planter: 'farm_machinery', sprayer: 'farm_machinery', square_baler: 'farm_machinery',
+  // Forest Machinery (8 cargo types)
+  exc_craw: 'forest_machinery', forwarder: 'forest_machinery', log_harvest: 'forest_machinery',
+  log_stacker: 'forest_machinery', mob_tr_winch: 'forest_machinery', mulcher: 'forest_machinery',
+  skidder: 'forest_machinery', wood_chipper: 'forest_machinery',
+};
 
 function extractCargo(): CargoData[] {
   const cargoDir = join(defsPath, 'cargo');
@@ -212,6 +252,7 @@ function extractCargo(): CargoData[] {
       overweight: id === 'overweight' || groups.includes('oversize'),
       excluded: false,
       unit_load_time: typeof unit.props.unit_load_time === 'number' ? unit.props.unit_load_time : 0,
+      dlc: CARGO_DLC_MAP[id],
     });
   }
 
@@ -825,6 +866,7 @@ function main() {
       body_types: c.body_types,
       groups: c.groups,
       excluded: c.excluded,
+      ...(c.dlc ? { dlc: c.dlc } : {}),
     }])),
     trailers: Object.fromEntries(trailers.map(t => [t.id, {
       name: t.name,

--- a/src/frontend/__tests__/storage.test.ts
+++ b/src/frontend/__tests__/storage.test.ts
@@ -31,6 +31,7 @@ describe('storage', () => {
         selectedCountries: [],
         cityTrailers: {},
         ownedTrailerDLCs: storage.ALL_DLC_IDS,
+        ownedCargoDLCs: storage.ALL_CARGO_DLC_IDS,
       });
     });
 

--- a/src/frontend/cargo.ts
+++ b/src/frontend/cargo.ts
@@ -4,7 +4,7 @@
  */
 
 import { loadAllData, buildLookups, applyDLCFilter, normalize, type AllData, type Lookups, type Company, type Trailer } from './data';
-import { getOwnedTrailerDLCs } from './storage';
+import { getOwnedTrailerDLCs, getOwnedCargoDLCs, CARGO_DLC_MAP } from './storage';
 import { initDLCPanel } from './dlc-ui';
 
 let data: AllData | null = null;
@@ -315,7 +315,7 @@ async function init(): Promise<void> {
   content.innerHTML = '<div class="loading">Loading cargo...</div>';
 
   try {
-    data = applyDLCFilter(await loadAllData(), getOwnedTrailerDLCs());
+    data = applyDLCFilter(await loadAllData(), getOwnedTrailerDLCs(), getOwnedCargoDLCs(), CARGO_DLC_MAP);
     lookups = buildLookups(data);
 
     initDLCPanel();

--- a/src/frontend/data.ts
+++ b/src/frontend/data.ts
@@ -425,48 +425,76 @@ function buildTrailers(defs: GameDefs | null, obs: Observations | null): Trailer
  * Returns a new AllData with filtered trailers and cleaned-up gameDefs maps.
  * SCS trailers always pass. DLC trailers pass only if their brand is in ownedDLCs.
  */
-export function applyDLCFilter(data: AllData, ownedDLCs: string[]): AllData {
-  const ownedSet = new Set(ownedDLCs);
+export function applyDLCFilter(
+  data: AllData,
+  ownedTrailerDLCs: string[],
+  ownedCargoDLCs?: string[],
+  cargoDLCMap?: Record<string, string>
+): AllData {
+  const ownedTrailerSet = new Set(ownedTrailerDLCs);
 
-  function isAllowed(trailerId: string): boolean {
+  function isTrailerAllowed(trailerId: string): boolean {
     const brand = trailerId.split('.')[0];
-    return brand === 'scs' || ownedSet.has(brand);
+    return brand === 'scs' || ownedTrailerSet.has(brand);
   }
 
-  const trailers = data.trailers.filter((t) => isAllowed(t.id));
+  // Filter cargo by DLC ownership
+  const ownedCargoSet = ownedCargoDLCs ? new Set(ownedCargoDLCs) : null;
+  function isCargoAllowed(cargoId: string): boolean {
+    if (!ownedCargoSet || !cargoDLCMap) return true;
+    const dlc = cargoDLCMap[cargoId];
+    return !dlc || ownedCargoSet.has(dlc);
+  }
 
-  // Clone gameDefs with filtered trailer-related maps
+  const trailers = data.trailers.filter((t) => isTrailerAllowed(t.id));
+  const cargo = data.cargo.filter((c) => isCargoAllowed(c.id));
+
   let gameDefs = data.gameDefs;
   if (gameDefs) {
     const filteredTrailers: typeof gameDefs.trailers = {};
     for (const [id, t] of Object.entries(gameDefs.trailers)) {
-      if (isAllowed(id)) filteredTrailers[id] = t;
+      if (isTrailerAllowed(id)) filteredTrailers[id] = t;
+    }
+
+    const filteredCargo: typeof gameDefs.cargo = {};
+    for (const [id, c] of Object.entries(gameDefs.cargo)) {
+      if (isCargoAllowed(id)) filteredCargo[id] = c;
     }
 
     const filteredCTU: typeof gameDefs.cargo_trailer_units = {};
     for (const [cargoId, tmap] of Object.entries(gameDefs.cargo_trailer_units)) {
+      if (!isCargoAllowed(cargoId)) continue;
       const filtered: Record<string, number> = {};
       for (const [tid, units] of Object.entries(tmap)) {
-        if (isAllowed(tid)) filtered[tid] = units;
+        if (isTrailerAllowed(tid)) filtered[tid] = units;
       }
       if (Object.keys(filtered).length > 0) filteredCTU[cargoId] = filtered;
     }
 
     const filteredCT: typeof gameDefs.cargo_trailers = {};
     for (const [cargoId, tids] of Object.entries(gameDefs.cargo_trailers)) {
-      const filtered = tids.filter(isAllowed);
+      if (!isCargoAllowed(cargoId)) continue;
+      const filtered = tids.filter(isTrailerAllowed);
       if (filtered.length > 0) filteredCT[cargoId] = filtered;
+    }
+
+    const filteredCC: typeof gameDefs.company_cargo = {};
+    for (const [compId, cargoIds] of Object.entries(gameDefs.company_cargo)) {
+      const filtered = cargoIds.filter(isCargoAllowed);
+      if (filtered.length > 0) filteredCC[compId] = filtered;
     }
 
     gameDefs = {
       ...gameDefs,
+      cargo: filteredCargo,
       trailers: filteredTrailers,
       cargo_trailer_units: filteredCTU,
       cargo_trailers: filteredCT,
+      company_cargo: filteredCC,
     };
   }
 
-  return { ...data, trailers, gameDefs };
+  return { ...data, trailers, cargo, gameDefs };
 }
 
 // Build lookup maps for efficient access

--- a/src/frontend/dlc-ui.ts
+++ b/src/frontend/dlc-ui.ts
@@ -1,11 +1,14 @@
 /**
  * Shared DLC settings panel for all pages.
- * Renders a "DLCs" button in the nav and a dropdown with checkboxes.
+ * Renders a "DLCs" button in the nav and a dropdown with checkboxes
+ * for both trailer DLCs and cargo DLCs.
  * Changing DLC selection saves to localStorage and reloads the page.
  */
 import {
   TRAILER_DLCS, ALL_DLC_IDS,
   getOwnedTrailerDLCs, toggleTrailerDLC, setOwnedTrailerDLCs,
+  CARGO_DLCS, ALL_CARGO_DLC_IDS,
+  getOwnedCargoDLCs, toggleCargoDLC, setOwnedCargoDLCs,
 } from './storage';
 
 /**
@@ -38,51 +41,89 @@ export function initDLCPanel(): void {
     }
   });
 
-  panel.querySelectorAll<HTMLInputElement>('input[data-dlc]').forEach((cb) => {
+  // Trailer DLC checkboxes
+  panel.querySelectorAll<HTMLInputElement>('input[data-trailer-dlc]').forEach((cb) => {
     cb.addEventListener('change', () => {
-      toggleTrailerDLC(cb.dataset.dlc!);
+      toggleTrailerDLC(cb.dataset.trailerDlc!);
       location.reload();
     });
   });
 
-  panel.querySelector('.dlc-all')?.addEventListener('click', () => {
+  panel.querySelector('.dlc-trailer-all')?.addEventListener('click', () => {
     setOwnedTrailerDLCs([...ALL_DLC_IDS]);
     location.reload();
   });
-  panel.querySelector('.dlc-none')?.addEventListener('click', () => {
+  panel.querySelector('.dlc-trailer-none')?.addEventListener('click', () => {
     setOwnedTrailerDLCs([]);
+    location.reload();
+  });
+
+  // Cargo DLC checkboxes
+  panel.querySelectorAll<HTMLInputElement>('input[data-cargo-dlc]').forEach((cb) => {
+    cb.addEventListener('change', () => {
+      toggleCargoDLC(cb.dataset.cargoDlc!);
+      location.reload();
+    });
+  });
+
+  panel.querySelector('.dlc-cargo-all')?.addEventListener('click', () => {
+    setOwnedCargoDLCs([...ALL_CARGO_DLC_IDS]);
+    location.reload();
+  });
+  panel.querySelector('.dlc-cargo-none')?.addEventListener('click', () => {
+    setOwnedCargoDLCs([]);
     location.reload();
   });
 }
 
 function updateBadge(btn: HTMLButtonElement): void {
-  const owned = getOwnedTrailerDLCs();
-  const total = ALL_DLC_IDS.length;
-  if (owned.length === total) {
+  const ownedTrailers = getOwnedTrailerDLCs();
+  const ownedCargo = getOwnedCargoDLCs();
+  const totalTrailer = ALL_DLC_IDS.length;
+  const totalCargo = ALL_CARGO_DLC_IDS.length;
+  const allOwned = ownedTrailers.length === totalTrailer && ownedCargo.length === totalCargo;
+
+  if (allOwned) {
     btn.textContent = 'DLCs';
     btn.classList.remove('dlc-filtered');
   } else {
-    btn.textContent = `DLCs (${owned.length}/${total})`;
+    const parts: string[] = [];
+    if (ownedTrailers.length < totalTrailer) parts.push(`T:${ownedTrailers.length}/${totalTrailer}`);
+    if (ownedCargo.length < totalCargo) parts.push(`C:${ownedCargo.length}/${totalCargo}`);
+    btn.textContent = `DLCs (${parts.join(' ')})`;
     btn.classList.add('dlc-filtered');
   }
 }
 
 function buildPanelHTML(): string {
-  const owned = getOwnedTrailerDLCs();
-  const rows = ALL_DLC_IDS.map((id) => {
-    const checked = owned.includes(id) ? 'checked' : '';
-    const name = TRAILER_DLCS[id];
-    return `<label class="dlc-row"><input type="checkbox" data-dlc="${id}" ${checked}> ${name}</label>`;
+  const ownedTrailers = getOwnedTrailerDLCs();
+  const trailerRows = ALL_DLC_IDS.map((id) => {
+    const checked = ownedTrailers.includes(id) ? 'checked' : '';
+    return `<label class="dlc-row"><input type="checkbox" data-trailer-dlc="${id}" ${checked}> ${TRAILER_DLCS[id]}</label>`;
+  }).join('');
+
+  const ownedCargo = getOwnedCargoDLCs();
+  const cargoRows = ALL_CARGO_DLC_IDS.map((id) => {
+    const checked = ownedCargo.includes(id) ? 'checked' : '';
+    return `<label class="dlc-row"><input type="checkbox" data-cargo-dlc="${id}" ${checked}> ${CARGO_DLCS[id]}</label>`;
   }).join('');
 
   return `
     <div class="dlc-panel-header">
       <span>Trailer DLCs</span>
       <span class="dlc-actions">
-        <button class="dlc-all">All</button>
-        <button class="dlc-none">None</button>
+        <button class="dlc-trailer-all">All</button>
+        <button class="dlc-trailer-none">None</button>
       </span>
     </div>
-    ${rows}
+    ${trailerRows}
+    <div class="dlc-panel-header dlc-section-sep">
+      <span>Cargo DLCs</span>
+      <span class="dlc-actions">
+        <button class="dlc-cargo-all">All</button>
+        <button class="dlc-cargo-none">None</button>
+      </span>
+    </div>
+    ${cargoRows}
   `;
 }

--- a/src/frontend/main.ts
+++ b/src/frontend/main.ts
@@ -7,7 +7,7 @@ import {
   getOwnedGarages, toggleOwnedGarage,
   getFilterMode, setFilterMode,
   getSelectedCountries, setSelectedCountries,
-  getOwnedTrailerDLCs,
+  getOwnedTrailerDLCs, getOwnedCargoDLCs, CARGO_DLC_MAP,
 } from './storage.js';
 import { initDLCPanel } from './dlc-ui.js';
 import type { AllData, Lookups } from './data.js';
@@ -473,7 +473,7 @@ async function init() {
   showLoading();
 
   try {
-    data = applyDLCFilter(await loadAllData(), getOwnedTrailerDLCs());
+    data = applyDLCFilter(await loadAllData(), getOwnedTrailerDLCs(), getOwnedCargoDLCs(), CARGO_DLC_MAP);
     lookups = buildLookups(data);
 
     initDLCPanel();

--- a/src/frontend/storage.ts
+++ b/src/frontend/storage.ts
@@ -19,6 +19,56 @@ export const TRAILER_DLCS: Record<string, string> = {
 
 export const ALL_DLC_IDS = Object.keys(TRAILER_DLCS);
 
+/** Cargo DLC packs — pack ID → display name */
+export const CARGO_DLCS: Record<string, string> = {
+  high_power: 'High Power Cargo',
+  heavy_cargo: 'Heavy Cargo',
+  special_transport: 'Special Transport',
+  volvo_ce: 'Volvo Construction',
+  jcb: 'JCB Equipment',
+  bobcat: 'Bobcat Cargo',
+  krone_agri: 'KRONE Agriculture',
+  farm_machinery: 'Farm Machinery',
+  forest_machinery: 'Forest Machinery',
+};
+
+export const ALL_CARGO_DLC_IDS = Object.keys(CARGO_DLCS);
+
+/** Cargo ID → DLC pack mapping (wiki-verified) */
+export const CARGO_DLC_MAP: Record<string, string> = {
+  // High Power Cargo Pack
+  aircond: 'high_power', hvac: 'high_power', crawler: 'high_power', driller: 'high_power',
+  tube: 'high_power', helicopter: 'high_power', roller: 'high_power', tracks: 'high_power', yacht: 'high_power',
+  // Heavy Cargo Pack
+  asph_miller: 'heavy_cargo', concr_beams: 'heavy_cargo', concr_beams2: 'heavy_cargo',
+  dozer: 'heavy_cargo', cable_reel: 'heavy_cargo', locomotive: 'heavy_cargo',
+  metal_center: 'heavy_cargo', mobile_crane: 'heavy_cargo', mob_crusher: 'heavy_cargo',
+  mob_screener: 'heavy_cargo', mob_stacker: 'heavy_cargo', transformat: 'heavy_cargo',
+  // Special Transport (only non-escort items with regular body types)
+  czl_es300: 'special_transport', czl_muv75: 'special_transport',
+  // Volvo Construction Equipment
+  volvo_a25g: 'volvo_ce', volvo_bucket: 'volvo_ce', volvo_sd160b: 'volvo_ce',
+  volvo_ec220e: 'volvo_ce', volvo_l250h: 'volvo_ce', volvo_rims: 'volvo_ce', vol_ew240emh: 'volvo_ce',
+  // JCB Equipment Pack
+  jcb_bhl4cx: 'jcb', jcb_g100rs: 'jcb', jcb_dmphtd5e: 'jcb', jcb_mexc19ce: 'jcb',
+  jcb_exc245xr: 'jcb', jcb_pw125qe: 'jcb', jcb_dmp6t2: 'jcb', jcb_th540180: 'jcb',
+  jcb_ft4220: 'jcb', jcb_wload457: 'jcb',
+  // Bobcat Cargo Pack
+  bob_tl3070a: 'bobcat', bob_pa127v: 'bobcat', bob_e60: 'bobcat', bob_d30: 'bobcat',
+  bob_e10e: 'bobcat', bob_s86: 'bobcat', bob_l95: 'bobcat',
+  // KRONE Agriculture Equipment
+  kr_ecb880cv: 'krone_agri', kr_bigx1180: 'krone_agri', kr_bigm450: 'krone_agri',
+  kr_stc1370: 'krone_agri', kr_vpv190xc: 'krone_agri', kr_bigp1290: 'krone_agri', kr_gx520: 'krone_agri',
+  // Farm Machinery
+  auger_wag: 'farm_machinery', tractor_au: 'farm_machinery', tractor_c: 'farm_machinery',
+  disc_harrows: 'farm_machinery', fert_spread: 'farm_machinery', forage_harv: 'farm_machinery',
+  planter: 'farm_machinery', sprayer: 'farm_machinery', square_baler: 'farm_machinery',
+  // Forest Machinery
+  exc_craw: 'forest_machinery', forwarder: 'forest_machinery', log_harvest: 'forest_machinery',
+  log_stacker: 'forest_machinery', mob_tr_winch: 'forest_machinery', mulcher: 'forest_machinery',
+  skidder: 'forest_machinery', wood_chipper: 'forest_machinery',
+};
+
 interface Settings {
   driverCount: number;
 }
@@ -30,6 +80,7 @@ interface AppState {
   selectedCountries: string[];
   cityTrailers: Record<string, string[]>;  // cityId -> array of body type IDs
   ownedTrailerDLCs: string[];              // DLC brand IDs the user owns
+  ownedCargoDLCs: string[];               // Cargo DLC pack IDs the user owns
 }
 
 const LEGACY_COUNTRIES_KEY = 'ets2-selected-countries';
@@ -43,6 +94,7 @@ const defaultState: AppState = {
   selectedCountries: [],
   cityTrailers: {},
   ownedTrailerDLCs: [...ALL_DLC_IDS],  // all owned by default
+  ownedCargoDLCs: [...ALL_CARGO_DLC_IDS],  // all owned by default
 };
 
 /**
@@ -62,6 +114,7 @@ export function loadState(): AppState {
         },
         cityTrailers: parsed.cityTrailers ?? {},
         ownedTrailerDLCs: parsed.ownedTrailerDLCs ?? [...ALL_DLC_IDS],
+        ownedCargoDLCs: parsed.ownedCargoDLCs ?? [...ALL_CARGO_DLC_IDS],
       };
       // Migrate legacy settings
       if (parsed.settings?.maxTrailers && !parsed.settings?.driverCount) {
@@ -275,4 +328,30 @@ export function toggleTrailerDLC(dlcId: string): boolean {
 
 export function isDLCOwned(dlcId: string): boolean {
   return getOwnedTrailerDLCs().includes(dlcId);
+}
+
+// ============================================
+// Cargo DLC Management
+// ============================================
+
+export function getOwnedCargoDLCs(): string[] {
+  return loadState().ownedCargoDLCs;
+}
+
+export function setOwnedCargoDLCs(dlcs: string[]): void {
+  const state = loadState();
+  state.ownedCargoDLCs = dlcs;
+  saveState(state);
+}
+
+export function toggleCargoDLC(dlcId: string): boolean {
+  const state = loadState();
+  const idx = state.ownedCargoDLCs.indexOf(dlcId);
+  if (idx >= 0) {
+    state.ownedCargoDLCs.splice(idx, 1);
+  } else {
+    state.ownedCargoDLCs.push(dlcId);
+  }
+  saveState(state);
+  return idx < 0;
 }

--- a/src/frontend/trailers.ts
+++ b/src/frontend/trailers.ts
@@ -10,7 +10,7 @@ import {
   pickBestTrailer, trailerTotalHV, formatTrailerSpec,
   type AllData, type Lookups, type Cargo, type Trailer,
 } from './data';
-import { getOwnedTrailerDLCs } from './storage';
+import { getOwnedTrailerDLCs, getOwnedCargoDLCs, CARGO_DLC_MAP } from './storage';
 import { initDLCPanel } from './dlc-ui';
 
 let data: AllData | null = null;
@@ -557,7 +557,7 @@ async function init(): Promise<void> {
   content.innerHTML = '<div class="loading">Loading trailers...</div>';
 
   try {
-    data = applyDLCFilter(await loadAllData(), getOwnedTrailerDLCs());
+    data = applyDLCFilter(await loadAllData(), getOwnedTrailerDLCs(), getOwnedCargoDLCs(), CARGO_DLC_MAP);
     lookups = buildLookups(data);
     bodyTypes = buildBodyTypes();
 


### PR DESCRIPTION
## Summary
- Add cargo DLC filtering across all pages (rankings, cargo browser, trailers)
- 9 cargo DLC packs with 71 cargo IDs mapped from wiki (High Power, Heavy Cargo, Special Transport, Volvo CE, JCB, Bobcat, KRONE Agriculture, Farm Machinery, Forest Machinery)
- DLC panel now has two sections: Trailer DLCs and Cargo DLCs with independent All/None controls
- `applyDLCFilter()` extended to filter both trailer and cargo DLCs in a single pass (backward compatible)
- Parser updated to track source filenames for future DLC detection on re-parse

## Test plan
- [x] All 44 tests pass
- [x] TypeScript compiles clean
- [x] Vite build succeeds
- [x] Cargo DLC toggles reload page and affect optimizer/rankings