### PR TITLE
Add garage toggle to city detail view for mobile users

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -951,6 +951,13 @@ tr.scs-fallback-row td {
   margin-bottom: 1rem;
 }
 
+.city-header-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
 .city-header h2 {
   font-size: 1.5rem;
   margin-bottom: 0.25rem;

--- a/src/frontend/main.ts
+++ b/src/frontend/main.ts
@@ -4,7 +4,7 @@ import {
   type CityRanking, type FleetEntry, type OptimalFleetEntry,
 } from './optimizer.js';
 import {
-  getOwnedGarages, toggleOwnedGarage,
+  getOwnedGarages, toggleOwnedGarage, isOwnedGarage,
   getFilterMode, setFilterMode,
   getSelectedCountries, setSelectedCountries,
   getOwnedTrailerDLCs, getOwnedCargoDLCs, getOwnedMapDLCs,
@@ -336,13 +336,23 @@ function renderCity(cityId: string) {
 
   const optimal = computeOptimalFleet(cityId, data!, lookups!);
   if (!optimal) {
+    const emptyOwned = isOwnedGarage(cityId);
     cityContent.innerHTML = `
       <div class="city-header">
-        <h2>${city.name}</h2>
-        <span class="country">${city.country}</span>
+        <div class="city-header-row">
+          <div>
+            <h2>${city.name}</h2>
+            <span class="country">${city.country}</span>
+          </div>
+          <button class="garage-toggle" id="city-garage-toggle"
+            aria-pressed="${emptyOwned}" aria-label="${emptyOwned ? 'Remove garage' : 'Mark as garage'}"
+            title="${emptyOwned ? 'Remove garage' : 'Mark as garage'}"
+            data-city-id="${cityId}">${emptyOwned ? '\u2605' : '\u2606'}</button>
+        </div>
       </div>
       <div class="empty-state">No cargo data for this city yet.</div>
     `;
+    wireGarageToggle(cityId);
     return;
   }
 
@@ -355,11 +365,20 @@ function renderCity(cityId: string) {
   const cargoTypes = rankingEntry?.cargoTypes ?? 0;
   const score = rankingEntry?.score ?? 0;
 
+  const owned = isOwnedGarage(cityId);
 
   cityContent.innerHTML = `
     <div class="city-header">
-      <h2>${city.name}</h2>
-      <span class="country">${city.country}</span>
+      <div class="city-header-row">
+        <div>
+          <h2>${city.name}</h2>
+          <span class="country">${city.country}</span>
+        </div>
+        <button class="garage-toggle" id="city-garage-toggle"
+          aria-pressed="${owned}" aria-label="${owned ? 'Remove garage' : 'Mark as garage'}"
+          title="${owned ? 'Remove garage' : 'Mark as garage'}"
+          data-city-id="${cityId}">${owned ? '\u2605' : '\u2606'}</button>
+      </div>
     </div>
 
     <div class="stats">
@@ -398,6 +417,30 @@ function renderCity(cityId: string) {
 
     </div>
   `;
+
+  wireGarageToggle(cityId);
+}
+
+function wireGarageToggle(cityId: string) {
+  const garageToggle = document.getElementById('city-garage-toggle');
+  if (garageToggle) {
+    garageToggle.addEventListener('click', () => {
+      const nowOwned = toggleOwnedGarage(cityId);
+      garageToggle.textContent = nowOwned ? '\u2605' : '\u2606';
+      garageToggle.setAttribute('aria-pressed', String(nowOwned));
+      garageToggle.setAttribute('aria-label', nowOwned ? 'Remove garage' : 'Mark as garage');
+      garageToggle.title = nowOwned ? 'Remove garage' : 'Mark as garage';
+      // Sync the rankings table star if it exists
+      const rankingStar = rankingsContent.querySelector(`.garage-star[data-city-id="${cityId}"]`) as HTMLElement | null;
+      if (rankingStar) {
+        rankingStar.textContent = nowOwned ? '\u2605' : '\u2606';
+        rankingStar.title = nowOwned ? 'Remove garage' : 'Mark as garage';
+        const row = rankingStar.closest('tr')!;
+        row.classList.toggle('owned-garage', nowOwned);
+      }
+      updateGarageCount();
+    });
+  }
 }
 
 


### PR DESCRIPTION
## Summary
- Add a garage star toggle button to the city detail view header
- Mobile users can now mark/unmark garages when viewing city details
- Uses same storage mechanism as the rankings table star column
- Syncs star state back to rankings table when toggled from city detail

Closes #122