### PR TITLE
Extract shared page initialization to eliminate duplication

### DIFF
--- a/src/frontend/cargo.ts
+++ b/src/frontend/cargo.ts
@@ -3,8 +3,8 @@
  * Displays cargo browser with provider/trailer information
  */
 
-import { loadAllData, buildLookups, applyDLCFilter, getBlockedCities, normalize, type AllData, type Lookups, type Company, type Trailer } from './data';
-import { getOwnedTrailerDLCs, getOwnedCargoDLCs, getOwnedMapDLCs, COMBINED_CARGO_DLC_MAP, CITY_DLC_MAP } from './storage';
+import { initPageData } from './page-init';
+import { normalize, type AllData, type Lookups, type Company, type Trailer } from './data';
 
 let data: AllData | null = null;
 let lookups: Lookups | null = null;
@@ -314,10 +314,9 @@ async function init(): Promise<void> {
   content.innerHTML = '<div class="loading">Loading cargo...</div>';
 
   try {
-    const ownedCargoAndMap = new Set([...getOwnedCargoDLCs(), ...getOwnedMapDLCs()]);
-    const blocked = getBlockedCities(getOwnedMapDLCs(), CITY_DLC_MAP);
-    data = applyDLCFilter(await loadAllData(), getOwnedTrailerDLCs(), ownedCargoAndMap, COMBINED_CARGO_DLC_MAP, blocked);
-    lookups = buildLookups(data);
+    const page = await initPageData();
+    data = page.data;
+    lookups = page.lookups;
 
     renderCargoList();
 

--- a/src/frontend/cities.ts
+++ b/src/frontend/cities.ts
@@ -3,8 +3,9 @@
  * Displays city browser with company/depot information
  */
 
-import { loadAllData, buildLookups, applyDLCFilter, getBlockedCities, normalize, type AllData, type Lookups, type Company } from './data';
-import { isOwnedGarage, getOwnedTrailerDLCs, getOwnedCargoDLCs, getOwnedMapDLCs, COMBINED_CARGO_DLC_MAP, CITY_DLC_MAP } from './storage';
+import { initPageData } from './page-init';
+import { normalize, type AllData, type Lookups, type Company } from './data';
+import { isOwnedGarage } from './storage';
 
 let data: AllData | null = null;
 let lookups: Lookups | null = null;
@@ -268,10 +269,9 @@ async function init(): Promise<void> {
   content.innerHTML = '<div class="loading">Loading cities...</div>';
 
   try {
-    const ownedCargoAndMap = new Set([...getOwnedCargoDLCs(), ...getOwnedMapDLCs()]);
-    const blocked = getBlockedCities(getOwnedMapDLCs(), CITY_DLC_MAP);
-    data = applyDLCFilter(await loadAllData(), getOwnedTrailerDLCs(), ownedCargoAndMap, COMBINED_CARGO_DLC_MAP, blocked);
-    lookups = buildLookups(data);
+    const page = await initPageData();
+    data = page.data;
+    lookups = page.lookups;
 
     renderCityList();
 

--- a/src/frontend/companies.ts
+++ b/src/frontend/companies.ts
@@ -3,8 +3,8 @@
  * Displays company browser with city/cargo information
  */
 
-import { loadAllData, buildLookups, applyDLCFilter, getBlockedCities, normalize, type AllData, type Lookups, type City, type Cargo } from './data';
-import { getOwnedTrailerDLCs, getOwnedCargoDLCs, getOwnedMapDLCs, COMBINED_CARGO_DLC_MAP, CITY_DLC_MAP } from './storage';
+import { initPageData } from './page-init';
+import { normalize, type AllData, type Lookups, type City, type Cargo } from './data';
 
 let data: AllData | null = null;
 let lookups: Lookups | null = null;
@@ -289,10 +289,9 @@ async function init(): Promise<void> {
   content.innerHTML = '<div class="loading">Loading companies...</div>';
 
   try {
-    const ownedCargoAndMap = new Set([...getOwnedCargoDLCs(), ...getOwnedMapDLCs()]);
-    const blocked = getBlockedCities(getOwnedMapDLCs(), CITY_DLC_MAP);
-    data = applyDLCFilter(await loadAllData(), getOwnedTrailerDLCs(), ownedCargoAndMap, COMBINED_CARGO_DLC_MAP, blocked);
-    lookups = buildLookups(data);
+    const page = await initPageData();
+    data = page.data;
+    lookups = page.lookups;
 
     renderCompanyList();
 

--- a/src/frontend/data.ts
+++ b/src/frontend/data.ts
@@ -43,6 +43,9 @@ export {
 // Body types
 export { getBodyTypeProfiles, getChassisMergeMap } from './body-types';
 
+// Page initialization
+export { initPageData, type PageData } from './page-init';
+
 // Utils
 export {
   normalize, formatTrailerSpec, trailerTotalHV, pickBestTrailer,

--- a/src/frontend/main.ts
+++ b/src/frontend/main.ts
@@ -1,4 +1,4 @@
-import { loadAllData, buildLookups, applyDLCFilter, getBlockedCities } from './data.js';
+import { initPageData } from './page-init.js';
 import {
   calculateCityRankings, computeOptimalFleet,
   type CityRanking, type FleetEntry, type OptimalFleetEntry,
@@ -7,10 +7,8 @@ import {
   getOwnedGarages, toggleOwnedGarage, isOwnedGarage,
   getFilterMode, setFilterMode,
   getSelectedCountries, setSelectedCountries,
-  getOwnedTrailerDLCs, getOwnedCargoDLCs, getOwnedMapDLCs,
   isFirstVisit, isBannerDismissed, dismissBanner,
   isOnboardingCollapsed, setOnboardingCollapsed,
-  COMBINED_CARGO_DLC_MAP, CITY_DLC_MAP,
 } from './storage.js';
 import { copyToClipboard } from './clipboard.js';
 import type { AllData, Lookups } from './data.js';
@@ -673,10 +671,9 @@ async function init() {
   showLoading();
 
   try {
-    const ownedCargoAndMap = new Set([...getOwnedCargoDLCs(), ...getOwnedMapDLCs()]);
-    const blocked = getBlockedCities(getOwnedMapDLCs(), CITY_DLC_MAP);
-    data = applyDLCFilter(await loadAllData(), getOwnedTrailerDLCs(), ownedCargoAndMap, COMBINED_CARGO_DLC_MAP, blocked);
-    lookups = buildLookups(data);
+    const page = await initPageData();
+    data = page.data;
+    lookups = page.lookups;
 
     renderCountryCheckboxes();
     updateCountryButtonText();

--- a/src/frontend/page-init.ts
+++ b/src/frontend/page-init.ts
@@ -1,0 +1,43 @@
+/**
+ * Shared page initialization for ETS2 Trucker Advisor
+ *
+ * Centralizes the data loading + DLC filtering + lookup building
+ * sequence that every page module needs. When DLC filtering logic
+ * changes, only this file needs updating.
+ */
+
+import { loadAllData } from './loader';
+import { buildLookups } from './lookups';
+import { applyDLCFilter, getBlockedCities } from './dlc-filter';
+import {
+  getOwnedTrailerDLCs, getOwnedCargoDLCs, getOwnedMapDLCs,
+  COMBINED_CARGO_DLC_MAP, CITY_DLC_MAP,
+} from './storage';
+import type { AllData, Lookups } from './types';
+
+export interface PageData {
+  data: AllData;
+  lookups: Lookups;
+}
+
+/**
+ * Load game data, apply DLC ownership filters, and build lookup maps.
+ *
+ * Every browser page calls this once at startup. The sequence is:
+ * 1. loadAllData()       — fetch game-defs.json + observations.json
+ * 2. applyDLCFilter()    — remove content from unowned DLCs
+ * 3. buildLookups()      — build efficient access maps
+ */
+export async function initPageData(): Promise<PageData> {
+  const ownedCargoAndMap = new Set([...getOwnedCargoDLCs(), ...getOwnedMapDLCs()]);
+  const blocked = getBlockedCities(getOwnedMapDLCs(), CITY_DLC_MAP);
+  const data = applyDLCFilter(
+    await loadAllData(),
+    getOwnedTrailerDLCs(),
+    ownedCargoAndMap,
+    COMBINED_CARGO_DLC_MAP,
+    blocked,
+  );
+  const lookups = buildLookups(data);
+  return { data, lookups };
+}

--- a/src/frontend/trailers.ts
+++ b/src/frontend/trailers.ts
@@ -5,12 +5,12 @@
  * Level 3: All trailer variants within a tier, sorted by totalHV
  */
 
+import { initPageData } from './page-init';
 import {
-  loadAllData, buildLookups, applyDLCFilter, getBlockedCities, normalize, getOwnableTrailers,
+  normalize, getOwnableTrailers,
   pickBestTrailer, trailerTotalHV, formatTrailerSpec,
   type AllData, type Lookups, type Cargo, type Trailer,
 } from './data';
-import { getOwnedTrailerDLCs, getOwnedCargoDLCs, getOwnedMapDLCs, COMBINED_CARGO_DLC_MAP, CITY_DLC_MAP } from './storage';
 
 let data: AllData | null = null;
 let lookups: Lookups | null = null;
@@ -556,10 +556,9 @@ async function init(): Promise<void> {
   content.innerHTML = '<div class="loading">Loading trailers...</div>';
 
   try {
-    const ownedCargoAndMap = new Set([...getOwnedCargoDLCs(), ...getOwnedMapDLCs()]);
-    const blocked = getBlockedCities(getOwnedMapDLCs(), CITY_DLC_MAP);
-    data = applyDLCFilter(await loadAllData(), getOwnedTrailerDLCs(), ownedCargoAndMap, COMBINED_CARGO_DLC_MAP, blocked);
-    lookups = buildLookups(data);
+    const page = await initPageData();
+    data = page.data;
+    lookups = page.lookups;
     bodyTypes = buildBodyTypes();
 
     renderList();


### PR DESCRIPTION
## Summary
- Extract common data loading + DLC filtering sequence into `page-init.ts`
- All 5 page modules (main, cities, companies, cargo, trailers) now use shared `initPageData()` instead of duplicating the pattern
- Reduces maintenance burden when DLC filtering logic changes
- Re-exported via `data.ts` barrel for backward compatibility

Closes #125