### PR TITLE
fix: correct mobile rankings column visibility after garage star column shift

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1710,18 +1710,18 @@ tr.owned-garage {
     margin-bottom: 1rem;
   }
 
-  /* Rankings table only: show City, Value, Score on mobile */
-  /* Hide: #(1), Country(3), Depots(4), Jobs(5), €/Job(7) */
+  /* Rankings table only: show City(3), Fleet EV(7), Best Trailers(8) on mobile */
+  /* Hide: Star(1), Rank(2), Country(4), Depots(5), Cargo(6) */
   .table-rankings th:nth-child(1),
   .table-rankings td:nth-child(1),
-  .table-rankings th:nth-child(3),
-  .table-rankings td:nth-child(3),
+  .table-rankings th:nth-child(2),
+  .table-rankings td:nth-child(2),
   .table-rankings th:nth-child(4),
   .table-rankings td:nth-child(4),
   .table-rankings th:nth-child(5),
   .table-rankings td:nth-child(5),
-  .table-rankings th:nth-child(7),
-  .table-rankings td:nth-child(7) {
+  .table-rankings th:nth-child(6),
+  .table-rankings td:nth-child(6) {
     display: none;
   }
 


### PR DESCRIPTION
## Summary
- Fixed CSS `nth-child` selectors in mobile media query for the rankings table that were off-by-one after the garage star column was added as column 1
- Previously hid City (col 3) and Fleet EV (col 7) — the two most important columns on mobile
- Now correctly hides Star (1), Rank (2), Country (4), Depots (5), Cargo (6) and shows City (3), Fleet EV (7), Best Trailers (8)

## Test plan
- [x] `npm run lint` passes
- [x] `npm run test` passes (126 tests)
- [x] Verified in real browser at 375x812 mobile viewport — City, Fleet EV, and Best Trailers columns are visible; Star, Rank, Country, Depots, Cargo columns are hidden

Closes #148