### PR TITLE
Fix test regression: hasGarage missing from test assertions

### DIFF
--- a/src/frontend/__tests__/data.test.ts
+++ b/src/frontend/__tests__/data.test.ts
@@ -53,6 +53,7 @@ function buildAllData(obs = sampleObservations) {
       id,
       name: titleCase(id),
       country: '',
+      hasGarage: true,
     })),
     companies: obs.companies.map((id) => ({
       id,
@@ -117,7 +118,7 @@ describe('data.ts', () => {
       expect(result.observations).toEqual(sampleObservations);
       expect(result.gameDefs).toBeNull();
       expect(result.cities).toHaveLength(2);
-      expect(result.cities[0]).toEqual({ id: 'berlin', name: 'Berlin', country: '' });
+      expect(result.cities[0]).toEqual({ id: 'berlin', name: 'Berlin', country: '', hasGarage: true });
       expect(result.companies).toHaveLength(2);
       expect(result.cargo).toHaveLength(4);
       expect(result.trailers).toHaveLength(3);
@@ -208,8 +209,8 @@ describe('data.ts', () => {
     it('creates citiesById map correctly', () => {
       const lookups = data.buildLookups(testData);
 
-      expect(lookups.citiesById.get('berlin')).toEqual({ id: 'berlin', name: 'Berlin', country: '' });
-      expect(lookups.citiesById.get('paris')).toEqual({ id: 'paris', name: 'Paris', country: '' });
+      expect(lookups.citiesById.get('berlin')).toEqual({ id: 'berlin', name: 'Berlin', country: '', hasGarage: true });
+      expect(lookups.citiesById.get('paris')).toEqual({ id: 'paris', name: 'Paris', country: '', hasGarage: true });
       expect(lookups.citiesById.get('unknown')).toBeUndefined();
     });
 

--- a/src/frontend/__tests__/optimizer.test.ts
+++ b/src/frontend/__tests__/optimizer.test.ts
@@ -73,9 +73,9 @@ describe('optimizer', () => {
     },
     observations: null,
     cities: [
-      { id: 'berlin', name: 'Berlin', country: 'germany' },
-      { id: 'paris', name: 'Paris', country: 'france' },
-      { id: 'empty_city', name: 'Empty City', country: '' },
+      { id: 'berlin', name: 'Berlin', country: 'germany', hasGarage: true },
+      { id: 'paris', name: 'Paris', country: 'france', hasGarage: true },
+      { id: 'empty_city', name: 'Empty City', country: '', hasGarage: true },
     ],
     companies: [
       { id: 'logistics_co', name: 'Logistics Co' },


### PR DESCRIPTION
## Summary
- Add `hasGarage` property to all mock city objects in data.test.ts and optimizer.test.ts
- Tests were failing after #118 added hasGarage to the City interface

Closes #119