### PR TITLE
fix: escape search input, remove duplicate normalize, use direct worker imports

### DIFF
--- a/src/frontend/main.ts
+++ b/src/frontend/main.ts
@@ -9,6 +9,7 @@ import {
   isOnboardingCollapsed, setOnboardingCollapsed,
 } from './storage.js';
 import { copyToClipboard } from './clipboard.js';
+import { normalize } from './data.js';
 import type { AllData, Lookups } from './data.js';
 
 let data: AllData | null = null;
@@ -23,10 +24,6 @@ function debounce(fn: () => void, ms: number): () => void {
     clearTimeout(timer);
     timer = setTimeout(fn, ms);
   };
-}
-
-function normalize(str: string): string {
-  return str.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '');
 }
 
 function formatNumber(n: number): string {
@@ -258,7 +255,8 @@ async function renderRankings() {
   if (displayRankings.length === 0) {
     let message: string;
     if (searchTerm) {
-      message = `No cities match '${citySearch.value.trim()}'`;
+      const escaped = citySearch.value.trim().replace(/</g, '&lt;').replace(/>/g, '&gt;');
+      message = `No cities match '${escaped}'`;
     } else if (selectedCountries.length > 0) {
       message = 'No cities match your filters';
     } else {

--- a/src/frontend/optimizer.ts
+++ b/src/frontend/optimizer.ts
@@ -14,8 +14,8 @@
 import {
   formatTrailerSpec,
   cargoBonus,
-} from './data.js';
-import type { AllData, Lookups, Trailer } from './data.js';
+} from './utils.js';
+import type { AllData, Lookups, Trailer } from './types.js';
 
 /** Jobs spawned per depot instance on each visit */
 const JOBS_PER_DEPOT = 3;


### PR DESCRIPTION
## Summary
- **XSS fix**: Escape user search input in `main.ts` before interpolating into innerHTML, matching the pattern used in all other browser pages
- **Remove duplicate**: Delete local `normalize()` in `main.ts` and import from `data.js` barrel (which re-exports from `utils.ts`)
- **Direct worker imports**: Change `optimizer.ts` imports from `./data.js` barrel to direct `./utils.js` and `./types.js`, preventing the worker from pulling in `page-init.ts`/`storage.ts` (which reference `localStorage`)

## Test plan
- [x] `npm run lint` passes
- [x] `npm run test` passes (126 tests)
- [x] `npm run build:frontend` succeeds

Closes #153