### PR TITLE
Default DLCs to none owned with first-visit configuration prompt

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -261,6 +261,59 @@ nav {
   border-top: 1px solid #2a3a5a;
 }
 
+/* First-Visit DLC Banner */
+.dlc-banner {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.75rem 1rem;
+  margin-bottom: 1.5rem;
+  background: linear-gradient(135deg, #1a2744 0%, #16213e 100%);
+  border: 1px solid #f39c12;
+  border-radius: 6px;
+}
+
+.dlc-banner-text {
+  flex: 1;
+  color: #ccc;
+  font-size: 0.95rem;
+}
+
+.dlc-banner-link {
+  color: #1a1a2e;
+  background: #f39c12;
+  padding: 0.4rem 1rem;
+  border-radius: 4px;
+  text-decoration: none;
+  font-weight: 600;
+  font-size: 0.9rem;
+  white-space: nowrap;
+  transition: background 0.2s;
+}
+
+.dlc-banner-link:hover {
+  background: #e67e22;
+}
+
+.dlc-banner-dismiss {
+  background: none;
+  border: none;
+  color: #888;
+  font-size: 1.25rem;
+  cursor: pointer;
+  padding: 0.25rem;
+  line-height: 1;
+  min-width: 32px;
+  min-height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.dlc-banner-dismiss:hover {
+  color: #f39c12;
+}
+
 /* Onboarding Section */
 .onboarding {
   background: linear-gradient(135deg, #16213e 0%, #1a2744 100%);
@@ -1572,6 +1625,22 @@ tr.owned-garage {
   .stat {
     flex: 1;
     min-width: 140px;
+  }
+
+  .dlc-banner {
+    flex-direction: column;
+    align-items: stretch;
+    text-align: center;
+  }
+
+  .dlc-banner-dismiss {
+    position: absolute;
+    top: 0.5rem;
+    right: 0.5rem;
+  }
+
+  .dlc-banner {
+    position: relative;
   }
 
   .cards-grid {

--- a/src/frontend/__tests__/storage.test.ts
+++ b/src/frontend/__tests__/storage.test.ts
@@ -30,9 +30,9 @@ describe('storage', () => {
         garageFilterMode: 'all',
         selectedCountries: [],
         cityTrailers: {},
-        ownedTrailerDLCs: storage.ALL_DLC_IDS,
-        ownedCargoDLCs: storage.ALL_CARGO_DLC_IDS,
-        ownedMapDLCs: storage.ALL_MAP_DLC_IDS,
+        ownedTrailerDLCs: [],
+        ownedCargoDLCs: [],
+        ownedMapDLCs: [],
       });
     });
 
@@ -146,6 +146,28 @@ describe('storage', () => {
       expect(storage.getFilterMode()).toBe('all');
       storage.setFilterMode('owned');
       expect(storage.getFilterMode()).toBe('owned');
+    });
+  });
+
+  describe('first-visit detection', () => {
+    it('detects first visit when no state exists', () => {
+      expect(storage.isFirstVisit()).toBe(true);
+    });
+
+    it('detects returning visitor after state is saved', () => {
+      storage.saveState(storage.loadState());
+      expect(storage.isFirstVisit()).toBe(false);
+    });
+  });
+
+  describe('banner dismissal', () => {
+    it('banner is not dismissed by default', () => {
+      expect(storage.isBannerDismissed()).toBe(false);
+    });
+
+    it('remembers banner dismissal', () => {
+      storage.dismissBanner();
+      expect(storage.isBannerDismissed()).toBe(true);
     });
   });
 

--- a/src/frontend/main.ts
+++ b/src/frontend/main.ts
@@ -8,6 +8,7 @@ import {
   getFilterMode, setFilterMode,
   getSelectedCountries, setSelectedCountries,
   getOwnedTrailerDLCs, getOwnedCargoDLCs, getOwnedMapDLCs,
+  isFirstVisit, isBannerDismissed, dismissBanner,
   COMBINED_CARGO_DLC_MAP, CITY_DLC_MAP,
 } from './storage.js';
 import type { AllData, Lookups } from './data.js';
@@ -466,10 +467,39 @@ function showError(errorMessage: string) {
 
 
 // ============================================
+// First-visit DLC banner
+// ============================================
+
+function showDLCBanner() {
+  // Show banner only for first-time visitors who haven't dismissed it
+  if (!isFirstVisit() || isBannerDismissed()) return;
+
+  const banner = document.createElement('div');
+  banner.className = 'dlc-banner';
+  banner.setAttribute('role', 'alert');
+  banner.innerHTML = `
+    <span class="dlc-banner-text">
+      First time here? Configure your owned DLCs for accurate recommendations.
+    </span>
+    <a href="dlcs.html" class="dlc-banner-link">DLC Settings</a>
+    <button class="dlc-banner-dismiss" aria-label="Dismiss banner" type="button">&times;</button>
+  `;
+
+  const main = document.getElementById('main-content')!;
+  main.insertBefore(banner, main.firstChild);
+
+  banner.querySelector('.dlc-banner-dismiss')!.addEventListener('click', () => {
+    dismissBanner();
+    banner.remove();
+  });
+}
+
+// ============================================
 // Init
 // ============================================
 
 async function init() {
+  showDLCBanner();
   showLoading();
 
   try {

--- a/src/frontend/storage.ts
+++ b/src/frontend/storage.ts
@@ -19,6 +19,7 @@ export {
 } from './dlc-data';
 
 const STORAGE_KEY = 'ets2-trucker-advisor';
+const BANNER_DISMISSED_KEY = 'ets2-dlc-banner-dismissed';
 
 interface Settings {
   driverCount: number;
@@ -45,9 +46,9 @@ const defaultState: AppState = {
   garageFilterMode: 'all',
   selectedCountries: [],
   cityTrailers: {},
-  ownedTrailerDLCs: [...ALL_DLC_IDS],  // all owned by default
-  ownedCargoDLCs: [...ALL_CARGO_DLC_IDS],  // all owned by default
-  ownedMapDLCs: [...ALL_MAP_DLC_IDS],  // all owned by default
+  ownedTrailerDLCs: [],  // none owned by default — first-time visitors configure on DLC page
+  ownedCargoDLCs: [],   // none owned by default
+  ownedMapDLCs: [],     // none owned by default
 };
 
 /**
@@ -334,4 +335,29 @@ export function toggleMapDLC(dlcId: string): boolean {
   }
   saveState(state);
   return idx < 0;
+}
+
+// ============================================
+// First-Visit Detection
+// ============================================
+
+/**
+ * Returns true if the user has never saved any state (first visit).
+ */
+export function isFirstVisit(): boolean {
+  return localStorage.getItem(STORAGE_KEY) === null;
+}
+
+/**
+ * Returns true if the DLC configuration banner has been dismissed.
+ */
+export function isBannerDismissed(): boolean {
+  return localStorage.getItem(BANNER_DISMISSED_KEY) === 'true';
+}
+
+/**
+ * Mark the DLC configuration banner as dismissed.
+ */
+export function dismissBanner(): void {
+  localStorage.setItem(BANNER_DISMISSED_KEY, 'true');
 }


### PR DESCRIPTION
## Summary
- Change DLC defaults from all-owned to none-owned for accurate first-visit recommendations
- Add dismissible banner directing new users to configure their DLCs
- Add first-visit detection via localStorage
- Existing users with saved state are unaffected (migration fallback preserves all-owned)

Closes #121