### PR TITLE
Show no-results message when city search returns empty

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1547,6 +1547,14 @@ tr.owned-garage {
   background: rgba(243, 156, 18, 0.06);
 }
 
+/* No Results State */
+.no-results {
+  text-align: center;
+  padding: 2rem;
+  color: #888;
+  font-size: 0.95rem;
+}
+
 /* Empty Garages State */
 .empty-garages {
   text-align: center;

--- a/src/frontend/main.ts
+++ b/src/frontend/main.ts
@@ -235,6 +235,40 @@ function renderRankings() {
     return;
   }
 
+  if (displayRankings.length === 0) {
+    let message: string;
+    if (searchTerm) {
+      message = `No cities match '${citySearch.value.trim()}'`;
+    } else if (selectedCountries.length > 0) {
+      message = 'No cities match your filters';
+    } else {
+      message = 'No results found';
+    }
+    rankingsContent.innerHTML = `
+      <div class="table-section">
+        <table class="table-rankings">
+          <thead>
+            <tr>
+              <th></th>
+              <th>#</th>
+              <th>City</th>
+              <th>Country</th>
+              <th class="tooltip" data-tooltip="Company facilities in this city">Depots</th>
+              <th class="tooltip" data-tooltip="Distinct cargo types available">Cargo</th>
+              <th class="tooltip" data-tooltip="Sum of top 5 body type EVs — fleet earning potential">Fleet EV</th>
+              <th class="tooltip" data-tooltip="Top earning trailer types for this city">Best Trailers</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr><td colspan="8" class="no-results">${message}</td></tr>
+          </tbody>
+        </table>
+      </div>
+    `;
+    updateGarageCount();
+    return;
+  }
+
   rankingsContent.innerHTML = `
     <div class="table-section">
       <h2>City Rankings (${displayRankings.length} cities)</h2>


### PR DESCRIPTION
## Summary
- Display contextual message when city search/filter returns no results
- Previously showed an empty table with no feedback

Closes #104