### PR TITLE
fix: extract shared escapeHtml utility and fix XSS in error handlers

### DIFF
--- a/src/frontend/__tests__/utils.test.ts
+++ b/src/frontend/__tests__/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { normalize, titleCase, trailerTotalHV, formatTrailerSpec } from '../utils';
+import { normalize, titleCase, trailerTotalHV, formatTrailerSpec, escapeHtml } from '../utils';
 import type { Trailer, Lookups, Cargo } from '../types';
 
 describe('normalize', () => {
@@ -291,5 +291,39 @@ describe('formatTrailerSpec', () => {
   it('includes length in meters', () => {
     const spec = formatTrailerSpec(makeTrailer({ length: 15.0 }));
     expect(spec).toContain('15m');
+  });
+});
+
+describe('escapeHtml', () => {
+  it('escapes ampersands', () => {
+    expect(escapeHtml('Tom & Jerry')).toBe('Tom &amp; Jerry');
+  });
+
+  it('escapes angle brackets', () => {
+    expect(escapeHtml('<script>alert("xss")</script>')).toBe(
+      '&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;',
+    );
+  });
+
+  it('escapes double quotes', () => {
+    expect(escapeHtml('say "hello"')).toBe('say &quot;hello&quot;');
+  });
+
+  it('escapes single quotes', () => {
+    expect(escapeHtml("it's")).toBe('it&#39;s');
+  });
+
+  it('handles strings with no special characters', () => {
+    expect(escapeHtml('plain text')).toBe('plain text');
+  });
+
+  it('handles empty string', () => {
+    expect(escapeHtml('')).toBe('');
+  });
+
+  it('escapes all special characters together', () => {
+    expect(escapeHtml('<div class="x">&\'</div>')).toBe(
+      '&lt;div class=&quot;x&quot;&gt;&amp;&#39;&lt;/div&gt;',
+    );
   });
 });

--- a/src/frontend/cargo.ts
+++ b/src/frontend/cargo.ts
@@ -5,6 +5,7 @@
 
 import { initPageData, initThemeToggle } from './page-init';
 import { normalize, type AllData, type Lookups, type Company, type Trailer } from './data';
+import { escapeHtml } from './utils';
 
 let data: AllData | null = null;
 let lookups: Lookups | null = null;
@@ -98,7 +99,7 @@ function renderCargoList(filter = ''): void {
     .sort((a, b) => a.name.localeCompare(b.name));
 
   if (filtered.length === 0) {
-    const escaped = filter.replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    const escaped = escapeHtml(filter);
     content.innerHTML = filter
       ? `<div class="empty-state">No cargo found matching "${escaped}". Try a different search term.</div>`
       : '<div class="empty-state">No cargo found.</div>';
@@ -338,7 +339,7 @@ async function init(): Promise<void> {
     content.innerHTML = `
       <div class="empty-state" role="alert">
         <p>Failed to load data</p>
-        <p class="error-detail">${message}</p>
+        <p class="error-detail">${escapeHtml(message)}</p>
       </div>
     `;
   }

--- a/src/frontend/cities.ts
+++ b/src/frontend/cities.ts
@@ -6,6 +6,7 @@
 import { initPageData, initThemeToggle } from './page-init';
 import { normalize, type AllData, type Lookups, type Company } from './data';
 import { isOwnedGarage } from './storage';
+import { escapeHtml } from './utils';
 
 let data: AllData | null = null;
 let lookups: Lookups | null = null;
@@ -119,7 +120,7 @@ function renderCityList(filter = ''): void {
   const grouped = groupByCountry(filtered);
 
   if (grouped.length === 0) {
-    const escaped = filter.replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    const escaped = escapeHtml(filter);
     content.innerHTML = filter
       ? `<div class="empty-state">No cities found matching "${escaped}". Try a different search term.</div>`
       : '<div class="empty-state">No cities found.</div>';
@@ -293,7 +294,7 @@ async function init(): Promise<void> {
     content.innerHTML = `
       <div class="empty-state" role="alert">
         <p>Failed to load data</p>
-        <p class="error-detail">${message}</p>
+        <p class="error-detail">${escapeHtml(message)}</p>
       </div>
     `;
   }

--- a/src/frontend/companies.ts
+++ b/src/frontend/companies.ts
@@ -5,6 +5,7 @@
 
 import { initPageData, initThemeToggle } from './page-init';
 import { normalize, cargoBonus, type AllData, type Lookups, type City, type Cargo } from './data';
+import { escapeHtml } from './utils';
 
 let data: AllData | null = null;
 let lookups: Lookups | null = null;
@@ -86,7 +87,7 @@ function renderCompanyList(filter = ''): void {
     .sort((a, b) => a.name.localeCompare(b.name));
 
   if (filtered.length === 0) {
-    const escaped = filter.replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    const escaped = escapeHtml(filter);
     content.innerHTML = filter
       ? `<div class="empty-state">No companies found matching "${escaped}". Try a different search term.</div>`
       : '<div class="empty-state">No companies found.</div>';
@@ -313,7 +314,7 @@ async function init(): Promise<void> {
     content.innerHTML = `
       <div class="empty-state" role="alert">
         <p>Failed to load data</p>
-        <p class="error-detail">${message}</p>
+        <p class="error-detail">${escapeHtml(message)}</p>
       </div>
     `;
   }

--- a/src/frontend/rankings-view.ts
+++ b/src/frontend/rankings-view.ts
@@ -13,6 +13,7 @@ import {
   getSelectedCountries, setSelectedCountries,
 } from './storage.js';
 import { normalize } from './data.js';
+import { escapeHtml } from './utils.js';
 import type { AllData, Lookups } from './data.js';
 
 // ============================================
@@ -311,7 +312,7 @@ export async function renderRankings(
   if (displayRankings.length === 0) {
     let message: string;
     if (searchTerm) {
-      const escaped = citySearch.value.trim().replace(/</g, '&lt;').replace(/>/g, '&gt;');
+      const escaped = escapeHtml(citySearch.value.trim());
       message = `No cities match '${escaped}'`;
     } else if (selectedCountries.length > 0) {
       message = 'No cities match your filters';
@@ -543,7 +544,7 @@ export function showError(rankingsContent: HTMLElement, errorMessage: string): v
   rankingsContent.innerHTML = `
     <div class="empty-state" role="alert" aria-live="assertive">
       <p>Failed to load data</p>
-      <p class="error-detail">${errorMessage}</p>
+      <p class="error-detail">${escapeHtml(errorMessage)}</p>
     </div>
   `;
 }

--- a/src/frontend/trailers.ts
+++ b/src/frontend/trailers.ts
@@ -11,6 +11,7 @@ import {
   pickBestTrailer, trailerTotalHV, formatTrailerSpec,
   type AllData, type Lookups, type Cargo, type Trailer,
 } from './data';
+import { escapeHtml } from './utils';
 
 let data: AllData | null = null;
 let lookups: Lookups | null = null;
@@ -183,7 +184,7 @@ function renderList(filter = ''): void {
   const totalCargo = data.cargo.filter((c) => !c.excluded).length;
 
   if (filtered.length === 0) {
-    const escaped = filter.replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    const escaped = escapeHtml(filter);
     content.innerHTML = filter
       ? `<div class="empty-state">No body types found matching "${escaped}".</div>`
       : '<div class="empty-state">No trailer data found.</div>';
@@ -594,7 +595,7 @@ async function init(): Promise<void> {
     content.innerHTML = `
       <div class="empty-state" role="alert">
         <p>Failed to load data</p>
-        <p class="error-detail">${message}</p>
+        <p class="error-detail">${escapeHtml(message)}</p>
       </div>
     `;
   }

--- a/src/frontend/utils.ts
+++ b/src/frontend/utils.ts
@@ -134,3 +134,15 @@ export function titleCase(gameId: string): string {
 export function getOwnableTrailers(data: { trailers: Trailer[] }): Trailer[] {
   return data.trailers.filter((t) => t.ownable);
 }
+
+/**
+ * Escape HTML special characters to prevent XSS when interpolating into innerHTML.
+ */
+export function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}


### PR DESCRIPTION
## Summary
- Add `escapeHtml()` to utils.ts handling &, <, >, ", '
- Replace 5 inline `.replace(/</g, '&lt;').replace(/>/g, '&gt;')` patterns with escapeHtml()
- Fix showError() XSS: escape error message before innerHTML interpolation
- Fix 4 catch block error messages (cargo, cities, companies, trailers) with escapeHtml()
- Add 7 tests for escapeHtml() covering all special characters

Closes #178