### PR TITLE
Make Getting Started section collapsible/dismissible

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -326,6 +326,56 @@ nav {
   border-left: 4px solid #f39c12;
 }
 
+.onboarding-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.onboarding.collapsed .onboarding-header {
+  margin-bottom: 0;
+}
+
+.onboarding-toggle {
+  background: transparent;
+  border: none;
+  color: #f39c12;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0;
+  min-height: 44px;
+  font-size: 1rem;
+}
+
+.onboarding-toggle:hover {
+  color: #ffa726;
+}
+
+.onboarding-toggle:focus {
+  outline: 2px solid #f39c12;
+  outline-offset: 2px;
+}
+
+.onboarding-toggle h2 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.onboarding-content {
+  overflow: hidden;
+  max-height: 800px;
+  transition: max-height 0.3s ease, opacity 0.3s ease;
+  opacity: 1;
+}
+
+.onboarding.collapsed .onboarding-content {
+  max-height: 0;
+  opacity: 0;
+}
+
 .onboarding h2 {
   margin-bottom: 1rem;
 }

--- a/public/index.html
+++ b/public/index.html
@@ -25,50 +25,57 @@
     </header>
 
     <main id="main-content">
-    <div class="onboarding">
-      <h2>Getting Started</h2>
-      <p class="onboarding-intro">
-        This tool helps you choose the most profitable garage locations and the best trailers to buy for each one.
-        It analyzes all cargo jobs available in each city and recommends which trailers will maximize your income.
-      </p>
-      <div class="quick-steps">
-        <div class="step">
-          <span class="step-number">1</span>
-          <div class="step-content">
-            <strong>Browse city rankings</strong>
-            <span>Cities are ranked by job availability and cargo value</span>
-          </div>
-        </div>
-        <div class="step">
-          <span class="step-number">2</span>
-          <div class="step-content">
-            <strong>Click a city for trailer recommendations</strong>
-            <span>See which trailers work best for that location</span>
-          </div>
-        </div>
-        <div class="step">
-          <span class="step-number">3</span>
-          <div class="step-content">
-            <strong>Mark your garages with ★</strong>
-            <span>Track which cities you've set up garages in</span>
-          </div>
-        </div>
+    <div class="onboarding" id="onboarding">
+      <div class="onboarding-header">
+        <button class="onboarding-toggle" id="onboarding-toggle" aria-expanded="true">
+          <span class="toggle-icon">▼</span>
+          <h2>Getting Started</h2>
+        </button>
       </div>
-      <div class="terminology">
-        <h3>Key Terms</h3>
-        <dl class="term-list">
-          <dt class="tooltip" tabindex="0" data-tooltip="Company facilities (like Posped, EuroGoodies, etc.) that offer cargo jobs in a city">Depots</dt>
-          <dd>Company facilities where you pick up cargo</dd>
+      <div class="onboarding-content" id="onboarding-content">
+        <p class="onboarding-intro">
+          This tool helps you choose the most profitable garage locations and the best trailers to buy for each one.
+          It analyzes all cargo jobs available in each city and recommends which trailers will maximize your income.
+        </p>
+        <div class="quick-steps">
+          <div class="step">
+            <span class="step-number">1</span>
+            <div class="step-content">
+              <strong>Browse city rankings</strong>
+              <span>Cities are ranked by job availability and cargo value</span>
+            </div>
+          </div>
+          <div class="step">
+            <span class="step-number">2</span>
+            <div class="step-content">
+              <strong>Click a city for trailer recommendations</strong>
+              <span>See which trailers work best for that location</span>
+            </div>
+          </div>
+          <div class="step">
+            <span class="step-number">3</span>
+            <div class="step-content">
+              <strong>Mark your garages with ★</strong>
+              <span>Track which cities you've set up garages in</span>
+            </div>
+          </div>
+        </div>
+        <div class="terminology">
+          <h3>Key Terms</h3>
+          <dl class="term-list">
+            <dt class="tooltip" tabindex="0" data-tooltip="Company facilities (like Posped, EuroGoodies, etc.) that offer cargo jobs in a city">Depots</dt>
+            <dd>Company facilities where you pick up cargo</dd>
 
-          <dt class="tooltip" tabindex="0" data-tooltip="Earning value weighted by cargo value, spawn rate, and depot count">EV (Expected Value)</dt>
-          <dd>A trailer's earning potential in a specific city</dd>
+            <dt class="tooltip" tabindex="0" data-tooltip="Earning value weighted by cargo value, spawn rate, and depot count">EV (Expected Value)</dt>
+            <dd>A trailer's earning potential in a specific city</dd>
 
-          <dt class="tooltip" tabindex="0" data-tooltip="What fraction of the city's total earning potential this trailer covers">Share</dt>
-          <dd>Percentage of city value covered by a trailer type</dd>
+            <dt class="tooltip" tabindex="0" data-tooltip="What fraction of the city's total earning potential this trailer covers">Share</dt>
+            <dd>Percentage of city value covered by a trailer type</dd>
 
-          <dt class="tooltip" tabindex="0" data-tooltip="Total weighted cargo value — higher score means more profitable garage location">Score</dt>
-          <dd>Overall earning potential of a city's job market</dd>
-        </dl>
+            <dt class="tooltip" tabindex="0" data-tooltip="Total weighted cargo value — higher score means more profitable garage location">Score</dt>
+            <dd>Overall earning potential of a city's job market</dd>
+          </dl>
+        </div>
       </div>
     </div>
 

--- a/src/frontend/main.ts
+++ b/src/frontend/main.ts
@@ -9,6 +9,7 @@ import {
   getSelectedCountries, setSelectedCountries,
   getOwnedTrailerDLCs, getOwnedCargoDLCs, getOwnedMapDLCs,
   isFirstVisit, isBannerDismissed, dismissBanner,
+  isOnboardingCollapsed, setOnboardingCollapsed,
   COMBINED_CARGO_DLC_MAP, CITY_DLC_MAP,
 } from './storage.js';
 import type { AllData, Lookups } from './data.js';
@@ -182,6 +183,8 @@ const backLink = document.getElementById('back-link')!;
 const filterToggle = document.getElementById('filter-toggle')!;
 const citySearch = document.getElementById('city-search') as HTMLInputElement;
 const howItWorksToggle = document.getElementById('how-it-works-toggle');
+const onboardingToggle = document.getElementById('onboarding-toggle');
+const onboardingSection = document.getElementById('onboarding');
 
 // Filter toggle
 filterToggle.addEventListener('click', (e) => {
@@ -593,6 +596,31 @@ function showDLCBanner() {
 
 async function init() {
   showDLCBanner();
+
+  // Initialize onboarding section collapsed state
+  if (onboardingSection && onboardingToggle) {
+    const collapsed = isOnboardingCollapsed();
+    if (collapsed) {
+      onboardingSection.classList.add('collapsed');
+      onboardingToggle.setAttribute('aria-expanded', 'false');
+      onboardingToggle.querySelector('.toggle-icon')!.textContent = '▶';
+    }
+    onboardingToggle.addEventListener('click', () => {
+      const isCollapsed = onboardingSection.classList.contains('collapsed');
+      if (isCollapsed) {
+        onboardingSection.classList.remove('collapsed');
+        onboardingToggle.setAttribute('aria-expanded', 'true');
+        onboardingToggle.querySelector('.toggle-icon')!.textContent = '▼';
+        setOnboardingCollapsed(false);
+      } else {
+        onboardingSection.classList.add('collapsed');
+        onboardingToggle.setAttribute('aria-expanded', 'false');
+        onboardingToggle.querySelector('.toggle-icon')!.textContent = '▶';
+        setOnboardingCollapsed(true);
+      }
+    });
+  }
+
   showLoading();
 
   try {

--- a/src/frontend/storage.ts
+++ b/src/frontend/storage.ts
@@ -20,6 +20,7 @@ export {
 
 const STORAGE_KEY = 'ets2-trucker-advisor';
 const BANNER_DISMISSED_KEY = 'ets2-dlc-banner-dismissed';
+const ONBOARDING_COLLAPSED_KEY = 'ets2-onboarding-collapsed';
 
 interface Settings {
   driverCount: number;
@@ -360,4 +361,26 @@ export function isBannerDismissed(): boolean {
  */
 export function dismissBanner(): void {
   localStorage.setItem(BANNER_DISMISSED_KEY, 'true');
+}
+
+// ============================================
+// Onboarding Section Collapsed State
+// ============================================
+
+/**
+ * Returns true if the Getting Started section should be collapsed.
+ * Defaults to expanded for first-time visitors, collapsed for returning visitors.
+ */
+export function isOnboardingCollapsed(): boolean {
+  const stored = localStorage.getItem(ONBOARDING_COLLAPSED_KEY);
+  if (stored !== null) return stored === 'true';
+  // First-time visitors see it expanded; returning visitors (who have state) see it collapsed
+  return !isFirstVisit();
+}
+
+/**
+ * Save the onboarding collapsed state.
+ */
+export function setOnboardingCollapsed(collapsed: boolean): void {
+  localStorage.setItem(ONBOARDING_COLLAPSED_KEY, collapsed ? 'true' : 'false');
 }


### PR DESCRIPTION
## Summary
- Getting Started section is now collapsible with a toggle in the header
- State persisted in localStorage — collapsed for returning users
- First-time visitors still see it expanded

Closes #76