### PR TITLE
fix: resolve accessibility regressions in aria-atomic, contrast, and score tiers

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -963,7 +963,7 @@ tr.clickable:focus td:first-child {
 
 .trailer-spec {
   font-size: 0.75rem;
-  color: #8b95a0;
+  color: #96a0ab;
   margin-top: 0.15rem;
 }
 
@@ -1042,7 +1042,7 @@ tr.scs-fallback-row td {
 }
 
 .score-tier-good {
-  color: #3b82f6;
+  color: #60a5fa;
 }
 
 .score-tier-average {
@@ -1050,7 +1050,14 @@ tr.scs-fallback-row td {
 }
 
 .score-tier-below {
-  color: #9a9a9a;
+  color: #a3a3a3;
+}
+
+.score-tier-label {
+  display: block;
+  font-size: 0.7rem;
+  font-weight: normal;
+  opacity: 0.85;
 }
 
 /* Rank Display */
@@ -1622,7 +1629,7 @@ th.tooltip::before {
   font-size: 1.2rem;
   width: 2rem;
   text-align: center;
-  color: #8b8b8b;
+  color: #9e9e9e;
   user-select: none;
 }
 

--- a/public/index.html
+++ b/public/index.html
@@ -170,7 +170,7 @@
     </div>
 
     <div id="rankings-view">
-      <div id="rankings-content" aria-live="polite" aria-atomic="true">
+      <div id="rankings-content" aria-live="polite" aria-atomic="false">
         <!-- Loading state will be injected here by JavaScript -->
       </div>
     </div>

--- a/src/frontend/main.ts
+++ b/src/frontend/main.ts
@@ -319,7 +319,7 @@ async function renderRankings() {
               <td class="country">${r.country}</td>
               <td>${r.depotCount}</td>
               <td class="amount">${r.cargoTypes}</td>
-              <td class="score ${tier.className}" title="${tier.label}">${formatNumber(r.score)}</td>
+              <td class="score ${tier.className}" title="${tier.label}">${formatNumber(r.score)}${tier.label ? `<span class="score-tier-label">${tier.label.split(' — ')[0]}</span>` : ''}</td>
               <td class="trailer-summary">${trailerSummary}</td>
             </tr>
           `;
@@ -474,7 +474,7 @@ async function renderCity(cityId: string) {
         <div class="stat-label">Rank</div>
       </div>
       <div class="stat">
-        <div class="stat-value ${cityScoreTier.className}" title="${cityScoreTier.label}">${formatNumber(score)}</div>
+        <div class="stat-value ${cityScoreTier.className}" title="${cityScoreTier.label}" aria-label="Score ${formatNumber(score)}, ${cityScoreTier.label || 'unranked'}">${formatNumber(score)}</div>
         <div class="stat-label">Score${cityScoreTier.label ? ` — ${cityScoreTier.label.split(' — ')[0]}` : ''}</div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Fix `aria-atomic="true"` on `rankings-content` div causing full table re-announcement on every search keystroke (changed to `false`)
- Fix WCAG AA color contrast: `.score-tier-good` #3b82f6 → #60a5fa (6.25:1), `.trailer-spec` #8b95a0 → #96a0ab (5.99:1), `.garage-star` #8b8b8b → #9e9e9e (6.37:1), `.score-tier-below` #9a9a9a → #a3a3a3 (6.30:1)
- Add visible score tier text labels in rankings table so tier info is not conveyed only via color/title attribute
- Add `aria-label` to city detail score stat for screen reader accessibility

## Test plan
- [x] `npm run lint` passes
- [x] `npm run test` passes (126 tests)
- [ ] Verify score tier labels appear next to score values in rankings table
- [ ] Verify color contrast meets WCAG AA (4.5:1 minimum) on dark backgrounds

Closes #149