### PR TITLE
Enhance copy-to-clipboard feedback visibility

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -744,9 +744,17 @@ input[type="range"]::-moz-range-thumb {
   outline-offset: 2px;
 }
 
-.copy-btn.copied {
-  border-color: #2ecc71;
-  color: #2ecc71;
+.copy-btn.copied,
+.copy-success {
+  border-color: #2ecc71 !important;
+  color: #2ecc71 !important;
+  transition: border-color 0.2s, color 0.2s;
+}
+
+.copy-fail {
+  border-color: #e74c3c !important;
+  color: #e74c3c !important;
+  transition: border-color 0.2s, color 0.2s;
 }
 
 /* Section Headers */

--- a/src/frontend/clipboard.ts
+++ b/src/frontend/clipboard.ts
@@ -1,0 +1,28 @@
+/**
+ * Shared clipboard utility with visual feedback.
+ * Provides a consistent copy-to-clipboard experience across all pages.
+ */
+
+/**
+ * Copy text to clipboard and show visual feedback on the triggering button.
+ * On success: button shows "Copied!" with green styling for 2 seconds.
+ * On failure: button shows "Failed" with red styling for 2 seconds.
+ */
+export async function copyToClipboard(text: string, button: HTMLButtonElement): Promise<void> {
+  const originalText = button.textContent;
+  const originalClass = button.className;
+
+  try {
+    await navigator.clipboard.writeText(text);
+    button.textContent = '\u2713 Copied!';
+    button.classList.add('copy-success');
+  } catch {
+    button.textContent = 'Failed';
+    button.classList.add('copy-fail');
+  }
+
+  setTimeout(() => {
+    button.textContent = originalText;
+    button.className = originalClass;
+  }, 2000);
+}

--- a/src/frontend/main.ts
+++ b/src/frontend/main.ts
@@ -11,6 +11,7 @@ import {
   isFirstVisit, isBannerDismissed, dismissBanner,
   COMBINED_CARGO_DLC_MAP, CITY_DLC_MAP,
 } from './storage.js';
+import { copyToClipboard } from './clipboard.js';
 import type { AllData, Lookups } from './data.js';
 
 let data: AllData | null = null;
@@ -452,7 +453,12 @@ function renderCity(cityId: string) {
     </div>
 
     <div class="table-section">
-      <h2>Recommended Fleet — ${optimal.totalTrailers} trailers</h2>
+      <div class="section-header">
+        <h2>Recommended Fleet — ${optimal.totalTrailers} trailers</h2>
+        <div class="export-buttons">
+          <button class="btn copy-btn" id="copy-fleet-btn" type="button">Copy Fleet</button>
+        </div>
+      </div>
       <table>
         <thead>
           <tr>
@@ -470,6 +476,21 @@ function renderCity(cityId: string) {
   `;
 
   wireGarageToggle(cityId);
+  wireCopyFleetButton(city.name, optimal.drivers);
+}
+
+function wireCopyFleetButton(cityName: string, drivers: OptimalFleetEntry[]) {
+  const copyBtn = document.getElementById('copy-fleet-btn') as HTMLButtonElement | null;
+  if (!copyBtn) return;
+
+  copyBtn.addEventListener('click', () => {
+    const lines = drivers.map(d => {
+      const countLabel = d.count > 1 ? ` x${d.count}` : '';
+      return `${d.displayName}${countLabel} (EV: ${formatNumber(d.ev)}, ${d.cargoMatched} cargo)`;
+    });
+    const text = `${cityName} Fleet:\n${lines.join('\n')}`;
+    copyToClipboard(text, copyBtn);
+  });
 }
 
 function wireGarageToggle(cityId: string) {


### PR DESCRIPTION
## Summary
- Added shared `copyToClipboard()` utility in `src/frontend/clipboard.ts` with consistent visual feedback
- Copy buttons show "Copied!" with green styling on success, "Failed" in red on error, reverting after 2 seconds
- Added "Copy Fleet" button on city detail view to copy recommended trailer set as formatted text
- Added `.copy-success` and `.copy-fail` CSS classes for feedback states

## Test plan
- [ ] Open a city detail page and click "Copy Fleet" -- verify button text changes to "Copied!" with green styling
- [ ] Paste clipboard content -- should show city name and fleet list with EV and cargo counts
- [ ] After 2 seconds, button should revert to "Copy Fleet"
- [ ] Run `npm run lint` and `npm run test` -- both pass

Closes #77