### PR TITLE
Improve touch targets on collapsible section headers

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -126,7 +126,8 @@ nav {
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  padding: 0.35rem 0.5rem;
+  padding: 0.5rem 0.75rem;
+  min-height: 44px;
   cursor: pointer;
   font-size: 0.85rem;
   border-radius: 3px;
@@ -444,6 +445,7 @@ nav {
   gap: 0.5rem;
   padding: 0;
   min-height: 44px;
+  width: 100%;
   font-size: 1rem;
 }
 
@@ -605,6 +607,7 @@ nav {
   gap: 0.5rem;
   padding: 0;
   min-height: 44px;
+  width: 100%;
   font-size: 1rem;
 }
 
@@ -1051,6 +1054,7 @@ a.link:hover {
   align-items: center;
   cursor: pointer;
   padding: 0.5rem 0;
+  min-height: 44px;
 }
 
 .country-header h3 {
@@ -1667,6 +1671,11 @@ tr.owned-garage {
 
   .cards-grid {
     grid-template-columns: 1fr;
+  }
+
+  .country-header {
+    min-height: 44px;
+    padding: 0.75rem 0;
   }
 
   .dlc-page-columns {


### PR DESCRIPTION
## Summary
- All collapsible section headers now have minimum 44px touch targets
- DLC checkbox rows also increased to 44px minimum
- Meets Apple HIG and WCAG touch target guidelines

Closes #91