### PR TITLE
feat: add service worker for offline caching

### DIFF
--- a/public/cargo.html
+++ b/public/cargo.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Cargo - ETS2 Trucker Advisor</title>
   <link rel="stylesheet" href="css/style.css">
+  <script>if('serviceWorker' in navigator)navigator.serviceWorker.register('/trucker/sw.js');</script>
 </head>
 <body>
   <a href="#main-content" class="skip-link">Skip to main content</a>

--- a/public/cities.html
+++ b/public/cities.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Cities - ETS2 Trucker Advisor</title>
   <link rel="stylesheet" href="css/style.css">
+  <script>if('serviceWorker' in navigator)navigator.serviceWorker.register('/trucker/sw.js');</script>
 </head>
 <body>
   <a href="#main-content" class="skip-link">Skip to main content</a>

--- a/public/companies.html
+++ b/public/companies.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Companies - ETS2 Trucker Advisor</title>
   <link rel="stylesheet" href="css/style.css">
+  <script>if('serviceWorker' in navigator)navigator.serviceWorker.register('/trucker/sw.js');</script>
 </head>
 <body>
   <a href="#main-content" class="skip-link">Skip to main content</a>

--- a/public/dlcs.html
+++ b/public/dlcs.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>DLCs - ETS2 Trucker Advisor</title>
   <link rel="stylesheet" href="css/style.css">
+  <script>if('serviceWorker' in navigator)navigator.serviceWorker.register('/trucker/sw.js');</script>
 </head>
 <body>
   <a href="#main-content" class="skip-link">Skip to main content</a>

--- a/public/index.html
+++ b/public/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>ETS2 Trucker Advisor</title>
   <link rel="stylesheet" href="css/style.css">
+  <script>if('serviceWorker' in navigator)navigator.serviceWorker.register('/trucker/sw.js');</script>
 </head>
 <body>
   <a href="#main-content" class="skip-link">Skip to main content</a>

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,80 @@
+// Service worker for ETS2 Trucker Advisor — offline caching
+// Cache-first for static assets (CSS, JS, JSON), network-first for HTML
+
+const CACHE_NAME = 'trucker-cache-v1';
+const BASE = '/trucker/';
+
+// Assets to pre-cache on install
+const PRECACHE_URLS = [
+  BASE,
+  BASE + 'index.html',
+  BASE + 'cities.html',
+  BASE + 'companies.html',
+  BASE + 'cargo.html',
+  BASE + 'trailers.html',
+  BASE + 'dlcs.html',
+  BASE + 'css/style.css',
+  BASE + 'data/game-defs.json',
+  BASE + 'data/observations.json',
+];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(PRECACHE_URLS))
+  );
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+  // Remove old cache versions
+  event.waitUntil(
+    caches.keys().then((keys) =>
+      Promise.all(
+        keys
+          .filter((key) => key !== CACHE_NAME)
+          .map((key) => caches.delete(key))
+      )
+    )
+  );
+  self.clients.claim();
+});
+
+self.addEventListener('fetch', (event) => {
+  const url = new URL(event.request.url);
+
+  // Only handle same-origin requests under the base path
+  if (url.origin !== self.location.origin || !url.pathname.startsWith(BASE)) {
+    return;
+  }
+
+  // Network-first for HTML pages (so users get fresh content)
+  if (event.request.mode === 'navigate' || url.pathname.endsWith('.html')) {
+    event.respondWith(
+      fetch(event.request)
+        .then((response) => {
+          const clone = response.clone();
+          caches.open(CACHE_NAME).then((cache) => cache.put(event.request, clone));
+          return response;
+        })
+        .catch(() => caches.match(event.request))
+    );
+    return;
+  }
+
+  // Cache-first for static assets (CSS, JS, JSON, images)
+  event.respondWith(
+    caches.match(event.request).then((cached) => {
+      if (cached) {
+        return cached;
+      }
+      return fetch(event.request).then((response) => {
+        // Cache successful GET responses for assets
+        if (response.ok && event.request.method === 'GET') {
+          const clone = response.clone();
+          caches.open(CACHE_NAME).then((cache) => cache.put(event.request, clone));
+        }
+        return response;
+      });
+    })
+  );
+});

--- a/public/trailers.html
+++ b/public/trailers.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Trailers - ETS2 Trucker Advisor</title>
   <link rel="stylesheet" href="css/style.css">
+  <script>if('serviceWorker' in navigator)navigator.serviceWorker.register('/trucker/sw.js');</script>
 </head>
 <body>
   <a href="#main-content" class="skip-link">Skip to main content</a>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -61,6 +61,7 @@ export default defineConfig({
       targets: [
         { src: 'public/data/*', dest: 'data' },
         { src: 'public/css/*', dest: 'css' },
+        { src: 'public/sw.js', dest: '.' },
       ],
     }),
     flattenHtmlOutput(),


### PR DESCRIPTION
## Summary
- Add `public/sw.js` service worker with cache-first strategy for static assets (CSS, JS, JSON) and network-first for HTML pages
- Register service worker in all 6 HTML pages via inline `<script>` tag
- Add `sw.js` to Vite static copy targets so it's included in production builds
- Pre-caches all HTML pages, CSS, and JSON data files on install
- Cleans up old cache versions on activate

## Test plan
- [x] `npm run build:frontend` succeeds and `sw.js` is in `public/dist/`
- [x] All 6 built HTML files contain SW registration script
- [x] `npm run lint` passes
- [x] All 176 tests pass
- [ ] After deploy, verify SW registers in browser DevTools > Application > Service Workers
- [ ] Verify cached assets load from SW cache on repeat visits
- [ ] Verify offline mode serves cached pages

Closes #79