### PR TITLE
feat: add city comparison view for side-by-side fleet analysis

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1697,6 +1697,171 @@ tr.owned-garage {
   font-size: 1rem;
 }
 
+/* Compare Column */
+.compare-col {
+  width: 3rem;
+  text-align: center;
+}
+
+.compare-check {
+  width: 18px;
+  height: 18px;
+  cursor: pointer;
+  accent-color: #f39c12;
+}
+
+/* Floating Compare Bar */
+.compare-bar {
+  position: fixed;
+  bottom: 1.5rem;
+  left: 50%;
+  transform: translateX(-50%);
+  background: #16213e;
+  border: 2px solid #f39c12;
+  border-radius: 8px;
+  padding: 0.6rem 1rem;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  z-index: 1000;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.5);
+  color: #eee;
+  font-size: 0.95rem;
+}
+
+.compare-bar-go {
+  background: #f39c12;
+  color: #1a1a2e;
+  border: none;
+  padding: 0.4rem 1rem;
+  border-radius: 4px;
+  font-weight: 600;
+  cursor: pointer;
+  font-size: 0.9rem;
+  min-height: 36px;
+}
+
+.compare-bar-go:hover {
+  background: #e67e22;
+}
+
+.compare-bar-clear {
+  background: none;
+  border: none;
+  color: #9a9a9a;
+  font-size: 1.25rem;
+  cursor: pointer;
+  padding: 0.25rem;
+  line-height: 1;
+  min-width: 36px;
+  min-height: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.compare-bar-clear:hover {
+  color: #e74c3c;
+}
+
+/* Comparison View Grid */
+.compare-grid {
+  display: grid;
+  grid-template-columns: repeat(var(--compare-cols, 2), 1fr);
+  gap: 1.5rem;
+  margin-top: 1rem;
+}
+
+.compare-card {
+  background: #16213e;
+  border: 1px solid #2a3a5a;
+  border-radius: 8px;
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.compare-card-header h3 {
+  color: #f39c12;
+  font-size: 1.15rem;
+  margin-bottom: 0.25rem;
+}
+
+.compare-card-header .country {
+  font-size: 0.9rem;
+}
+
+.compare-stats {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.compare-stat {
+  background: rgba(0, 0, 0, 0.2);
+  border-radius: 6px;
+  padding: 0.6rem 0.8rem;
+  border-left: 3px solid transparent;
+}
+
+.compare-stat.compare-winner {
+  border-left-color: #2ecc71;
+  background: rgba(46, 204, 113, 0.08);
+}
+
+.compare-stat-value {
+  font-size: 1.25rem;
+  font-weight: bold;
+  color: #f39c12;
+}
+
+.compare-stat-label {
+  font-size: 0.75rem;
+  color: #9a9a9a;
+  margin-top: 0.15rem;
+}
+
+.compare-fleet {
+  border-top: 1px solid #2a3a5a;
+  padding-top: 0.75rem;
+}
+
+.compare-fleet h4 {
+  color: #f39c12;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 0.5rem;
+}
+
+.compare-fleet-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.35rem 0;
+  font-size: 0.9rem;
+  border-bottom: 1px solid rgba(42, 58, 90, 0.5);
+}
+
+.compare-fleet-row:last-child {
+  border-bottom: none;
+}
+
+.compare-trailer-name {
+  color: #ccc;
+}
+
+.compare-trailer-ev {
+  color: #f39c12;
+  font-weight: 600;
+}
+
+.compare-no-data {
+  color: #9a9a9a;
+  font-size: 0.85rem;
+}
+
 /* Responsive */
 @media (max-width: 600px) {
   .container {
@@ -1732,7 +1897,7 @@ tr.owned-garage {
   }
 
   /* Rankings table only: show City(3), Fleet EV(7), Best Trailers(8) on mobile */
-  /* Hide: Star(1), Rank(2), Country(4), Depots(5), Cargo(6) */
+  /* Hide: Star(1), Rank(2), Country(4), Depots(5), Cargo(6), Compare(9) */
   .table-rankings th:nth-child(1),
   .table-rankings td:nth-child(1),
   .table-rankings th:nth-child(2),
@@ -1742,8 +1907,15 @@ tr.owned-garage {
   .table-rankings th:nth-child(5),
   .table-rankings td:nth-child(5),
   .table-rankings th:nth-child(6),
-  .table-rankings td:nth-child(6) {
+  .table-rankings td:nth-child(6),
+  .table-rankings th:nth-child(9),
+  .table-rankings td:nth-child(9) {
     display: none;
+  }
+
+  /* Comparison view: stack vertically on mobile */
+  .compare-grid {
+    grid-template-columns: 1fr !important;
   }
 
   .stats {

--- a/src/frontend/comparison-view.ts
+++ b/src/frontend/comparison-view.ts
@@ -1,0 +1,126 @@
+/**
+ * City comparison view for ETS2 Trucker Advisor
+ *
+ * Renders a side-by-side comparison of 2-5 selected cities,
+ * highlighting the winner in each category.
+ */
+
+import { computeFleetAsync } from './optimizer-client.js';
+import type { CityRanking, OptimalFleet } from './optimizer.js';
+import { formatNumber, getScoreTier } from './rankings-view.js';
+import type { RankingsState } from './rankings-view.js';
+
+// ============================================
+// Types
+// ============================================
+
+interface CityComparisonData {
+  ranking: CityRanking;
+  fleet: OptimalFleet | null;
+  depotCount: number;
+  tierLabel: string;
+  tierClass: string;
+}
+
+// ============================================
+// Rendering
+// ============================================
+
+function bestIndex(values: number[]): number {
+  let best = 0;
+  for (let i = 1; i < values.length; i++) {
+    if (values[i] > values[best]) best = i;
+  }
+  return best;
+}
+
+function winnerClass(index: number, winnerIdx: number): string {
+  return index === winnerIdx ? ' compare-winner' : '';
+}
+
+export async function renderComparison(
+  cityIds: string[],
+  state: RankingsState,
+  container: HTMLElement,
+): Promise<void> {
+  if (cityIds.length < 2) {
+    container.innerHTML = '<div class="empty-state">Select at least 2 cities to compare.</div>';
+    return;
+  }
+
+  container.innerHTML = '<div class="empty-state">Loading comparison...</div>';
+
+  // Gather data for each city
+  const cities: CityComparisonData[] = [];
+  for (const cityId of cityIds) {
+    const ranking = state.cachedRankings?.find(r => r.id === cityId);
+    if (!ranking) continue;
+
+    const fleet = await computeFleetAsync(cityId, state.data, state.lookups);
+
+    const globalIndex = state.cachedRankings!.findIndex(r => r.id === cityId);
+    const tier = getScoreTier(globalIndex >= 0 ? globalIndex : 0, state.cachedRankings!.length);
+
+    cities.push({
+      ranking,
+      fleet,
+      depotCount: ranking.depotCount,
+      tierLabel: tier.label ? tier.label.split(' \u2014 ')[0] : '',
+      tierClass: tier.className,
+    });
+  }
+
+  if (cities.length < 2) {
+    container.innerHTML = '<div class="empty-state">Could not load data for selected cities.</div>';
+    return;
+  }
+
+  // Compute winners for each metric
+  const scores = cities.map(c => c.ranking.score);
+  const depots = cities.map(c => c.depotCount);
+  const cargoTypes = cities.map(c => c.ranking.cargoTypes);
+  const scoreWinner = bestIndex(scores);
+  const depotWinner = bestIndex(depots);
+  const cargoWinner = bestIndex(cargoTypes);
+
+  container.innerHTML = `
+    <div class="compare-grid" style="--compare-cols: ${cities.length}">
+      ${cities.map((city, i) => `
+        <div class="compare-card">
+          <div class="compare-card-header">
+            <h3>${city.ranking.name}</h3>
+            <span class="country">${city.ranking.country}</span>
+          </div>
+
+          <div class="compare-stats">
+            <div class="compare-stat${winnerClass(i, scoreWinner)}">
+              <div class="compare-stat-value ${city.tierClass}">${formatNumber(city.ranking.score)}</div>
+              <div class="compare-stat-label">Fleet EV${city.tierLabel ? ` \u2014 ${city.tierLabel}` : ''}</div>
+            </div>
+            <div class="compare-stat${winnerClass(i, depotWinner)}">
+              <div class="compare-stat-value">${city.depotCount}</div>
+              <div class="compare-stat-label">Depots</div>
+            </div>
+            <div class="compare-stat${winnerClass(i, cargoWinner)}">
+              <div class="compare-stat-value">${city.ranking.cargoTypes}</div>
+              <div class="compare-stat-label">Cargo Types</div>
+            </div>
+          </div>
+
+          <div class="compare-fleet">
+            <h4>Top Trailers</h4>
+            ${city.fleet ? city.fleet.drivers.map(d => {
+              const countLabel = d.count > 1 ? ` \u00d7${d.count}` : '';
+              return `
+                <div class="compare-fleet-row">
+                  <span class="compare-trailer-name">${d.displayName}${countLabel}</span>
+                  <span class="compare-trailer-ev">${formatNumber(d.ev)}</span>
+                </div>
+              `;
+            }).join('') : '<div class="compare-no-data">No fleet data</div>'}
+          </div>
+        </div>
+      `).join('')}
+    </div>
+  `;
+}

--- a/src/frontend/main.ts
+++ b/src/frontend/main.ts
@@ -16,9 +16,11 @@ import type { CityRanking } from './optimizer.js';
 import {
   renderRankings, initRankingsView,
   showLoading, showError,
+  getComparisonCityIds, clearComparison,
   type RankingsState,
 } from './rankings-view.js';
 import { renderCity } from './city-detail-view.js';
+import { renderComparison } from './comparison-view.js';
 
 // ============================================
 // Shared state
@@ -65,10 +67,43 @@ function debounce(fn: () => void, ms: number): () => void {
 // Navigation
 // ============================================
 
+// ============================================
+// Comparison view container (created lazily)
+// ============================================
+
+let compareView: HTMLElement | null = null;
+let compareContent: HTMLElement | null = null;
+let compareBackLink: HTMLElement | null = null;
+
+function ensureCompareView() {
+  if (compareView) return;
+  compareView = document.createElement('div');
+  compareView.id = 'compare-view';
+  compareView.style.display = 'none';
+
+  compareBackLink = document.createElement('button');
+  compareBackLink.className = 'back-link';
+  compareBackLink.id = 'compare-back-link';
+  (compareBackLink as HTMLButtonElement).type = 'button';
+  compareBackLink.textContent = '\u2190 Back to rankings';
+  compareBackLink.addEventListener('click', showRankings);
+
+  compareContent = document.createElement('div');
+  compareContent.id = 'compare-content';
+  compareContent.setAttribute('aria-live', 'polite');
+
+  compareView.appendChild(compareBackLink);
+  compareView.appendChild(compareContent);
+
+  // Insert alongside the other views
+  cityView.parentNode!.insertBefore(compareView, cityView.nextSibling);
+}
+
 async function showCity(cityId: string) {
   currentCityId = cityId;
   rankingsView.style.display = 'none';
   cityView.style.display = 'block';
+  if (compareView) compareView.style.display = 'none';
   if (window.location.hash !== `#city-${cityId}`) {
     window.location.hash = `city-${cityId}`;
   }
@@ -76,9 +111,23 @@ async function showCity(cityId: string) {
   window.scrollTo(0, 0);
 }
 
+async function showComparison() {
+  ensureCompareView();
+  currentCityId = null;
+  rankingsView.style.display = 'none';
+  cityView.style.display = 'none';
+  compareView!.style.display = 'block';
+  if (window.location.hash !== '#compare') {
+    window.location.hash = 'compare';
+  }
+  await renderComparison(getComparisonCityIds(), state, compareContent!);
+  window.scrollTo(0, 0);
+}
+
 function showRankings() {
   currentCityId = null;
   cityView.style.display = 'none';
+  if (compareView) compareView.style.display = 'none';
   rankingsView.style.display = 'block';
   window.location.hash = '';
   renderRankings(state, rankingsContent, citySearch, resultsCount, showCity);
@@ -86,6 +135,14 @@ function showRankings() {
 
 function handleHashNavigation(): boolean {
   const hash = window.location.hash;
+  if (hash === '#compare') {
+    const ids = getComparisonCityIds();
+    if (ids.length >= 2) {
+      showComparison();
+      return true;
+    }
+    return false;
+  }
   if (hash.startsWith('#city-')) {
     const cityId = hash.replace('#city-', '');
     if (cityId && state.lookups?.citiesById.has(cityId)) {

--- a/src/frontend/rankings-view.ts
+++ b/src/frontend/rankings-view.ts
@@ -32,6 +32,68 @@ export interface RankingsState {
 }
 
 // ============================================
+// Comparison selection state (session only)
+// ============================================
+
+const MAX_COMPARE = 5;
+const comparisonSet = new Set<string>();
+
+export function getComparisonCityIds(): string[] {
+  return Array.from(comparisonSet);
+}
+
+export function clearComparison(): void {
+  comparisonSet.clear();
+}
+
+function toggleComparison(cityId: string): boolean {
+  if (comparisonSet.has(cityId)) {
+    comparisonSet.delete(cityId);
+    return false;
+  }
+  if (comparisonSet.size >= MAX_COMPARE) return false; // silently reject
+  comparisonSet.add(cityId);
+  return true;
+}
+
+function updateCompareBar() {
+  let bar = document.getElementById('compare-bar');
+  const count = comparisonSet.size;
+
+  if (count < 2) {
+    if (bar) bar.style.display = 'none';
+    return;
+  }
+
+  if (!bar) {
+    bar = document.createElement('div');
+    bar.id = 'compare-bar';
+    bar.className = 'compare-bar';
+    document.body.appendChild(bar);
+  }
+
+  bar.style.display = 'flex';
+  bar.innerHTML = `
+    <span>Compare ${count} cities</span>
+    <button class="compare-bar-go" id="compare-bar-go" type="button">Compare</button>
+    <button class="compare-bar-clear" id="compare-bar-clear" type="button">&times;</button>
+  `;
+
+  document.getElementById('compare-bar-go')!.addEventListener('click', () => {
+    window.location.hash = 'compare';
+  });
+
+  document.getElementById('compare-bar-clear')!.addEventListener('click', () => {
+    comparisonSet.clear();
+    updateCompareBar();
+    // Uncheck all checkboxes
+    document.querySelectorAll('.compare-check').forEach(cb => {
+      (cb as HTMLInputElement).checked = false;
+    });
+  });
+}
+
+// ============================================
 // Utility functions
 // ============================================
 
@@ -269,10 +331,11 @@ export async function renderRankings(
               <th class="tooltip" data-tooltip="Distinct cargo types available">Cargo</th>
               <th class="tooltip" data-tooltip="Sum of top 5 body type EVs \u2014 fleet earning potential">Fleet EV</th>
               <th class="tooltip" data-tooltip="Top earning trailer types for this city">Best Trailers</th>
+              <th class="compare-col tooltip" data-tooltip="Select cities to compare side by side">Cmp</th>
             </tr>
           </thead>
           <tbody>
-            <tr><td colspan="8" class="no-results" role="status">${message}</td></tr>
+            <tr><td colspan="9" class="no-results" role="status">${message}</td></tr>
           </tbody>
         </table>
       </div>
@@ -297,6 +360,7 @@ export async function renderRankings(
             <th class="tooltip" data-tooltip="Distinct cargo types available">Cargo</th>
             <th class="tooltip" data-tooltip="Sum of top 5 body type EVs \u2014 fleet earning potential">Fleet EV</th>
             <th class="tooltip" data-tooltip="Top earning trailer types for this city">Best Trailers</th>
+            <th class="compare-col tooltip" data-tooltip="Select cities to compare side by side">Cmp</th>
           </tr>
         </thead>
         <tbody>
@@ -305,6 +369,7 @@ export async function renderRankings(
             const starred = ownedSet.has(r.id);
             const globalIndex = state.cachedRankings!.findIndex(cr => cr.id === r.id);
             const tier = getScoreTier(globalIndex >= 0 ? globalIndex : i, state.cachedRankings!.length);
+            const checked = comparisonSet.has(r.id);
             return `
             <tr class="clickable${starred ? ' owned-garage' : ''}" data-city-id="${r.id}" tabindex="0">
               <td class="garage-star" data-city-id="${r.id}" title="${starred ? 'Remove garage' : 'Mark as garage'}" tabindex="0" role="button" aria-label="${starred ? 'Remove garage for' : 'Toggle garage for'} ${r.name}">${starred ? '\u2605' : '\u2606'}</td>
@@ -315,6 +380,7 @@ export async function renderRankings(
               <td class="amount">${r.cargoTypes}</td>
               <td class="score ${tier.className}" title="${tier.label}">${formatNumber(r.score)}${tier.label ? `<span class="score-tier-label">${tier.label.split(' \u2014 ')[0]}</span>` : ''}</td>
               <td class="trailer-summary">${trailerSummary}</td>
+              <td class="compare-col"><input type="checkbox" class="compare-check" data-city-id="${r.id}" ${checked ? 'checked' : ''} aria-label="Compare ${r.name}" title="Compare ${r.name}"></td>
             </tr>
           `;
           }).join('')}
@@ -348,15 +414,38 @@ export async function renderRankings(
   });
 
   rankingsContent.querySelectorAll('tr.clickable').forEach((row) => {
-    row.addEventListener('click', () => showCity((row as HTMLElement).dataset.cityId!));
+    row.addEventListener('click', (e) => {
+      // Don't navigate when clicking the compare checkbox
+      if ((e.target as HTMLElement).classList.contains('compare-check')) return;
+      showCity((row as HTMLElement).dataset.cityId!);
+    });
     row.addEventListener('keydown', (e) => {
       if ((e as KeyboardEvent).key === 'Enter' || (e as KeyboardEvent).key === ' ') {
+        if ((e.target as HTMLElement).classList.contains('compare-check')) return;
         e.preventDefault();
         showCity((row as HTMLElement).dataset.cityId!);
       }
     });
   });
 
+  // Comparison checkboxes
+  rankingsContent.querySelectorAll('.compare-check').forEach((cb) => {
+    cb.addEventListener('click', (e) => {
+      e.stopPropagation();
+    });
+    cb.addEventListener('change', (e) => {
+      const el = e.target as HTMLInputElement;
+      const cityId = el.dataset.cityId!;
+      const added = toggleComparison(cityId);
+      // If we tried to add but the set was full, uncheck
+      if (el.checked && !added && !comparisonSet.has(cityId)) {
+        el.checked = false;
+      }
+      updateCompareBar();
+    });
+  });
+
+  updateCompareBar();
   updateGarageCount(state.data, state.lookups, citySearch);
   updateResultsCount(resultsCount, displayRankings.length, rankings.length);
 }


### PR DESCRIPTION
## Summary
- Adds a "Cmp" checkbox column to the city rankings table allowing selection of 2-5 cities
- Shows a floating "Compare N cities" bar when 2+ cities are selected, with Compare and Clear buttons
- Clicking Compare navigates to `#compare` route showing side-by-side city cards with Fleet EV (with tier), depot count, cargo types, and top trailer recommendations with EVs
- Winner highlighting (green left border) on the best value in each category
- Responsive: stacks vertically on mobile, hides compare column on small screens

## Files Changed
- `src/frontend/comparison-view.ts` — new module: renders comparison grid
- `src/frontend/rankings-view.ts` — comparison selection state, checkboxes, floating bar
- `src/frontend/main.ts` — `#compare` hash route, comparison view container
- `public/css/style.css` — comparison grid, floating bar, winner highlight styles

## Test plan
- [x] TypeScript type check passes (`npm run lint`)
- [x] All 176 tests pass (`npm run test`)
- [x] Production build succeeds (`npm run build:frontend`)
- [x] Verified in browser: select 3 cities, click Compare, view side-by-side cards
- [x] Back to rankings navigation works
- [x] Compare bar appears at 2+ selections, hidden at 0-1

Closes #4