### PR TITLE
Expand test coverage: DLC filtering, analytical EV, body type profiling

### DIFF
--- a/src/frontend/__tests__/body-types.test.ts
+++ b/src/frontend/__tests__/body-types.test.ts
@@ -1,0 +1,263 @@
+import { describe, it, expect } from 'vitest';
+import { getBodyTypeProfiles, getChassisMergeMap } from '../body-types';
+import { buildLookups } from '../lookups';
+import type { AllData, Trailer } from '../types';
+
+/**
+ * Build minimal AllData with gameDefs for body type profiling tests.
+ * Uses realistic trailer ID conventions: brand.body_type.chain_variant
+ */
+function createBodyTypeTestData(): AllData {
+  return {
+    gameDefs: {
+      cities: {
+        berlin: { name: 'Berlin', country: 'germany', has_garage: true },
+      },
+      countries: { germany: { name: 'Germany' } },
+      companies: {
+        logistics_co: { name: 'Logistics Co', cargo_out: ['electronics', 'machinery', 'glass', 'cement'], cargo_in: [], cities: ['berlin'] },
+      },
+      cargo: {
+        electronics: { name: 'Electronics', value: 2.5, volume: 1, mass: 500, fragility: 0, fragile: false, high_value: false, adr_class: 0, prob_coef: 1, body_types: ['curtainside'], groups: [], excluded: false },
+        machinery: { name: 'Machinery', value: 3.0, volume: 1, mass: 800, fragility: 0, fragile: false, high_value: false, adr_class: 0, prob_coef: 1, body_types: ['flatbed'], groups: [], excluded: false },
+        glass: { name: 'Glass', value: 2.0, volume: 1, mass: 600, fragility: 0.6, fragile: true, high_value: false, adr_class: 0, prob_coef: 1, body_types: ['curtainside', 'flatbed'], groups: [], excluded: false },
+        cement: { name: 'Cement', value: 1.5, volume: 1, mass: 1000, fragility: 0, fragile: false, high_value: false, adr_class: 0, prob_coef: 1, body_types: ['silo'], groups: [], excluded: false },
+      },
+      trailers: {
+        // Curtainside body type trailers
+        'scs.curtainside.single_3': { name: 'SCS Curtainside 3-axle', body_type: 'curtainside', volume: 90, chassis_mass: 5000, body_mass: 3000, gross_weight_limit: 40000, length: 13.6, chain_type: 'single', ownable: true },
+        'scs.curtainside.double_3_2': { name: 'SCS Curtainside Double', body_type: 'curtainside', volume: 135, chassis_mass: 7000, body_mass: 4000, gross_weight_limit: 50000, length: 20, chain_type: 'double', country_validity: ['sweden', 'finland'], ownable: true },
+        // Flatbed body type trailers
+        'scs.flatbed.single_3': { name: 'SCS Flatbed 3-axle', body_type: 'flatbed', volume: 80, chassis_mass: 4000, body_mass: 2000, gross_weight_limit: 40000, length: 13.6, chain_type: 'single', ownable: true },
+        // Silo body type trailers
+        'scs.silo.single_3': { name: 'SCS Silo 3-axle', body_type: 'silo', volume: 32, chassis_mass: 4500, body_mass: 2500, gross_weight_limit: 40000, length: 12, chain_type: 'single', ownable: true },
+        // Non-ownable trailer
+        'scs.special.single_3': { name: 'SCS Special', body_type: 'special', volume: 50, chassis_mass: 5000, body_mass: 3000, gross_weight_limit: 40000, length: 13.6, chain_type: 'single', ownable: false },
+      },
+      city_companies: { berlin: { logistics_co: 2 } },
+      company_cargo: { logistics_co: ['electronics', 'machinery', 'glass', 'cement'] },
+      cargo_trailers: {
+        electronics: ['scs.curtainside.single_3', 'scs.curtainside.double_3_2'],
+        machinery: ['scs.flatbed.single_3'],
+        glass: ['scs.curtainside.single_3', 'scs.curtainside.double_3_2', 'scs.flatbed.single_3'],
+        cement: ['scs.silo.single_3'],
+      },
+      cargo_trailer_units: {
+        electronics: { 'scs.curtainside.single_3': 90, 'scs.curtainside.double_3_2': 135 },
+        machinery: { 'scs.flatbed.single_3': 1 },
+        glass: { 'scs.curtainside.single_3': 90, 'scs.curtainside.double_3_2': 135, 'scs.flatbed.single_3': 80 },
+        cement: { 'scs.silo.single_3': 32 },
+      },
+      economy: { fixed_revenue: 0, revenue_coef_per_km: 1, cargo_market_revenue_coef_per_km: 1 },
+      trucks: [],
+    },
+    observations: null,
+    cities: [
+      { id: 'berlin', name: 'Berlin', country: 'germany', hasGarage: true },
+    ],
+    companies: [{ id: 'logistics_co', name: 'Logistics Co' }],
+    cargo: [
+      { id: 'electronics', name: 'Electronics', value: 2.5, volume: 1, mass: 500, fragility: 0, fragile: false, high_value: false, adr_class: 0, prob_coef: 1, body_types: ['curtainside'], groups: [], excluded: false },
+      { id: 'machinery', name: 'Machinery', value: 3.0, volume: 1, mass: 800, fragility: 0, fragile: false, high_value: false, adr_class: 0, prob_coef: 1, body_types: ['flatbed'], groups: [], excluded: false },
+      { id: 'glass', name: 'Glass', value: 2.0, volume: 1, mass: 600, fragility: 0.6, fragile: true, high_value: false, adr_class: 0, prob_coef: 1, body_types: ['curtainside', 'flatbed'], groups: [], excluded: false },
+      { id: 'cement', name: 'Cement', value: 1.5, volume: 1, mass: 1000, fragility: 0, fragile: false, high_value: false, adr_class: 0, prob_coef: 1, body_types: ['silo'], groups: [], excluded: false },
+    ],
+    trailers: [
+      { id: 'scs.curtainside.single_3', name: 'SCS Curtainside 3-axle', body_type: 'curtainside', volume: 90, chassis_mass: 5000, body_mass: 3000, gross_weight_limit: 40000, length: 13.6, chain_type: 'single', ownable: true },
+      { id: 'scs.curtainside.double_3_2', name: 'SCS Curtainside Double', body_type: 'curtainside', volume: 135, chassis_mass: 7000, body_mass: 4000, gross_weight_limit: 50000, length: 20, chain_type: 'double', country_validity: ['sweden', 'finland'], ownable: true },
+      { id: 'scs.flatbed.single_3', name: 'SCS Flatbed 3-axle', body_type: 'flatbed', volume: 80, chassis_mass: 4000, body_mass: 2000, gross_weight_limit: 40000, length: 13.6, chain_type: 'single', ownable: true },
+      { id: 'scs.silo.single_3', name: 'SCS Silo 3-axle', body_type: 'silo', volume: 32, chassis_mass: 4500, body_mass: 2500, gross_weight_limit: 40000, length: 12, chain_type: 'single', ownable: true },
+      { id: 'scs.special.single_3', name: 'SCS Special', body_type: 'special', volume: 50, chassis_mass: 5000, body_mass: 3000, gross_weight_limit: 40000, length: 13.6, chain_type: 'single', ownable: false },
+    ],
+  };
+}
+
+describe('getBodyTypeProfiles', () => {
+  it('returns profiles only for body types with ownable trailers', () => {
+    const data = createBodyTypeTestData();
+    const lookups = buildLookups(data);
+    const profiles = getBodyTypeProfiles(data, lookups);
+
+    const bodyTypes = profiles.map((p) => p.bodyType);
+    expect(bodyTypes).toContain('curtainside');
+    expect(bodyTypes).toContain('flatbed');
+    expect(bodyTypes).toContain('silo');
+    // special is non-ownable, should not appear
+    expect(bodyTypes).not.toContain('special');
+  });
+
+  it('counts distinct cargo per body type', () => {
+    const data = createBodyTypeTestData();
+    const lookups = buildLookups(data);
+    const profiles = getBodyTypeProfiles(data, lookups);
+
+    const curtainside = profiles.find((p) => p.bodyType === 'curtainside');
+    // curtainside can haul: electronics, glass
+    expect(curtainside!.cargoCount).toBe(2);
+
+    const flatbed = profiles.find((p) => p.bodyType === 'flatbed');
+    // flatbed can haul: machinery, glass
+    expect(flatbed!.cargoCount).toBe(2);
+
+    const silo = profiles.find((p) => p.bodyType === 'silo');
+    // silo can haul: cement only
+    expect(silo!.cargoCount).toBe(1);
+  });
+
+  it('detects doubles availability from trailer IDs', () => {
+    const data = createBodyTypeTestData();
+    const lookups = buildLookups(data);
+    const profiles = getBodyTypeProfiles(data, lookups);
+
+    const curtainside = profiles.find((p) => p.bodyType === 'curtainside');
+    expect(curtainside!.hasDoubles).toBe(true);
+    expect(curtainside!.doublesCountries.length).toBeGreaterThan(0);
+
+    const flatbed = profiles.find((p) => p.bodyType === 'flatbed');
+    expect(flatbed!.hasDoubles).toBe(false);
+  });
+
+  it('populates bestTrailerId and bestTotalHV', () => {
+    const data = createBodyTypeTestData();
+    const lookups = buildLookups(data);
+    const profiles = getBodyTypeProfiles(data, lookups);
+
+    for (const profile of profiles) {
+      expect(profile.bestTrailerId).toBeTruthy();
+      expect(profile.bestTotalHV).toBeGreaterThan(0);
+      expect(profile.bestTrailerName).toBeTruthy();
+    }
+  });
+
+  it('sorts profiles by bestTotalHV descending', () => {
+    const data = createBodyTypeTestData();
+    const lookups = buildLookups(data);
+    const profiles = getBodyTypeProfiles(data, lookups);
+
+    for (let i = 0; i < profiles.length - 1; i++) {
+      expect(profiles[i].bestTotalHV).toBeGreaterThanOrEqual(profiles[i + 1].bestTotalHV);
+    }
+  });
+
+  it('generates display names from body type IDs', () => {
+    const data = createBodyTypeTestData();
+    const lookups = buildLookups(data);
+    const profiles = getBodyTypeProfiles(data, lookups);
+
+    const curtainside = profiles.find((p) => p.bodyType === 'curtainside');
+    expect(curtainside!.displayName).toContain('Curtainside');
+
+    const silo = profiles.find((p) => p.bodyType === 'silo');
+    expect(silo!.displayName).toContain('Silo');
+  });
+
+  it('detects dominated body types (subset cargo)', () => {
+    // Create data where silo cargo is a subset of curtainside cargo
+    const data = createBodyTypeTestData();
+    // Add cement to curtainside's compatible trailers
+    data.gameDefs!.cargo_trailers['cement'].push('scs.curtainside.single_3');
+    data.gameDefs!.cargo_trailer_units['cement']['scs.curtainside.single_3'] = 32;
+
+    const lookups = buildLookups(data);
+    const profiles = getBodyTypeProfiles(data, lookups);
+
+    // Silo can haul only cement; curtainside can haul electronics + glass + cement
+    // So silo should be dominated by curtainside
+    const silo = profiles.find((p) => p.bodyType === 'silo');
+    if (silo) {
+      expect(silo.dominatedBy).toBe('curtainside');
+    }
+  });
+});
+
+describe('getChassisMergeMap', () => {
+  it('returns empty map when no chassis merges needed', () => {
+    // Simple data: each body type on different chassis model
+    const data: AllData = {
+      gameDefs: null,
+      observations: null,
+      cities: [],
+      companies: [],
+      cargo: [],
+      trailers: [
+        { id: 'scs.curtainside.single_3', name: 'CS', body_type: 'curtainside', volume: 90, chassis_mass: 5000, body_mass: 3000, gross_weight_limit: 40000, length: 13.6, chain_type: 'single', ownable: true },
+        { id: 'scs.flatbed.single_3', name: 'FB', body_type: 'flatbed', volume: 80, chassis_mass: 4000, body_mass: 2000, gross_weight_limit: 40000, length: 13.6, chain_type: 'single', ownable: true },
+      ],
+    };
+
+    const mergeMap = getChassisMergeMap(data);
+    expect(mergeMap.size).toBe(0);
+  });
+
+  it('detects chassis merges when two body types share a chassis model', () => {
+    // scs.flatbed.single_3 and scs.flatbed.container_3 share scs.flatbed chassis
+    const data: AllData = {
+      gameDefs: null,
+      observations: null,
+      cities: [],
+      companies: [],
+      cargo: [],
+      trailers: [
+        { id: 'scs.flatbed.single_3', name: 'FB', body_type: 'flatbed', volume: 80, chassis_mass: 4000, body_mass: 2000, gross_weight_limit: 40000, length: 13.6, chain_type: 'single', ownable: true },
+        { id: 'scs.flatbed.container_3', name: 'Container', body_type: 'container', volume: 60, chassis_mass: 4000, body_mass: 2000, gross_weight_limit: 40000, length: 13.6, chain_type: 'single', ownable: true },
+      ],
+    };
+
+    const mergeMap = getChassisMergeMap(data);
+    // container should merge into flatbed (flatbed matches the chassis family name)
+    expect(mergeMap.get('container')).toBe('flatbed');
+  });
+
+  it('skips non-ownable trailers', () => {
+    const data: AllData = {
+      gameDefs: null,
+      observations: null,
+      cities: [],
+      companies: [],
+      cargo: [],
+      trailers: [
+        { id: 'scs.flatbed.single_3', name: 'FB', body_type: 'flatbed', volume: 80, chassis_mass: 4000, body_mass: 2000, gross_weight_limit: 40000, length: 13.6, chain_type: 'single', ownable: true },
+        { id: 'scs.flatbed.container_3', name: 'Container', body_type: 'container', volume: 60, chassis_mass: 4000, body_mass: 2000, gross_weight_limit: 40000, length: 13.6, chain_type: 'single', ownable: false },
+      ],
+    };
+
+    const mergeMap = getChassisMergeMap(data);
+    // container is non-ownable, so no merge should happen
+    expect(mergeMap.size).toBe(0);
+  });
+
+  it('prefers body type matching the chassis family name as survivor', () => {
+    const data: AllData = {
+      gameDefs: null,
+      observations: null,
+      cities: [],
+      companies: [],
+      cargo: [],
+      trailers: [
+        { id: 'scs.flatbed.alpha_3', name: 'Alpha', body_type: 'alpha_body', volume: 80, chassis_mass: 4000, body_mass: 2000, gross_weight_limit: 40000, length: 13.6, chain_type: 'single', ownable: true },
+        { id: 'scs.flatbed.flatbed_3', name: 'Flatbed', body_type: 'flatbed', volume: 80, chassis_mass: 4000, body_mass: 2000, gross_weight_limit: 40000, length: 13.6, chain_type: 'single', ownable: true },
+      ],
+    };
+
+    const mergeMap = getChassisMergeMap(data);
+    // 'flatbed' matches the family name (scs.flatbed), so alpha_body should merge into flatbed
+    expect(mergeMap.get('alpha_body')).toBe('flatbed');
+    expect(mergeMap.has('flatbed')).toBe(false); // survivor should not be in the map
+  });
+
+  it('handles trailers with single-segment IDs gracefully', () => {
+    const data: AllData = {
+      gameDefs: null,
+      observations: null,
+      cities: [],
+      companies: [],
+      cargo: [],
+      trailers: [
+        { id: 'simple', name: 'Simple', body_type: 'basic', volume: 50, chassis_mass: 3000, body_mass: 2000, gross_weight_limit: 30000, length: 10, chain_type: 'single', ownable: true },
+      ],
+    };
+
+    const mergeMap = getChassisMergeMap(data);
+    expect(mergeMap.size).toBe(0);
+  });
+});

--- a/src/frontend/__tests__/dlc-filter.test.ts
+++ b/src/frontend/__tests__/dlc-filter.test.ts
@@ -1,0 +1,421 @@
+import { describe, it, expect } from 'vitest';
+import { applyDLCFilter, getBlockedCities } from '../dlc-filter';
+import type { AllData } from '../types';
+
+/**
+ * Build minimal AllData with gameDefs for DLC filter testing.
+ * Trailers use brand prefix convention: scs.* = base game, feldbinder.* = DLC, etc.
+ */
+function createDLCTestData(): AllData {
+  return {
+    gameDefs: {
+      cities: {
+        berlin: { name: 'Berlin', country: 'germany', has_garage: true },
+        paris: { name: 'Paris', country: 'france', has_garage: true },
+        lisboa: { name: 'Lisboa', country: 'portugal', has_garage: true },
+        athens: { name: 'Athens', country: 'greece', has_garage: true },
+        // Non-garage city
+        small_town: { name: 'Small Town', country: 'germany' },
+      },
+      countries: {
+        germany: { name: 'Germany' },
+        france: { name: 'France' },
+        portugal: { name: 'Portugal' },
+        greece: { name: 'Greece' },
+      },
+      companies: {
+        logistics_co: { name: 'Logistics Co', cargo_out: ['electronics', 'olives', 'yacht'], cargo_in: [], cities: ['berlin', 'paris', 'lisboa', 'athens'] },
+      },
+      cargo: {
+        electronics: { name: 'Electronics', value: 2.5, volume: 1, mass: 500, fragility: 0, fragile: false, high_value: false, adr_class: 0, prob_coef: 1, body_types: ['dryvan'], groups: [], excluded: false },
+        olives: { name: 'Olives', value: 1.8, volume: 1, mass: 400, fragility: 0, fragile: false, high_value: false, adr_class: 0, prob_coef: 1, body_types: ['reefer'], groups: [], excluded: false },
+        yacht: { name: 'Yacht', value: 10.0, volume: 1, mass: 2000, fragility: 0, fragile: false, high_value: true, adr_class: 0, prob_coef: 0.5, body_types: ['lowbed'], groups: [], excluded: false },
+      },
+      trailers: {
+        'scs.curtainside.single_3': { name: 'SCS Curtainside', body_type: 'dryvan', volume: 90, chassis_mass: 5000, body_mass: 3000, gross_weight_limit: 40000, length: 13.6, chain_type: 'single', ownable: true },
+        'feldbinder.silo.single_3': { name: 'Feldbinder Silo', body_type: 'silo', volume: 60, chassis_mass: 4500, body_mass: 2500, gross_weight_limit: 40000, length: 12, chain_type: 'single', ownable: true },
+        'krone.box.single_3': { name: 'Krone Box', body_type: 'dryvan', volume: 85, chassis_mass: 5000, body_mass: 3000, gross_weight_limit: 40000, length: 13.6, chain_type: 'single', ownable: true },
+        'scs.lowbed.single_3': { name: 'SCS Lowbed', body_type: 'lowbed', volume: 40, chassis_mass: 6000, body_mass: 4000, gross_weight_limit: 60000, length: 15, chain_type: 'single', ownable: true },
+      },
+      city_companies: {
+        berlin: { logistics_co: 2 },
+        paris: { logistics_co: 1 },
+        lisboa: { logistics_co: 1 },
+        athens: { logistics_co: 1 },
+      },
+      company_cargo: {
+        logistics_co: ['electronics', 'olives', 'yacht'],
+      },
+      cargo_trailers: {
+        electronics: ['scs.curtainside.single_3', 'krone.box.single_3'],
+        olives: ['scs.curtainside.single_3'],
+        yacht: ['scs.lowbed.single_3'],
+      },
+      cargo_trailer_units: {
+        electronics: { 'scs.curtainside.single_3': 90, 'krone.box.single_3': 85 },
+        olives: { 'scs.curtainside.single_3': 90 },
+        yacht: { 'scs.lowbed.single_3': 1 },
+      },
+      economy: { fixed_revenue: 0, revenue_coef_per_km: 1, cargo_market_revenue_coef_per_km: 1 },
+      trucks: [],
+    },
+    observations: null,
+    cities: [
+      { id: 'berlin', name: 'Berlin', country: 'germany', hasGarage: true },
+      { id: 'paris', name: 'Paris', country: 'france', hasGarage: true },
+      { id: 'lisboa', name: 'Lisboa', country: 'portugal', hasGarage: true },
+      { id: 'athens', name: 'Athens', country: 'greece', hasGarage: true },
+      { id: 'small_town', name: 'Small Town', country: 'germany', hasGarage: false },
+    ],
+    companies: [{ id: 'logistics_co', name: 'Logistics Co' }],
+    cargo: [
+      { id: 'electronics', name: 'Electronics', value: 2.5, volume: 1, mass: 500, fragility: 0, fragile: false, high_value: false, adr_class: 0, prob_coef: 1, body_types: ['dryvan'], groups: [], excluded: false },
+      { id: 'olives', name: 'Olives', value: 1.8, volume: 1, mass: 400, fragility: 0, fragile: false, high_value: false, adr_class: 0, prob_coef: 1, body_types: ['reefer'], groups: [], excluded: false },
+      { id: 'yacht', name: 'Yacht', value: 10.0, volume: 1, mass: 2000, fragility: 0, fragile: false, high_value: true, adr_class: 0, prob_coef: 0.5, body_types: ['lowbed'], groups: [], excluded: false },
+    ],
+    trailers: [
+      { id: 'scs.curtainside.single_3', name: 'SCS Curtainside', body_type: 'dryvan', volume: 90, chassis_mass: 5000, body_mass: 3000, gross_weight_limit: 40000, length: 13.6, chain_type: 'single', ownable: true },
+      { id: 'feldbinder.silo.single_3', name: 'Feldbinder Silo', body_type: 'silo', volume: 60, chassis_mass: 4500, body_mass: 2500, gross_weight_limit: 40000, length: 12, chain_type: 'single', ownable: true },
+      { id: 'krone.box.single_3', name: 'Krone Box', body_type: 'dryvan', volume: 85, chassis_mass: 5000, body_mass: 3000, gross_weight_limit: 40000, length: 13.6, chain_type: 'single', ownable: true },
+      { id: 'scs.lowbed.single_3', name: 'SCS Lowbed', body_type: 'lowbed', volume: 40, chassis_mass: 6000, body_mass: 4000, gross_weight_limit: 60000, length: 15, chain_type: 'single', ownable: true },
+    ],
+  };
+}
+
+describe('applyDLCFilter', () => {
+  describe('trailer brand filtering', () => {
+    it('keeps all trailers when all DLCs owned', () => {
+      const data = createDLCTestData();
+      const filtered = applyDLCFilter(data, ['feldbinder', 'krone']);
+
+      expect(filtered.trailers).toHaveLength(4);
+      const ids = filtered.trailers.map((t) => t.id);
+      expect(ids).toContain('scs.curtainside.single_3');
+      expect(ids).toContain('feldbinder.silo.single_3');
+      expect(ids).toContain('krone.box.single_3');
+      expect(ids).toContain('scs.lowbed.single_3');
+    });
+
+    it('removes feldbinder trailers when feldbinder DLC not owned', () => {
+      const data = createDLCTestData();
+      const filtered = applyDLCFilter(data, ['krone']); // no feldbinder
+
+      const ids = filtered.trailers.map((t) => t.id);
+      expect(ids).not.toContain('feldbinder.silo.single_3');
+      expect(ids).toContain('scs.curtainside.single_3');
+      expect(ids).toContain('krone.box.single_3');
+      expect(ids).toContain('scs.lowbed.single_3');
+    });
+
+    it('removes krone trailers when krone DLC not owned', () => {
+      const data = createDLCTestData();
+      const filtered = applyDLCFilter(data, ['feldbinder']); // no krone
+
+      const ids = filtered.trailers.map((t) => t.id);
+      expect(ids).not.toContain('krone.box.single_3');
+      expect(ids).toContain('feldbinder.silo.single_3');
+    });
+
+    it('always keeps scs (base game) trailers', () => {
+      const data = createDLCTestData();
+      const filtered = applyDLCFilter(data, []); // no DLCs owned
+
+      const ids = filtered.trailers.map((t) => t.id);
+      expect(ids).toContain('scs.curtainside.single_3');
+      expect(ids).toContain('scs.lowbed.single_3');
+      expect(ids).not.toContain('feldbinder.silo.single_3');
+      expect(ids).not.toContain('krone.box.single_3');
+    });
+
+    it('filters gameDefs.trailers in sync with top-level trailers array', () => {
+      const data = createDLCTestData();
+      const filtered = applyDLCFilter(data, []); // no DLCs
+
+      const gameDefTrailerIds = Object.keys(filtered.gameDefs!.trailers);
+      expect(gameDefTrailerIds).toContain('scs.curtainside.single_3');
+      expect(gameDefTrailerIds).toContain('scs.lowbed.single_3');
+      expect(gameDefTrailerIds).not.toContain('feldbinder.silo.single_3');
+      expect(gameDefTrailerIds).not.toContain('krone.box.single_3');
+    });
+
+    it('filters cargo_trailers to remove blocked trailer IDs', () => {
+      const data = createDLCTestData();
+      const filtered = applyDLCFilter(data, []); // no DLCs
+
+      // electronics had both scs.curtainside and krone.box -- only scs remains
+      const electronicsTrailers = filtered.gameDefs!.cargo_trailers['electronics'];
+      expect(electronicsTrailers).toContain('scs.curtainside.single_3');
+      expect(electronicsTrailers).not.toContain('krone.box.single_3');
+    });
+
+    it('filters cargo_trailer_units to remove blocked trailer IDs', () => {
+      const data = createDLCTestData();
+      const filtered = applyDLCFilter(data, []); // no DLCs
+
+      const electronicsUnits = filtered.gameDefs!.cargo_trailer_units['electronics'];
+      expect(electronicsUnits['scs.curtainside.single_3']).toBe(90);
+      expect(electronicsUnits['krone.box.single_3']).toBeUndefined();
+    });
+  });
+
+  describe('cargo pack filtering', () => {
+    it('keeps all cargo when no cargo DLC filtering applied', () => {
+      const data = createDLCTestData();
+      const filtered = applyDLCFilter(data, []);
+
+      expect(filtered.cargo).toHaveLength(3);
+    });
+
+    it('removes cargo from unowned cargo packs', () => {
+      const data = createDLCTestData();
+      const cargoDLCMap: Record<string, string> = {
+        yacht: 'high_power',
+      };
+      const ownedCargoDLCs = new Set<string>([]); // don't own high_power
+
+      const filtered = applyDLCFilter(data, [], ownedCargoDLCs, cargoDLCMap);
+
+      const cargoIds = filtered.cargo.map((c) => c.id);
+      expect(cargoIds).not.toContain('yacht');
+      expect(cargoIds).toContain('electronics');
+      expect(cargoIds).toContain('olives');
+    });
+
+    it('keeps cargo from owned cargo packs', () => {
+      const data = createDLCTestData();
+      const cargoDLCMap: Record<string, string> = {
+        yacht: 'high_power',
+      };
+      const ownedCargoDLCs = new Set(['high_power']);
+
+      const filtered = applyDLCFilter(data, [], ownedCargoDLCs, cargoDLCMap);
+
+      const cargoIds = filtered.cargo.map((c) => c.id);
+      expect(cargoIds).toContain('yacht');
+    });
+
+    it('keeps cargo not associated with any DLC pack', () => {
+      const data = createDLCTestData();
+      const cargoDLCMap: Record<string, string> = {
+        yacht: 'high_power',
+      };
+      const ownedCargoDLCs = new Set<string>([]);
+
+      const filtered = applyDLCFilter(data, [], ownedCargoDLCs, cargoDLCMap);
+
+      // electronics and olives have no DLC association
+      const cargoIds = filtered.cargo.map((c) => c.id);
+      expect(cargoIds).toContain('electronics');
+      expect(cargoIds).toContain('olives');
+    });
+
+    it('removes cargo from gameDefs when cargo DLC not owned', () => {
+      const data = createDLCTestData();
+      const cargoDLCMap: Record<string, string> = { yacht: 'high_power' };
+      const ownedCargoDLCs = new Set<string>([]);
+
+      const filtered = applyDLCFilter(data, [], ownedCargoDLCs, cargoDLCMap);
+
+      expect(filtered.gameDefs!.cargo['yacht']).toBeUndefined();
+      expect(filtered.gameDefs!.cargo['electronics']).toBeDefined();
+    });
+
+    it('removes cargo from company_cargo when DLC not owned', () => {
+      const data = createDLCTestData();
+      const cargoDLCMap: Record<string, string> = { yacht: 'high_power' };
+      const ownedCargoDLCs = new Set<string>([]);
+
+      const filtered = applyDLCFilter(data, [], ownedCargoDLCs, cargoDLCMap);
+
+      const companyCargo = filtered.gameDefs!.company_cargo['logistics_co'];
+      expect(companyCargo).not.toContain('yacht');
+      expect(companyCargo).toContain('electronics');
+    });
+
+    it('removes cargo_trailers entries for blocked cargo', () => {
+      const data = createDLCTestData();
+      const cargoDLCMap: Record<string, string> = { yacht: 'high_power' };
+      const ownedCargoDLCs = new Set<string>([]);
+
+      const filtered = applyDLCFilter(data, [], ownedCargoDLCs, cargoDLCMap);
+
+      expect(filtered.gameDefs!.cargo_trailers['yacht']).toBeUndefined();
+      expect(filtered.gameDefs!.cargo_trailer_units['yacht']).toBeUndefined();
+    });
+  });
+
+  describe('map DLC city blocking', () => {
+    it('removes blocked cities from the result', () => {
+      const data = createDLCTestData();
+      const blockedCities = new Set(['athens', 'lisboa']);
+
+      const filtered = applyDLCFilter(data, [], undefined, undefined, blockedCities);
+
+      const cityIds = filtered.cities.map((c) => c.id);
+      expect(cityIds).not.toContain('athens');
+      expect(cityIds).not.toContain('lisboa');
+      expect(cityIds).toContain('berlin');
+      expect(cityIds).toContain('paris');
+    });
+
+    it('removes blocked cities from gameDefs.city_companies', () => {
+      const data = createDLCTestData();
+      const blockedCities = new Set(['athens']);
+
+      const filtered = applyDLCFilter(data, [], undefined, undefined, blockedCities);
+
+      expect(filtered.gameDefs!.city_companies['athens']).toBeUndefined();
+      expect(filtered.gameDefs!.city_companies['berlin']).toBeDefined();
+    });
+
+    it('removes blocked cities from gameDefs.cities', () => {
+      const data = createDLCTestData();
+      const blockedCities = new Set(['lisboa']);
+
+      const filtered = applyDLCFilter(data, [], undefined, undefined, blockedCities);
+
+      expect(filtered.gameDefs!.cities['lisboa']).toBeUndefined();
+      expect(filtered.gameDefs!.cities['berlin']).toBeDefined();
+    });
+  });
+
+  describe('garage-only filtering', () => {
+    it('removes non-garage cities from the result', () => {
+      const data = createDLCTestData();
+      const filtered = applyDLCFilter(data, []);
+
+      const cityIds = filtered.cities.map((c) => c.id);
+      // small_town has hasGarage=false in data.cities, should be filtered
+      expect(cityIds).not.toContain('small_town');
+      expect(cityIds).toContain('berlin');
+    });
+
+    it('removes non-garage cities from gameDefs.city_companies', () => {
+      const data = createDLCTestData();
+      // Add small_town to city_companies in gameDefs
+      data.gameDefs!.city_companies['small_town'] = { logistics_co: 1 };
+
+      const filtered = applyDLCFilter(data, []);
+
+      // small_town has no has_garage in gameDefs, and isn't in GARAGE_CITIES either
+      // (it may or may not be in GARAGE_CITIES depending on the real data,
+      //  but since it's a made-up city, it won't be)
+      expect(filtered.gameDefs!.city_companies['berlin']).toBeDefined();
+    });
+  });
+
+  describe('combined effects', () => {
+    it('applies trailer + cargo + city filters simultaneously', () => {
+      const data = createDLCTestData();
+      const cargoDLCMap: Record<string, string> = { yacht: 'high_power' };
+      const ownedCargoDLCs = new Set<string>([]); // no cargo DLCs
+      const blockedCities = new Set(['athens']);
+
+      const filtered = applyDLCFilter(
+        data, [], // no trailer DLCs
+        ownedCargoDLCs, cargoDLCMap, blockedCities,
+      );
+
+      // Trailers: only SCS trailers remain
+      const trailerIds = filtered.trailers.map((t) => t.id);
+      expect(trailerIds).toEqual(expect.arrayContaining([
+        'scs.curtainside.single_3', 'scs.lowbed.single_3',
+      ]));
+      expect(trailerIds).not.toContain('feldbinder.silo.single_3');
+      expect(trailerIds).not.toContain('krone.box.single_3');
+
+      // Cargo: yacht removed (high_power DLC not owned)
+      const cargoIds = filtered.cargo.map((c) => c.id);
+      expect(cargoIds).not.toContain('yacht');
+      expect(cargoIds).toContain('electronics');
+      expect(cargoIds).toContain('olives');
+
+      // Cities: athens removed (blocked), small_town removed (no garage)
+      const cityIds = filtered.cities.map((c) => c.id);
+      expect(cityIds).not.toContain('athens');
+      expect(cityIds).not.toContain('small_town');
+      expect(cityIds).toContain('berlin');
+      expect(cityIds).toContain('paris');
+      expect(cityIds).toContain('lisboa');
+    });
+
+    it('preserves original data (immutability check)', () => {
+      const data = createDLCTestData();
+      const originalTrailerCount = data.trailers.length;
+      const originalCargoCount = data.cargo.length;
+      const originalCityCount = data.cities.length;
+
+      applyDLCFilter(data, [], new Set<string>(), { yacht: 'high_power' }, new Set(['athens']));
+
+      expect(data.trailers).toHaveLength(originalTrailerCount);
+      expect(data.cargo).toHaveLength(originalCargoCount);
+      expect(data.cities).toHaveLength(originalCityCount);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('handles data with no gameDefs (observations only)', () => {
+      const data = createDLCTestData();
+      data.gameDefs = null;
+
+      const filtered = applyDLCFilter(data, []);
+
+      // Should still filter top-level trailers
+      const ids = filtered.trailers.map((t) => t.id);
+      expect(ids).toContain('scs.curtainside.single_3');
+      expect(ids).not.toContain('feldbinder.silo.single_3');
+      expect(filtered.gameDefs).toBeNull();
+    });
+
+    it('handles empty owned trailer DLCs list', () => {
+      const data = createDLCTestData();
+      const filtered = applyDLCFilter(data, []);
+
+      expect(filtered.trailers.length).toBeLessThan(data.trailers.length);
+      // Only SCS trailers remain
+      for (const t of filtered.trailers) {
+        expect(t.id.startsWith('scs.')).toBe(true);
+      }
+    });
+  });
+});
+
+describe('getBlockedCities', () => {
+  it('returns empty set when all map DLCs owned', () => {
+    const cityDLCMap = {
+      iberia: ['lisboa', 'madrid'],
+      greece: ['athens'],
+    };
+    const blocked = getBlockedCities(['iberia', 'greece'], cityDLCMap);
+    expect(blocked.size).toBe(0);
+  });
+
+  it('blocks cities from unowned map DLCs', () => {
+    const cityDLCMap = {
+      iberia: ['lisboa', 'madrid'],
+      greece: ['athens', 'thessaloniki'],
+    };
+    const blocked = getBlockedCities(['iberia'], cityDLCMap); // no greece
+
+    expect(blocked.has('athens')).toBe(true);
+    expect(blocked.has('thessaloniki')).toBe(true);
+    expect(blocked.has('lisboa')).toBe(false);
+    expect(blocked.has('madrid')).toBe(false);
+  });
+
+  it('blocks all cities when no map DLCs owned', () => {
+    const cityDLCMap = {
+      iberia: ['lisboa'],
+      greece: ['athens'],
+    };
+    const blocked = getBlockedCities([], cityDLCMap);
+
+    expect(blocked.has('lisboa')).toBe(true);
+    expect(blocked.has('athens')).toBe(true);
+  });
+
+  it('handles empty city DLC map', () => {
+    const blocked = getBlockedCities(['iberia'], {});
+    expect(blocked.size).toBe(0);
+  });
+});

--- a/src/frontend/__tests__/optimizer.test.ts
+++ b/src/frontend/__tests__/optimizer.test.ts
@@ -3,6 +3,9 @@ import { buildLookups, type AllData } from '../data.ts';
 import {
   calculateCityRankings,
   computeOptimalFleet,
+  analyticalFirstPickEV,
+  buildCityDepotProfiles,
+  type CityDepotData,
 } from '../optimizer.ts';
 
 describe('optimizer', () => {
@@ -211,6 +214,198 @@ describe('optimizer', () => {
         for (let i = 0; i < rank.topTrailers.length - 1; i++) {
           expect(rank.topTrailers[i].cityValue).toBeGreaterThanOrEqual(rank.topTrailers[i + 1].cityValue);
         }
+      }
+    });
+  });
+
+  describe('analyticalFirstPickEV', () => {
+    it('returns 0 for body type with no compatible cargo', () => {
+      // Single depot with one cargo that has no HV for "nonexistent" body type
+      const depots: CityDepotData[] = [{
+        companyId: 'test',
+        cargo: [{ cargoId: 'electronics', probCoef: 1, bodyHV: { dryvan: 225 } }],
+        totalProbCoef: 1,
+        cumProbs: [1],
+      }];
+
+      expect(analyticalFirstPickEV(depots, 'nonexistent')).toBe(0);
+    });
+
+    it('returns exact HV when single depot has single cargo (deterministic)', () => {
+      // One depot, one cargo, one body type => P(max = HV) = 1
+      // All 3 jobs will be the same cargo, so max = HV = 225
+      const depots: CityDepotData[] = [{
+        companyId: 'test',
+        cargo: [{ cargoId: 'electronics', probCoef: 1, bodyHV: { dryvan: 225 } }],
+        totalProbCoef: 1,
+        cumProbs: [1],
+      }];
+
+      const ev = analyticalFirstPickEV(depots, 'dryvan');
+      expect(ev).toBeCloseTo(225, 5);
+    });
+
+    it('returns weighted EV for single depot with two cargo items', () => {
+      // Depot with 2 cargo: electronics (prob=1, HV=225) and machinery (prob=1, HV=3)
+      // 3 draws per depot. E[max of 3] should be > simple expected value
+      const depots: CityDepotData[] = [{
+        companyId: 'test',
+        cargo: [
+          { cargoId: 'electronics', probCoef: 1, bodyHV: { dryvan: 225 } },
+          { cargoId: 'machinery', probCoef: 1, bodyHV: { dryvan: 3 } },
+        ],
+        totalProbCoef: 2,
+        cumProbs: [0.5, 1],
+      }];
+
+      const ev = analyticalFirstPickEV(depots, 'dryvan');
+
+      // P(electronics) = 0.5, P(machinery) = 0.5
+      // P(max <= 3) = P(all 3 draws are machinery) = 0.5^3 = 0.125
+      // P(max = 3) = P(max<=3) - P(max<=0) = 0.125 - 0 = 0.125
+      // P(max = 225) = 1 - 0.125 = 0.875
+      // E[max] = 3 * 0.125 + 225 * 0.875 = 0.375 + 196.875 = 197.25
+      expect(ev).toBeCloseTo(197.25, 5);
+    });
+
+    it('increases EV with more depots (more draws)', () => {
+      // Same cargo profile at 1 depot vs 2 depot instances
+      const singleDepot: CityDepotData[] = [{
+        companyId: 'test',
+        cargo: [
+          { cargoId: 'electronics', probCoef: 1, bodyHV: { dryvan: 225 } },
+          { cargoId: 'machinery', probCoef: 1, bodyHV: { dryvan: 3 } },
+        ],
+        totalProbCoef: 2,
+        cumProbs: [0.5, 1],
+      }];
+
+      const twoDepots: CityDepotData[] = [
+        ...singleDepot,
+        { ...singleDepot[0] }, // duplicate depot instance
+      ];
+
+      const ev1 = analyticalFirstPickEV(singleDepot, 'dryvan');
+      const ev2 = analyticalFirstPickEV(twoDepots, 'dryvan');
+
+      // More depots = more draws = higher E[max]
+      expect(ev2).toBeGreaterThan(ev1);
+    });
+
+    it('respects prob_coef weighting (rare cargo less likely to appear)', () => {
+      // High-value cargo with very low prob_coef vs normal cargo
+      const depots: CityDepotData[] = [{
+        companyId: 'test',
+        cargo: [
+          { cargoId: 'rare', probCoef: 0.1, bodyHV: { dryvan: 1000 } },
+          { cargoId: 'common', probCoef: 2.0, bodyHV: { dryvan: 100 } },
+        ],
+        totalProbCoef: 2.1,
+        cumProbs: [0.1 / 2.1, 1],
+      }];
+
+      const ev = analyticalFirstPickEV(depots, 'dryvan');
+
+      // P(rare) = 0.1/2.1 ~= 0.0476, P(common) = 2.0/2.1 ~= 0.9524
+      // P(max <= 100) = P(all draws are common or zero) = (2.0/2.1)^3
+      // Since all cargo has HV > 0, P(max <= 100) = (2.0/2.1)^3 ~= 0.864
+      // P(max = 1000) = 1 - 0.864 ~= 0.136
+      // E[max] ~= 100 * 0.864 + 1000 * 0.136 ~= 86.4 + 136.2 ~= 222.6
+      // EV should be between 100 and 1000, much closer to 100 because rare is rare
+      expect(ev).toBeGreaterThan(100);
+      expect(ev).toBeLessThan(1000);
+    });
+
+    it('can be computed via buildCityDepotProfiles from real mock data', () => {
+      // Integration test: build depot profiles from the standard mock data
+      // and verify analyticalFirstPickEV produces reasonable results
+      const data = createMockData();
+      const lookups = buildLookups(data);
+      const depots = buildCityDepotProfiles('berlin', lookups);
+
+      expect(depots).not.toBeNull();
+
+      // Berlin has 3 logistics_co + 2 transport_inc depots
+      // Test each body type that has cargo
+      const dryvanEV = analyticalFirstPickEV(depots!, 'dryvan');
+      const flatbedEV = analyticalFirstPickEV(depots!, 'flatbed');
+      const tankerEV = analyticalFirstPickEV(depots!, 'tanker');
+
+      // All should be positive
+      expect(dryvanEV).toBeGreaterThan(0);
+      expect(flatbedEV).toBeGreaterThan(0);
+      expect(tankerEV).toBeGreaterThan(0);
+
+      // Dryvan handles electronics (HV=225) and furniture (HV=135),
+      // so its EV should be > tanker which handles only chemicals (HV=166.4)
+      // with lower units but fragile bonus
+      expect(dryvanEV).toBeGreaterThan(tankerEV);
+    });
+
+    it('returns consistent results with calculateCityRankings', () => {
+      // The ranking score for a city is the sum of top 5 body type EVs
+      // from analyticalFirstPickEV. Verify they agree.
+      const data = createMockData();
+      const lookups = buildLookups(data);
+      const rankings = calculateCityRankings(data, lookups);
+      const depots = buildCityDepotProfiles('paris', lookups);
+
+      expect(depots).not.toBeNull();
+      const paris = rankings.find((r) => r.id === 'paris');
+      expect(paris).toBeDefined();
+
+      // Paris should have a positive score
+      expect(paris!.score).toBeGreaterThan(0);
+
+      // Compute EV for each body type manually and verify sum matches score
+      // (minus dominated body types, which we can't easily replicate here)
+      // At minimum, the top trailer's cityValue should match analyticalFirstPickEV
+      const topBT = paris!.topTrailers[0].bodyType;
+      const topEV = analyticalFirstPickEV(depots!, topBT);
+      expect(paris!.topTrailers[0].cityValue).toBeCloseTo(topEV, 2);
+    });
+  });
+
+  describe('buildCityDepotProfiles', () => {
+    it('returns null for city with no companies', () => {
+      const data = createMockData();
+      const lookups = buildLookups(data);
+      expect(buildCityDepotProfiles('empty_city', lookups)).toBeNull();
+    });
+
+    it('creates correct number of depot instances from depot counts', () => {
+      const data = createMockData();
+      const lookups = buildLookups(data);
+      const depots = buildCityDepotProfiles('berlin', lookups);
+
+      expect(depots).not.toBeNull();
+      // Berlin: logistics_co × 3 + transport_inc × 2 = 5 depot instances
+      expect(depots!.length).toBe(5);
+    });
+
+    it('excludes excluded cargo from depot profiles', () => {
+      const data = createMockData();
+      const lookups = buildLookups(data);
+      const depots = buildCityDepotProfiles('berlin', lookups);
+
+      // None of the depot entries should contain excluded_cargo
+      for (const depot of depots!) {
+        const cargoIds = depot.cargo.map((c) => c.cargoId);
+        expect(cargoIds).not.toContain('excluded_cargo');
+      }
+    });
+
+    it('builds correct CDF for sampling', () => {
+      const data = createMockData();
+      const lookups = buildLookups(data);
+      const depots = buildCityDepotProfiles('berlin', lookups);
+
+      for (const depot of depots!) {
+        // CDF should be monotonically increasing and end at 1
+        for (let i = 1; i < depot.cumProbs.length; i++) {
+          expect(depot.cumProbs[i]).toBeGreaterThan(depot.cumProbs[i - 1]);
+        }
+        expect(depot.cumProbs[depot.cumProbs.length - 1]).toBeCloseTo(1, 10);
       }
     });
   });

--- a/src/frontend/__tests__/utils.test.ts
+++ b/src/frontend/__tests__/utils.test.ts
@@ -1,0 +1,295 @@
+import { describe, it, expect } from 'vitest';
+import { normalize, titleCase, trailerTotalHV, formatTrailerSpec } from '../utils';
+import type { Trailer, Lookups, Cargo } from '../types';
+
+describe('normalize', () => {
+  it('converts to lowercase', () => {
+    expect(normalize('Berlin')).toBe('berlin');
+    expect(normalize('PARIS')).toBe('paris');
+  });
+
+  it('removes diacritics from accented characters', () => {
+    expect(normalize('Córdoba')).toBe('cordoba');
+    expect(normalize('Zürich')).toBe('zurich');
+    expect(normalize('Malmö')).toBe('malmo');
+    expect(normalize('Kraków')).toBe('krakow');
+  });
+
+  it('handles combined diacritics', () => {
+    expect(normalize('Kögel')).toBe('kogel');
+    expect(normalize('Schwarzmüller')).toBe('schwarzmuller');
+  });
+
+  it('handles strings with no diacritics', () => {
+    expect(normalize('london')).toBe('london');
+    expect(normalize('Berlin')).toBe('berlin');
+  });
+
+  it('handles empty string', () => {
+    expect(normalize('')).toBe('');
+  });
+
+  it('preserves non-letter characters', () => {
+    expect(normalize('A Coruña')).toBe('a coruna');
+    expect(normalize('Cluj-Napoca')).toBe('cluj-napoca');
+  });
+
+  it('handles Unicode characters beyond basic Latin', () => {
+    // Turkish İ (capital I with dot above) -> NFD strips the dot -> 'istanbul'
+    expect(normalize('İstanbul')).toBe('istanbul');
+    expect(normalize('Šiauliai')).toBe('siauliai');
+  });
+});
+
+describe('titleCase', () => {
+  it('converts simple game ID to title case', () => {
+    expect(titleCase('electronics')).toBe('Electronics');
+  });
+
+  it('handles underscore-separated words', () => {
+    expect(titleCase('high_value_cargo')).toBe('High Value Cargo');
+    expect(titleCase('excluded_cargo')).toBe('Excluded Cargo');
+  });
+
+  it('handles single character words', () => {
+    expect(titleCase('apples_c')).toBe('Apples C');
+  });
+
+  it('handles already capitalized input', () => {
+    expect(titleCase('Berlin')).toBe('Berlin');
+  });
+
+  it('handles single word', () => {
+    expect(titleCase('machinery')).toBe('Machinery');
+  });
+
+  it('handles empty string', () => {
+    expect(titleCase('')).toBe('');
+  });
+});
+
+describe('trailerTotalHV', () => {
+  function makeTrailer(overrides: Partial<Trailer> = {}): Trailer {
+    return {
+      id: 'scs.curtainside.single_3',
+      name: 'Curtainside',
+      body_type: 'curtainside',
+      volume: 90,
+      chassis_mass: 5000,
+      body_mass: 3000,
+      gross_weight_limit: 40000,
+      length: 13.6,
+      chain_type: 'single',
+      ownable: true,
+      ...overrides,
+    };
+  }
+
+  function makeCargo(overrides: Partial<Cargo> = {}): Cargo {
+    return {
+      id: 'electronics',
+      name: 'Electronics',
+      value: 2.5,
+      volume: 1,
+      mass: 500,
+      fragility: 0,
+      fragile: false,
+      high_value: false,
+      adr_class: 0,
+      prob_coef: 1,
+      body_types: ['curtainside'],
+      groups: [],
+      excluded: false,
+      ...overrides,
+    };
+  }
+
+  function makeLookups(
+    trailerCargo: [string, Set<string>][],
+    cargoEntries: Cargo[],
+    units: [string, number][] = [],
+  ): Lookups {
+    return {
+      citiesById: new Map(),
+      companiesById: new Map(),
+      cargoById: new Map(cargoEntries.map((c) => [c.id, c])),
+      trailersById: new Map(),
+      cityCompanyMap: new Map(),
+      companyCargoMap: new Map(),
+      trailerCargoMap: new Map(trailerCargo),
+      cargoTrailerMap: new Map(),
+      cargoTrailerUnits: new Map(units),
+    };
+  }
+
+  it('returns 0 for trailer with no compatible cargo', () => {
+    const trailer = makeTrailer();
+    const lookups = makeLookups([], []);
+    expect(trailerTotalHV(trailer, lookups)).toBe(0);
+  });
+
+  it('calculates total haul value for single cargo', () => {
+    const trailer = makeTrailer();
+    const cargo = makeCargo({ value: 2.5 });
+    const lookups = makeLookups(
+      [['scs.curtainside.single_3', new Set(['electronics'])]],
+      [cargo],
+      [['electronics:scs.curtainside.single_3', 90]],
+    );
+
+    // value * bonus * units = 2.5 * 1.0 * 90 = 225
+    expect(trailerTotalHV(trailer, lookups)).toBe(225);
+  });
+
+  it('applies fragile bonus (+30%)', () => {
+    const trailer = makeTrailer();
+    const cargo = makeCargo({ value: 2.0, fragile: true });
+    const lookups = makeLookups(
+      [['scs.curtainside.single_3', new Set(['electronics'])]],
+      [cargo],
+      [['electronics:scs.curtainside.single_3', 10]],
+    );
+
+    // value * bonus * units = 2.0 * 1.3 * 10 = 26
+    expect(trailerTotalHV(trailer, lookups)).toBeCloseTo(26);
+  });
+
+  it('applies high_value bonus (+30%)', () => {
+    const trailer = makeTrailer();
+    const cargo = makeCargo({ value: 5.0, high_value: true });
+    const lookups = makeLookups(
+      [['scs.curtainside.single_3', new Set(['electronics'])]],
+      [cargo],
+      [['electronics:scs.curtainside.single_3', 10]],
+    );
+
+    // value * bonus * units = 5.0 * 1.3 * 10 = 65
+    expect(trailerTotalHV(trailer, lookups)).toBeCloseTo(65);
+  });
+
+  it('stacks fragile + high_value bonuses (+60%)', () => {
+    const trailer = makeTrailer();
+    const cargo = makeCargo({ value: 4.0, fragile: true, high_value: true });
+    const lookups = makeLookups(
+      [['scs.curtainside.single_3', new Set(['electronics'])]],
+      [cargo],
+      [['electronics:scs.curtainside.single_3', 10]],
+    );
+
+    // value * bonus * units = 4.0 * 1.6 * 10 = 64
+    expect(trailerTotalHV(trailer, lookups)).toBeCloseTo(64);
+  });
+
+  it('sums across multiple compatible cargoes', () => {
+    const trailer = makeTrailer();
+    const cargo1 = makeCargo({ id: 'electronics', value: 2.5 });
+    const cargo2 = makeCargo({ id: 'glass', name: 'Glass', value: 1.0 });
+    const lookups = makeLookups(
+      [['scs.curtainside.single_3', new Set(['electronics', 'glass'])]],
+      [cargo1, cargo2],
+      [
+        ['electronics:scs.curtainside.single_3', 90],
+        ['glass:scs.curtainside.single_3', 45],
+      ],
+    );
+
+    // (2.5 * 1 * 90) + (1.0 * 1 * 45) = 225 + 45 = 270
+    expect(trailerTotalHV(trailer, lookups)).toBe(270);
+  });
+
+  it('skips excluded cargo', () => {
+    const trailer = makeTrailer();
+    const cargo1 = makeCargo({ id: 'electronics', value: 2.5 });
+    const cargo2 = makeCargo({ id: 'excluded_thing', name: 'Excluded', value: 100.0, excluded: true });
+    const lookups = makeLookups(
+      [['scs.curtainside.single_3', new Set(['electronics', 'excluded_thing'])]],
+      [cargo1, cargo2],
+      [
+        ['electronics:scs.curtainside.single_3', 90],
+        ['excluded_thing:scs.curtainside.single_3', 90],
+      ],
+    );
+
+    // Only electronics counts: 2.5 * 1 * 90 = 225
+    expect(trailerTotalHV(trailer, lookups)).toBe(225);
+  });
+
+  it('defaults to 1 unit when no cargo_trailer_units entry', () => {
+    const trailer = makeTrailer();
+    const cargo = makeCargo({ value: 3.0 });
+    const lookups = makeLookups(
+      [['scs.curtainside.single_3', new Set(['electronics'])]],
+      [cargo],
+      [], // no units entries
+    );
+
+    // value * bonus * units = 3.0 * 1.0 * 1 = 3
+    expect(trailerTotalHV(trailer, lookups)).toBe(3);
+  });
+});
+
+describe('formatTrailerSpec', () => {
+  function makeTrailer(overrides: Partial<Trailer> = {}): Trailer {
+    return {
+      id: 'scs.curtainside.single_3',
+      name: 'SCS Curtainside',
+      body_type: 'curtainside',
+      volume: 90,
+      chassis_mass: 5000,
+      body_mass: 3000,
+      gross_weight_limit: 40000,
+      length: 13.6,
+      chain_type: 'single',
+      ownable: true,
+      ...overrides,
+    };
+  }
+
+  it('formats basic SCS single trailer', () => {
+    const spec = formatTrailerSpec(makeTrailer());
+    // Brand "Scs", 3-axle, 40t, 13.6m
+    expect(spec).toBe('Scs 3-axle 40t 13.6m');
+  });
+
+  it('capitalizes brand from trailer ID prefix', () => {
+    const spec = formatTrailerSpec(makeTrailer({ id: 'krone.box.single_3' }));
+    expect(spec).toContain('Krone');
+  });
+
+  it('includes chain type label for doubles', () => {
+    const spec = formatTrailerSpec(makeTrailer({
+      id: 'scs.curtainside.double_3_2',
+      chain_type: 'double',
+    }));
+    expect(spec).toContain('Double');
+    expect(spec).toContain('3+2-axle');
+  });
+
+  it('includes HCT label', () => {
+    const spec = formatTrailerSpec(makeTrailer({
+      id: 'scs.curtainside.hct_3_2_3',
+      chain_type: 'hct',
+    }));
+    expect(spec).toContain('HCT');
+    expect(spec).toContain('3+2+3-axle');
+  });
+
+  it('includes B-double label', () => {
+    const spec = formatTrailerSpec(makeTrailer({
+      id: 'scs.curtainside.bdouble_2_2',
+      chain_type: 'b_double',
+    }));
+    expect(spec).toContain('B-double');
+    expect(spec).toContain('2+2-axle');
+  });
+
+  it('formats weight in tonnes', () => {
+    const spec = formatTrailerSpec(makeTrailer({ gross_weight_limit: 60000 }));
+    expect(spec).toContain('60t');
+  });
+
+  it('includes length in meters', () => {
+    const spec = formatTrailerSpec(makeTrailer({ length: 15.0 }));
+    expect(spec).toContain('15m');
+  });
+});

--- a/src/frontend/optimizer.ts
+++ b/src/frontend/optimizer.ts
@@ -95,7 +95,7 @@ interface DepotCargoItem {
 }
 
 /** A depot instance with its cargo profile and sampling CDF */
-interface CityDepotData {
+export interface CityDepotData {
   companyId: string;
   cargo: DepotCargoItem[];
   totalProbCoef: number;
@@ -109,7 +109,7 @@ interface CityDepotData {
  * Each cargo item includes best haul value per body type from ownable trailers
  * available in the city's country (standard + zone variants if country qualifies).
  */
-function buildCityDepotProfiles(cityId: string, lookups: Lookups): CityDepotData[] | null {
+export function buildCityDepotProfiles(cityId: string, lookups: Lookups): CityDepotData[] | null {
   const city = lookups.citiesById.get(cityId);
   const country = city?.country ?? '';
   const cityCompanies = lookups.cityCompanyMap.get(cityId) || [];
@@ -184,7 +184,7 @@ function buildCityDepotProfiles(cityId: string, lookups: Lookups): CityDepotData
  *
  * Then E[max] = Σ_i hv_i × [P(max ≤ hv_i) - P(max ≤ hv_{i-1})]
  */
-function analyticalFirstPickEV(depots: CityDepotData[], bodyType: string): number {
+export function analyticalFirstPickEV(depots: CityDepotData[], bodyType: string): number {
   // Collect all unique HV values across all depots for this body type
   const hvSet = new Set<number>([0]);
   for (const depot of depots) {


### PR DESCRIPTION
## Summary
- Add dlc-filter.test.ts: trailer brand filtering, cargo pack filtering, map DLC city blocking, garage-only filtering, combined effects, edge cases
- Add utils.test.ts: normalize (Unicode/diacritics), titleCase, trailerTotalHV (bonuses, exclusions, units), formatTrailerSpec (brands, chain types, axles)
- Add body-types.test.ts: getBodyTypeProfiles (cargo counts, doubles detection, domination, sorting), getChassisMergeMap (merge detection, survivor selection)
- Expand optimizer.test.ts: analyticalFirstPickEV (deterministic, probabilistic, multi-depot, prob_coef weighting, integration with buildCityDepotProfiles and calculateCityRankings), buildCityDepotProfiles (depot counts, excluded cargo, CDF correctness)
- Export analyticalFirstPickEV, buildCityDepotProfiles, CityDepotData from optimizer.ts for direct testing

Test count: 60 → 126 (+66 new tests)

Closes #127