### PR TITLE
refactor: extract shared cargoBonus() and deduplicate sumGarageScores

### DIFF
--- a/src/frontend/companies.ts
+++ b/src/frontend/companies.ts
@@ -4,7 +4,7 @@
  */
 
 import { initPageData } from './page-init';
-import { normalize, type AllData, type Lookups, type City, type Cargo } from './data';
+import { normalize, cargoBonus, type AllData, type Lookups, type City, type Cargo } from './data';
 
 let data: AllData | null = null;
 let lookups: Lookups | null = null;
@@ -49,7 +49,7 @@ function getCompanyCargo(companyId: string): CargoWithSpawn[] {
       const cargo = lookups!.cargoById.get(id);
       if (!cargo) return null;
       const spawnWeight = cargo.prob_coef ?? 1.0;
-      const multiplier = 1 + (cargo.fragile ? 0.3 : 0) + (cargo.high_value ? 0.3 : 0);
+      const multiplier = cargoBonus(cargo);
       const expectedValue = cargo.value * multiplier * spawnWeight;
       return { ...cargo, spawnWeight, expectedValue };
     })

--- a/src/frontend/data.ts
+++ b/src/frontend/data.ts
@@ -48,6 +48,7 @@ export { initPageData, type PageData } from './page-init';
 
 // Utils
 export {
+  cargoBonus,
   normalize, formatTrailerSpec, trailerTotalHV, pickBestTrailer,
   titleCase, getOwnableTrailers,
 } from './utils';

--- a/src/frontend/dlc-value.ts
+++ b/src/frontend/dlc-value.ts
@@ -27,15 +27,22 @@ export interface DLCMarginalValue {
   newGarageCities: Array<{ id: string; name: string; score: number }>;
 }
 
-function sumGarageScores(
+/**
+ * Compute total garage score and per-city scores for a given DLC ownership scenario.
+ * Pure computation — takes all DLC maps as parameters so it works in both
+ * the main thread and the Web Worker.
+ */
+export function sumGarageScores(
   rawData: AllData,
   ownedTrailer: string[],
   ownedCargoAndMap: Set<string>,
   ownedMap: string[],
   garageCityIds: Set<string>,
+  cityDlcMap: Record<string, string[]>,
+  combinedCargoDlcMap: Record<string, string>,
 ): { total: number; perCity: Map<string, number> } {
-  const blocked = getBlockedCities(ownedMap, CITY_DLC_MAP);
-  const filtered = applyDLCFilter(rawData, ownedTrailer, ownedCargoAndMap, COMBINED_CARGO_DLC_MAP, blocked);
+  const blocked = getBlockedCities(ownedMap, cityDlcMap);
+  const filtered = applyDLCFilter(rawData, ownedTrailer, ownedCargoAndMap, combinedCargoDlcMap, blocked);
   const lookups = buildLookups(filtered);
   clearTrailerInfoCache();
   const rankings = calculateCityRankings(filtered, lookups);
@@ -72,7 +79,7 @@ export async function computeAllDLCValues(
 
   // Baseline with current DLC ownership
   const baselineCargoSet = new Set([...ownedCargo, ...ownedMap]);
-  const baseline = sumGarageScores(rawData, ownedTrailer, baselineCargoSet, ownedMap, activeGarages);
+  const baseline = sumGarageScores(rawData, ownedTrailer, baselineCargoSet, ownedMap, activeGarages, CITY_DLC_MAP, COMBINED_CARGO_DLC_MAP);
 
   const unownedMap = ALL_MAP_DLC_IDS.filter(id => !ownedMap.includes(id));
   const unownedTrailer = ALL_DLC_IDS.filter(id => !ownedTrailer.includes(id));
@@ -107,7 +114,7 @@ export async function computeAllDLCValues(
       }
     }
 
-    const hypo = sumGarageScores(rawData, hypoTrailer, hypoCargoSet, hypoMap, hypoGarages);
+    const hypo = sumGarageScores(rawData, hypoTrailer, hypoCargoSet, hypoMap, hypoGarages, CITY_DLC_MAP, COMBINED_CARGO_DLC_MAP);
 
     // Existing garage delta = improvement at current garages only
     let existingGarageDelta = 0;

--- a/src/frontend/optimizer-worker.ts
+++ b/src/frontend/optimizer-worker.ts
@@ -13,9 +13,8 @@ import {
   computeOptimalFleet, calculateCityRankings, clearTrailerInfoCache,
   type OptimalFleet, type CityRanking,
 } from './optimizer';
-import { buildLookups, applyDLCFilter, getBlockedCities } from './data';
 import type { AllData, Lookups } from './types';
-import type { DLCMarginalValue } from './dlc-value';
+import { sumGarageScores, type DLCMarginalValue } from './dlc-value';
 
 // ============================================
 // Message types
@@ -51,32 +50,6 @@ export interface DLCConfig {
 // ============================================
 // DLC marginal value (worker-side)
 // ============================================
-
-function sumGarageScores(
-  rawData: AllData,
-  ownedTrailer: string[],
-  ownedCargoAndMap: Set<string>,
-  ownedMap: string[],
-  garageCityIds: Set<string>,
-  cityDlcMap: Record<string, string[]>,
-  combinedCargoDlcMap: Record<string, string>,
-): { total: number; perCity: Map<string, number> } {
-  const blocked = getBlockedCities(ownedMap, cityDlcMap);
-  const filtered = applyDLCFilter(rawData, ownedTrailer, ownedCargoAndMap, combinedCargoDlcMap, blocked);
-  const lookups = buildLookups(filtered);
-  clearTrailerInfoCache();
-  const rankings = calculateCityRankings(filtered, lookups);
-
-  let total = 0;
-  const perCity = new Map<string, number>();
-  for (const r of rankings) {
-    perCity.set(r.id, r.score);
-    if (garageCityIds.has(r.id)) {
-      total += r.score;
-    }
-  }
-  return { total, perCity };
-}
 
 function computeDLCValuesInWorker(
   rawData: AllData,

--- a/src/frontend/optimizer.ts
+++ b/src/frontend/optimizer.ts
@@ -13,6 +13,7 @@
 
 import {
   formatTrailerSpec,
+  cargoBonus,
 } from './data.js';
 import type { AllData, Lookups, Trailer } from './data.js';
 
@@ -127,7 +128,7 @@ export function buildCityDepotProfiles(cityId: string, lookups: Lookups): CityDe
       if (!c || c.excluded) continue;
 
       const probCoef = c.prob_coef ?? 1.0;
-      const bonus = 1 + (c.fragile ? 0.3 : 0) + (c.high_value ? 0.3 : 0);
+      const bonus = cargoBonus(c);
       const unitVal = c.value * bonus;
 
       // Find best haul value per body type from trailers available in this country
@@ -305,7 +306,7 @@ function getTrailerInfoForCountry(
       const c = lookups.cargoById.get(cargoId);
       if (!c || c.excluded) continue;
       const units = lookups.cargoTrailerUnits.get(`${cargoId}:${t.id}`) ?? 1;
-      const bonus = 1 + (c.fragile ? 0.3 : 0) + (c.high_value ? 0.3 : 0);
+      const bonus = cargoBonus(c);
       totalHV += c.value * bonus * units;
     }
 

--- a/src/frontend/trailer-profiles.ts
+++ b/src/frontend/trailer-profiles.ts
@@ -13,6 +13,7 @@ import type {
   CargoWeight, DepotProfile, CityCargoProfile,
   TrailerCityScore, CargoPoolEntry,
 } from './types';
+import { cargoBonus } from './utils';
 
 /**
  * Build earning profiles for all ownable trailer variants.
@@ -37,7 +38,7 @@ export function buildTrailerProfiles(data: AllData, lookups: Lookups): TrailerPr
       if (!c || c.excluded) continue;
 
       const units = lookups.cargoTrailerUnits.get(`${cargoId}:${trailer.id}`) ?? 1;
-      const bonus = 1 + (c.fragile ? 0.3 : 0) + (c.high_value ? 0.3 : 0);
+      const bonus = cargoBonus(c);
       const haulValue = c.value * bonus * units;
       const spawnWeight = c.prob_coef ?? 1.0;
 
@@ -81,7 +82,7 @@ export function buildDepotProfiles(data: AllData, lookups: Lookups): Map<string,
     for (const cargoId of cargoIds) {
       const c = lookups.cargoById.get(cargoId);
       if (!c || c.excluded) continue;
-      const bonus = 1 + (c.fragile ? 0.3 : 0) + (c.high_value ? 0.3 : 0);
+      const bonus = cargoBonus(c);
       const value = c.value * bonus;
       const spawnWeight = c.prob_coef ?? 1.0;
       const weightedValue = value * spawnWeight;
@@ -132,7 +133,7 @@ export function buildCityCargoProfile(
         existing.depotCount += count;
         existing.weightedValue = existing.value * existing.spawnWeight * existing.depotCount;
       } else {
-        const bonus = 1 + (c.fragile ? 0.3 : 0) + (c.high_value ? 0.3 : 0);
+        const bonus = cargoBonus(c);
         const value = c.value * bonus;
         const spawnWeight = c.prob_coef ?? 1.0;
         cargo.set(cargoId, {
@@ -331,7 +332,7 @@ export function getCityCargoPool(cityId: string, data: AllData, lookups: Lookups
     for (const cargoId of cargoIds) {
       const cargo = lookups.cargoById.get(cargoId);
       if (cargo && !cargo.excluded) {
-        const multiplier = 1 + (cargo.fragile ? 0.3 : 0) + (cargo.high_value ? 0.3 : 0);
+        const multiplier = cargoBonus(cargo);
         const spawnWeight = cargo.prob_coef ?? 1.0;
         pool.push({
           companyId,

--- a/src/frontend/trailers.ts
+++ b/src/frontend/trailers.ts
@@ -7,7 +7,7 @@
 
 import { initPageData } from './page-init';
 import {
-  normalize, getOwnableTrailers,
+  normalize, cargoBonus, getOwnableTrailers,
   pickBestTrailer, trailerTotalHV, formatTrailerSpec,
   type AllData, type Lookups, type Cargo, type Trailer,
 } from './data';
@@ -57,7 +57,7 @@ function getCargo(cargoIds: Set<string>, trailerId: string): CargoWithUnits[] {
       const cargo = lookups!.cargoById.get(cargoId);
       if (!cargo || cargo.excluded) return null;
       const units = lookups!.cargoTrailerUnits.get(`${cargoId}:${trailerId}`) ?? 1;
-      const multiplier = 1 + (cargo.fragile ? 0.3 : 0) + (cargo.high_value ? 0.3 : 0);
+      const multiplier = cargoBonus(cargo);
       const unitValue = cargo.value * multiplier;
       return { ...cargo, units, unitValue, haulValue: unitValue * units };
     })

--- a/src/frontend/utils.ts
+++ b/src/frontend/utils.ts
@@ -8,6 +8,14 @@
 import type { Trailer, Lookups } from './types';
 
 /**
+ * Cargo value bonus multiplier: +30% for fragile, +30% for high_value (stackable).
+ * Returns 1.0 (no bonus), 1.3 (one flag), or 1.6 (both flags).
+ */
+export function cargoBonus(cargo: { fragile: boolean; high_value: boolean }): number {
+  return 1 + (cargo.fragile ? 0.3 : 0) + (cargo.high_value ? 0.3 : 0);
+}
+
+/**
  * Normalize text for accent-insensitive search
  * Removes diacritics and converts to lowercase
  */
@@ -81,7 +89,7 @@ export function trailerTotalHV(t: Trailer, lookups: Lookups): number {
     const cargo = lookups.cargoById.get(cargoId);
     if (!cargo || cargo.excluded) continue;
     const units = lookups.cargoTrailerUnits.get(`${cargoId}:${t.id}`) ?? 1;
-    const bonus = 1 + (cargo.fragile ? 0.3 : 0) + (cargo.high_value ? 0.3 : 0);
+    const bonus = cargoBonus(cargo);
     total += cargo.value * bonus * units;
   }
   return total;


### PR DESCRIPTION
## Summary
- Extract cargoBonus() function in utils.ts to replace 9 inline copies of the fragile/high_value bonus formula across 6 files
- Deduplicate sumGarageScores() -- keep canonical implementation in dlc-value.ts with explicit parameters, import it in optimizer-worker.ts instead of copy-pasting
- Export cargoBonus from data.ts barrel for convenient access

## Test plan
- [x] npm run lint -- TypeScript type checking passes
- [x] npm run test -- all 126 tests pass
- [x] npm run build:frontend -- production build succeeds

Closes #152