### PR TITLE
fix: increase banner dismiss touch target and add keyboard access to garage star

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -307,8 +307,8 @@ nav {
   cursor: pointer;
   padding: 0.25rem;
   line-height: 1;
-  min-width: 32px;
-  min-height: 32px;
+  min-width: 44px;
+  min-height: 44px;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -1633,8 +1633,14 @@ th.tooltip::before {
   user-select: none;
 }
 
-.garage-star:hover {
+.garage-star:hover,
+.garage-star:focus {
   color: #f39c12;
+}
+
+.garage-star:focus-visible {
+  outline: 2px solid #f39c12;
+  outline-offset: 2px;
 }
 
 tr.owned-garage .garage-star {

--- a/src/frontend/main.ts
+++ b/src/frontend/main.ts
@@ -314,7 +314,7 @@ async function renderRankings() {
             const tier = getScoreTier(globalIndex >= 0 ? globalIndex : i, cachedRankings!.length);
             return `
             <tr class="clickable${starred ? ' owned-garage' : ''}" data-city-id="${r.id}" tabindex="0">
-              <td class="garage-star" data-city-id="${r.id}" title="${starred ? 'Remove garage' : 'Mark as garage'}">${starred ? '\u2605' : '\u2606'}</td>
+              <td class="garage-star" data-city-id="${r.id}" title="${starred ? 'Remove garage' : 'Mark as garage'}" tabindex="0" role="button" aria-label="${starred ? 'Remove garage for' : 'Toggle garage for'} ${r.name}">${starred ? '\u2605' : '\u2606'}</td>
               <td>${i + 1}</td>
               <td>${r.name}</td>
               <td class="country">${r.country}</td>
@@ -330,17 +330,27 @@ async function renderRankings() {
     </div>
   `;
 
-  // Star click toggles garage without navigating to city
+  // Star click/keyboard toggles garage without navigating to city
   rankingsContent.querySelectorAll('.garage-star').forEach((star) => {
-    star.addEventListener('click', (e) => {
+    const toggleStar = (e: Event) => {
       e.stopPropagation();
-      const cityId = (star as HTMLElement).dataset.cityId!;
+      e.preventDefault();
+      const el = star as HTMLElement;
+      const cityId = el.dataset.cityId!;
       const nowOwned = toggleOwnedGarage(cityId);
-      (star as HTMLElement).textContent = nowOwned ? '\u2605' : '\u2606';
-      (star as HTMLElement).title = nowOwned ? 'Remove garage' : 'Mark as garage';
-      const row = (star as HTMLElement).closest('tr')!;
+      el.textContent = nowOwned ? '\u2605' : '\u2606';
+      el.title = nowOwned ? 'Remove garage' : 'Mark as garage';
+      const cityName = el.closest('tr')!.querySelector('td:nth-child(3)')!.textContent!;
+      el.setAttribute('aria-label', `${nowOwned ? 'Remove garage for' : 'Toggle garage for'} ${cityName}`);
+      const row = el.closest('tr')!;
       row.classList.toggle('owned-garage', nowOwned);
       updateGarageCount();
+    };
+    star.addEventListener('click', toggleStar);
+    star.addEventListener('keydown', (e) => {
+      if ((e as KeyboardEvent).key === 'Enter' || (e as KeyboardEvent).key === ' ') {
+        toggleStar(e);
+      }
     });
   });
 


### PR DESCRIPTION
## Summary
- Increased `.dlc-banner-dismiss` touch target from 32px to 44px to match the 44px accessibility standard established in PR #139
- Added keyboard accessibility to garage star toggle in rankings table: `tabindex="0"`, `role="button"`, `aria-label`, Enter/Space keydown handler, and focus outline styling
- Updated aria-label dynamically on toggle to reflect current state

## Test plan
- [ ] Verify DLC banner dismiss button has 44×44px touch target
- [ ] Tab to garage star in rankings table — verify focus ring visible
- [ ] Press Enter or Space on focused star — verify garage toggles
- [ ] Verify star aria-label updates after toggle

Closes #154