### PR TITLE
Fix DLC page 3-column layout on mobile

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1577,4 +1577,13 @@ tr.owned-garage {
   .cards-grid {
     grid-template-columns: 1fr;
   }
+
+  .dlc-page-columns {
+    flex-direction: column;
+  }
+
+  .dlc-row {
+    min-height: 44px;
+    padding: 0.5rem 0.75rem;
+  }
 }


### PR DESCRIPTION
## Summary
- Add mobile breakpoint for `.dlc-page-columns` to stack vertically on screens < 600px
- Increase DLC row touch targets on mobile to meet 44px minimum height

Closes #120