### PR TITLE
Add ARIA live regions for dynamic content and fix color contrast

### DIFF
--- a/public/cargo.html
+++ b/public/cargo.html
@@ -29,13 +29,13 @@
       <input type="text" id="search" placeholder="Search cargo..." aria-label="Search cargo">
     </div>
 
-    <div id="content">
-      <div class="loading">Loading cargo...</div>
+    <div id="content" aria-live="polite">
+      <div class="loading" role="status">Loading cargo...</div>
     </div>
 
     <div id="cargo-detail" style="display: none;">
       <a href="#" class="back-link" id="back-link">← Back to cargo</a>
-      <div id="detail-content"></div>
+      <div id="detail-content" aria-live="polite"></div>
     </div>
     </main>
   </div>

--- a/public/cities.html
+++ b/public/cities.html
@@ -29,13 +29,13 @@
       <input type="text" id="search" placeholder="Search cities..." aria-label="Search cities">
     </div>
 
-    <div id="content">
-      <div class="loading">Loading cities...</div>
+    <div id="content" aria-live="polite">
+      <div class="loading" role="status">Loading cities...</div>
     </div>
 
     <div id="city-detail" style="display: none;">
       <a href="#" class="back-link" id="back-link">← Back to cities</a>
-      <div id="detail-content"></div>
+      <div id="detail-content" aria-live="polite"></div>
     </div>
     </main>
   </div>

--- a/public/companies.html
+++ b/public/companies.html
@@ -29,13 +29,13 @@
       <input type="text" id="search" placeholder="Search companies..." aria-label="Search companies">
     </div>
 
-    <div id="content">
-      <div class="loading">Loading companies...</div>
+    <div id="content" aria-live="polite">
+      <div class="loading" role="status">Loading companies...</div>
     </div>
 
     <div id="company-detail" style="display: none;">
       <a href="#" class="back-link" id="back-link">← Back to companies</a>
-      <div id="detail-content"></div>
+      <div id="detail-content" aria-live="polite"></div>
     </div>
     </main>
   </div>

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -62,7 +62,7 @@ h1 {
 }
 
 .subtitle {
-  color: #888;
+  color: #9a9a9a;
   font-size: 0.95rem;
   font-weight: normal;
 }
@@ -114,7 +114,7 @@ nav {
 .dlc-actions button {
   background: none;
   border: none;
-  color: #7a8a9a;
+  color: #8b95a0;
   cursor: pointer;
   font-size: 0.75rem;
   padding: 0.15rem 0.4rem;
@@ -165,7 +165,7 @@ nav {
 .dlc-count {
   font-weight: 400;
   font-size: 0.8rem;
-  color: #7a8a9a;
+  color: #8b95a0;
 }
 
 /* DLC value analysis */
@@ -202,7 +202,7 @@ nav {
   cursor: not-allowed;
 }
 .dlc-value-hint {
-  color: #7a8a9a;
+  color: #8b95a0;
   font-size: 0.85rem;
   margin-bottom: 1rem;
 }
@@ -217,7 +217,7 @@ nav {
   gap: 0.5rem;
 }
 .dlc-value-summary {
-  color: #7a8a9a;
+  color: #8b95a0;
   font-size: 0.85rem;
   margin-bottom: 0.5rem;
 }
@@ -241,7 +241,7 @@ nav {
 }
 .dlc-value-type {
   font-size: 0.75rem;
-  color: #7a8a9a;
+  color: #8b95a0;
   background: #1a2744;
   padding: 0.1rem 0.5rem;
   border-radius: 3px;
@@ -259,7 +259,7 @@ nav {
 .dlc-value-detail {
   width: 100%;
   font-size: 0.8rem;
-  color: #7a8a9a;
+  color: #8b95a0;
   margin-top: 0.3rem;
   padding-top: 0.3rem;
   border-top: 1px solid #2a3a5a;
@@ -302,7 +302,7 @@ nav {
 .dlc-banner-dismiss {
   background: none;
   border: none;
-  color: #888;
+  color: #9a9a9a;
   font-size: 1.25rem;
   cursor: pointer;
   padding: 0.25rem;
@@ -699,7 +699,7 @@ nav {
 }
 
 .slider-description {
-  color: #888;
+  color: #9a9a9a;
   font-size: 0.85rem;
   margin: -0.25rem 0 0.25rem 0;
   line-height: 1.4;
@@ -774,7 +774,7 @@ input[type="range"]::-moz-range-thumb {
 
 .reset-btn, .btn {
   background: transparent;
-  border: 1px solid #666;
+  border: 1px solid #8b8b8b;
   color: #9a9a9a;
   padding: 0.4rem 0.8rem;
   min-height: 44px;
@@ -963,7 +963,7 @@ tr.clickable:focus td:first-child {
 
 .trailer-spec {
   font-size: 0.75rem;
-  color: #7a8a9a;
+  color: #8b95a0;
   margin-top: 0.15rem;
 }
 
@@ -1032,7 +1032,7 @@ tr.scs-fallback-row td {
 }
 
 .score {
-  color: #e74c3c;
+  color: #ef5350;
   font-weight: bold;
 }
 
@@ -1050,7 +1050,7 @@ tr.scs-fallback-row td {
 }
 
 .score-tier-below {
-  color: #888;
+  color: #9a9a9a;
 }
 
 /* Rank Display */
@@ -1079,7 +1079,7 @@ tr.scs-fallback-row td {
 
 .trailer-cargoes {
   font-size: 0.8rem;
-  color: #888;
+  color: #9a9a9a;
   margin-top: 0.25rem;
 }
 
@@ -1153,7 +1153,7 @@ a.link:hover {
 }
 
 .country-count {
-  color: #888;
+  color: #9a9a9a;
   font-size: 0.9rem;
 }
 
@@ -1237,7 +1237,7 @@ a.link:hover {
 }
 
 .detail-header .subtitle {
-  color: #888;
+  color: #9a9a9a;
   font-size: 1rem;
 }
 
@@ -1291,11 +1291,17 @@ a.link:hover {
 .empty-state, .loading {
   text-align: center;
   padding: 3rem;
-  color: #e74c3c;
+  color: #ef5350;
 }
 
 .loading {
-  color: #888;
+  color: #9a9a9a;
+}
+
+.error-detail {
+  color: #9a9a9a;
+  font-size: 0.9rem;
+  margin-top: 0.5rem;
 }
 
 /* Loading Skeleton */
@@ -1585,7 +1591,7 @@ th.tooltip::before {
   background: transparent;
   border: none;
   font-size: 1.5rem;
-  color: #666;
+  color: #8b8b8b;
   cursor: pointer;
   padding: 0.25rem;
   min-width: 44px;
@@ -1616,7 +1622,7 @@ th.tooltip::before {
   font-size: 1.2rem;
   width: 2rem;
   text-align: center;
-  color: #666;
+  color: #8b8b8b;
   user-select: none;
 }
 
@@ -1637,7 +1643,7 @@ tr.owned-garage {
 .no-results {
   text-align: center;
   padding: 2rem;
-  color: #888;
+  color: #9a9a9a;
   font-size: 0.95rem;
 }
 
@@ -1645,7 +1651,7 @@ tr.owned-garage {
 .empty-garages {
   text-align: center;
   padding: 3rem;
-  color: #888;
+  color: #9a9a9a;
 }
 
 .empty-garages p {
@@ -1653,7 +1659,7 @@ tr.owned-garage {
 }
 
 .empty-garages .hint {
-  color: #666;
+  color: #8b8b8b;
   font-size: 0.9rem;
 }
 

--- a/public/dlcs.html
+++ b/public/dlcs.html
@@ -25,8 +25,8 @@
     </header>
 
     <main id="main-content">
-    <div id="dlc-settings">
-      <div class="loading">Loading DLC settings...</div>
+    <div id="dlc-settings" aria-live="polite">
+      <div class="loading" role="status">Loading DLC settings...</div>
     </div>
 
     <div id="dlc-value-section" style="display: none;">
@@ -35,8 +35,8 @@
         <button id="calc-value-btn" class="calc-btn">Calculate Marginal Value</button>
       </div>
       <p class="dlc-value-hint">Shows how much fleet EV each unowned DLC would add. Requires at least one owned garage.</p>
-      <div id="dlc-value-progress" style="display: none;"></div>
-      <div id="dlc-value-results"></div>
+      <div id="dlc-value-progress" role="status" aria-live="polite" style="display: none;"></div>
+      <div id="dlc-value-results" aria-live="polite"></div>
     </div>
     </main>
   </div>

--- a/public/index.html
+++ b/public/index.html
@@ -170,14 +170,14 @@
     </div>
 
     <div id="rankings-view">
-      <div id="rankings-content">
+      <div id="rankings-content" aria-live="polite" aria-atomic="true">
         <!-- Loading state will be injected here by JavaScript -->
       </div>
     </div>
 
     <div id="city-view" style="display: none;">
       <button class="back-link" id="back-link" type="button">← Back to rankings</button>
-      <div id="city-content"></div>
+      <div id="city-content" aria-live="polite"></div>
     </div>
     </main>
   </div>

--- a/public/trailers.html
+++ b/public/trailers.html
@@ -29,13 +29,13 @@
       <input type="text" id="search" placeholder="Search trailers..." aria-label="Search trailers">
     </div>
 
-    <div id="content">
-      <div class="loading">Loading trailers...</div>
+    <div id="content" aria-live="polite">
+      <div class="loading" role="status">Loading trailers...</div>
     </div>
 
     <div id="trailer-detail" style="display: none;">
       <a href="#" class="back-link" id="back-link">&larr; Back to trailers</a>
-      <div id="detail-content"></div>
+      <div id="detail-content" aria-live="polite"></div>
     </div>
     </main>
   </div>

--- a/src/frontend/cargo.ts
+++ b/src/frontend/cargo.ts
@@ -254,7 +254,7 @@ function showCargoDetail(cargoId: string): void {
           ? `
             <div class="table-section">
               <h2>Trailer Information</h2>
-              <p style="padding: 1rem; color: #888;">
+              <p style="padding: 1rem;" class="error-detail">
                 This is a trailer delivery job. The trailer is pre-assigned and cannot be chosen.
               </p>
             </div>
@@ -336,9 +336,9 @@ async function init(): Promise<void> {
     console.error('Failed to initialize:', err);
     const message = err instanceof Error ? err.message : 'Unknown error occurred';
     content.innerHTML = `
-      <div class="empty-state">
+      <div class="empty-state" role="alert">
         <p>Failed to load data</p>
-        <p style="color: #888; font-size: 0.9rem; margin-top: 0.5rem;">${message}</p>
+        <p class="error-detail">${message}</p>
       </div>
     `;
   }

--- a/src/frontend/cities.ts
+++ b/src/frontend/cities.ts
@@ -290,9 +290,9 @@ async function init(): Promise<void> {
     console.error('Failed to initialize:', err);
     const message = err instanceof Error ? err.message : 'Unknown error occurred';
     content.innerHTML = `
-      <div class="empty-state">
+      <div class="empty-state" role="alert">
         <p>Failed to load data</p>
-        <p style="color: #888; font-size: 0.9rem; margin-top: 0.5rem;">${message}</p>
+        <p class="error-detail">${message}</p>
       </div>
     `;
   }

--- a/src/frontend/companies.ts
+++ b/src/frontend/companies.ts
@@ -311,9 +311,9 @@ async function init(): Promise<void> {
     console.error('Failed to initialize:', err);
     const message = err instanceof Error ? err.message : 'Unknown error occurred';
     content.innerHTML = `
-      <div class="empty-state">
+      <div class="empty-state" role="alert">
         <p>Failed to load data</p>
-        <p style="color: #888; font-size: 0.9rem; margin-top: 0.5rem;">${message}</p>
+        <p class="error-detail">${message}</p>
       </div>
     `;
   }

--- a/src/frontend/main.ts
+++ b/src/frontend/main.ts
@@ -284,7 +284,7 @@ function renderRankings() {
             </tr>
           </thead>
           <tbody>
-            <tr><td colspan="8" class="no-results">${message}</td></tr>
+            <tr><td colspan="8" class="no-results" role="status">${message}</td></tr>
           </tbody>
         </table>
       </div>
@@ -588,7 +588,7 @@ function handleHashNavigation(): boolean {
 
 function showLoading() {
   rankingsContent.innerHTML = `
-    <div class="table-section">
+    <div class="table-section" role="status" aria-label="Loading city data">
       <h2>Loading city data...</h2>
       <div class="skeleton-row"><div class="skeleton-cell narrow"></div><div class="skeleton-cell medium"></div><div class="skeleton-cell medium"></div><div class="skeleton-cell narrow"></div><div class="skeleton-cell narrow"></div><div class="skeleton-cell narrow"></div><div class="skeleton-cell medium"></div></div>
       <div class="skeleton-row"><div class="skeleton-cell narrow"></div><div class="skeleton-cell medium"></div><div class="skeleton-cell medium"></div><div class="skeleton-cell narrow"></div><div class="skeleton-cell narrow"></div><div class="skeleton-cell narrow"></div><div class="skeleton-cell medium"></div></div>
@@ -599,9 +599,9 @@ function showLoading() {
 
 function showError(errorMessage: string) {
   rankingsContent.innerHTML = `
-    <div class="empty-state">
+    <div class="empty-state" role="alert" aria-live="assertive">
       <p>Failed to load data</p>
-      <p style="color: #888; font-size: 0.9rem; margin-top: 0.5rem;">${errorMessage}</p>
+      <p class="error-detail">${errorMessage}</p>
     </div>
   `;
 }

--- a/src/frontend/trailers.ts
+++ b/src/frontend/trailers.ts
@@ -592,9 +592,9 @@ async function init(): Promise<void> {
     console.error('Failed to initialize:', err);
     const message = err instanceof Error ? err.message : 'Unknown error occurred';
     content.innerHTML = `
-      <div class="empty-state">
+      <div class="empty-state" role="alert">
         <p>Failed to load data</p>
-        <p style="color: #888; font-size: 0.9rem; margin-top: 0.5rem;">${message}</p>
+        <p class="error-detail">${message}</p>
       </div>
     `;
   }


### PR DESCRIPTION
## Summary
- Add `aria-live="polite"` to rankings table, city detail, and all browser page content areas so screen readers announce dynamic content changes
- Add `role="status"` to loading indicators and `role="alert"` to error messages across all pages
- Fix color contrast on 20+ CSS selectors to meet WCAG AA 4.5:1 ratio for normal text:
  - `#666` (2.77-2.97:1) raised to `#8b8b8b` (4.67-5.01:1) for garage stars, hints
  - `#888` (4.48:1) raised to `#9a9a9a` (5.65:1) for no-results, loading, subtitles, score-tier-below
  - `#7a8a9a` (4.18-4.49:1) raised to `#8b95a0` (4.87-5.61:1) for trailer specs, DLC details
  - `#e74c3c` (4.16:1) raised to `#ef5350` (4.56:1) for score and empty-state text
- Replace inline `color: #888` styles with `.error-detail` CSS class in all error handlers

Closes #109