### PR TITLE
feat: add search results feedback

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1294,6 +1294,14 @@ a.link:hover {
   color: #999;
 }
 
+.results-count {
+  display: block;
+  color: #9a9a9a;
+  font-size: 0.85rem;
+  margin-top: 0.5rem;
+  min-height: 1.25em;
+}
+
 /* States */
 .empty-state, .loading {
   text-align: center;

--- a/public/index.html
+++ b/public/index.html
@@ -140,6 +140,7 @@
 
     <div class="search-box">
       <input type="text" id="city-search" placeholder="Search cities..." aria-label="Search cities">
+      <span id="results-count" class="results-count" role="status" aria-live="polite"></span>
     </div>
 
     <div class="country-filter">

--- a/src/frontend/main.ts
+++ b/src/frontend/main.ts
@@ -149,6 +149,18 @@ function updateGarageCount() {
 }
 
 // ============================================
+// Results count feedback
+// ============================================
+
+function updateResultsCount(shown: number, total: number) {
+  if (shown === total || total === 0) {
+    resultsCount.textContent = '';
+  } else {
+    resultsCount.textContent = `Showing ${shown} of ${total} cities`;
+  }
+}
+
+// ============================================
 // Score tier helpers
 // ============================================
 
@@ -194,6 +206,7 @@ const cityContent = document.getElementById('city-content')!;
 const backLink = document.getElementById('back-link')!;
 const filterToggle = document.getElementById('filter-toggle')!;
 const citySearch = document.getElementById('city-search') as HTMLInputElement;
+const resultsCount = document.getElementById('results-count')!;
 const howItWorksToggle = document.getElementById('how-it-works-toggle');
 const onboardingToggle = document.getElementById('onboarding-toggle');
 const onboardingSection = document.getElementById('onboarding');
@@ -224,6 +237,7 @@ async function renderRankings() {
   if (rankings.length === 0) {
     cachedRankings = null;
     rankingsContent.innerHTML = '<div class="empty-state">No cities with data yet.</div>';
+    updateResultsCount(0, 0);
     return;
   }
 
@@ -249,6 +263,7 @@ async function renderRankings() {
         <p class="hint">Click any city row, then click the star to mark it as your garage.</p>
       </div>
     `;
+    updateResultsCount(0, rankings.length);
     return;
   }
 
@@ -284,6 +299,7 @@ async function renderRankings() {
       </div>
     `;
     updateGarageCount();
+    updateResultsCount(0, rankings.length);
     return;
   }
 
@@ -363,6 +379,7 @@ async function renderRankings() {
   });
 
   updateGarageCount();
+  updateResultsCount(displayRankings.length, rankings.length);
 }
 
 // ============================================


### PR DESCRIPTION
## Summary
- Adds a "Showing X of Y cities" message below the search input when results are filtered
- Message appears on search text input, country filter, and "My Garages" toggle
- Message hidden when showing all cities (unfiltered view)
- Uses `role="status"` and `aria-live="polite"` for screen reader accessibility

## Test plan
- [x] Lint passes (`npm run lint`)
- [x] All 176 tests pass (`npm run test`)
- [x] Verified in browser: typing "germany" shows "Showing 21 of 63 cities"
- [x] Verified in browser: clearing search hides the count message
- [x] Element uses `role="status"` for accessibility

Closes #66