### PR TITLE
perf: cache rankings, localStorage state, parallelize comparison

### DIFF
--- a/src/frontend/__tests__/storage.test.ts
+++ b/src/frontend/__tests__/storage.test.ts
@@ -18,6 +18,7 @@ describe('storage', () => {
   beforeEach(() => {
     localStorageMock.clear();
     vi.clearAllMocks();
+    storage._resetStateCache();
   });
 
   describe('loadState', () => {

--- a/src/frontend/comparison-view.ts
+++ b/src/frontend/comparison-view.ts
@@ -50,25 +50,28 @@ export async function renderComparison(
 
   container.innerHTML = '<div class="empty-state">Loading comparison...</div>';
 
-  // Gather data for each city
-  const cities: CityComparisonData[] = [];
-  for (const cityId of cityIds) {
-    const ranking = state.cachedRankings?.find(r => r.id === cityId);
-    if (!ranking) continue;
+  // Gather data for each city — fleet computations run in parallel
+  const cities: CityComparisonData[] = (
+    await Promise.all(
+      cityIds.map(async (cityId) => {
+        const ranking = state.cachedRankings?.find(r => r.id === cityId);
+        if (!ranking) return null;
 
-    const fleet = await computeFleetAsync(cityId, state.data, state.lookups);
+        const fleet = await computeFleetAsync(cityId, state.data, state.lookups);
 
-    const globalIndex = state.cachedRankings!.findIndex(r => r.id === cityId);
-    const tier = getScoreTier(globalIndex >= 0 ? globalIndex : 0, state.cachedRankings!.length);
+        const globalIndex = state.cachedRankings!.findIndex(r => r.id === cityId);
+        const tier = getScoreTier(globalIndex >= 0 ? globalIndex : 0, state.cachedRankings!.length);
 
-    cities.push({
-      ranking,
-      fleet,
-      depotCount: ranking.depotCount,
-      tierLabel: tier.label ? tier.label.split(' \u2014 ')[0] : '',
-      tierClass: tier.className,
-    });
-  }
+        return {
+          ranking,
+          fleet,
+          depotCount: ranking.depotCount,
+          tierLabel: tier.label ? tier.label.split(' \u2014 ')[0] : '',
+          tierClass: tier.className,
+        } satisfies CityComparisonData;
+      }),
+    )
+  ).filter((c): c is CityComparisonData => c !== null);
 
   if (cities.length < 2) {
     container.innerHTML = '<div class="empty-state">Could not load data for selected cities.</div>';

--- a/src/frontend/rankings-view.ts
+++ b/src/frontend/rankings-view.ts
@@ -273,7 +273,7 @@ export async function renderRankings(
   resultsCount: HTMLElement,
   showCity: (cityId: string) => void,
 ): Promise<void> {
-  const rankings = await computeRankingsAsync(state.data, state.lookups);
+  const rankings = state.cachedRankings ?? await computeRankingsAsync(state.data, state.lookups);
   state.cachedRankings = rankings;
 
   if (rankings.length === 0) {

--- a/src/frontend/storage.ts
+++ b/src/frontend/storage.ts
@@ -40,6 +40,15 @@ interface AppState {
 
 const LEGACY_COUNTRIES_KEY = 'ets2-selected-countries';
 
+// Module-level cache — avoids repeated JSON.parse on every loadState() call.
+// Invalidated by saveState(). Exported for test reset only.
+let _cachedState: AppState | null = null;
+
+/** @internal — reset in-memory cache; for use in tests only */
+export function _resetStateCache(): void {
+  _cachedState = null;
+}
+
 const defaultState: AppState = {
   settings: {
     driverCount: 5,
@@ -54,9 +63,11 @@ const defaultState: AppState = {
 };
 
 /**
- * Load state from localStorage
+ * Load state from localStorage.
+ * Result is cached in-memory; cache is invalidated by saveState().
  */
 export function loadState(): AppState {
+  if (_cachedState !== null) return _cachedState;
   try {
     const stored = localStorage.getItem(STORAGE_KEY);
     if (stored) {
@@ -86,18 +97,22 @@ export function loadState(): AppState {
           saveState(state);
         }
       }
+      _cachedState = state;
       return state;
     }
   } catch (e) {
     console.warn('Failed to load state from localStorage:', e);
   }
-  return { ...defaultState };
+  const fallback = { ...defaultState };
+  _cachedState = fallback;
+  return fallback;
 }
 
 /**
- * Save state to localStorage
+ * Save state to localStorage and invalidate the in-memory cache.
  */
 export function saveState(state: AppState): void {
+  _cachedState = state;
   try {
     localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
   } catch (e) {


### PR DESCRIPTION
## Summary

- **Rankings cache**: `renderRankings` now reuses `state.cachedRankings` when available — search/filter keystrokes no longer re-invoke `computeRankingsAsync`
- **localStorage cache**: `loadState()` caches the parsed result in a module-level variable; `saveState()` keeps the cache warm; eliminates 4+ `JSON.parse` calls per render cycle
- **Parallel fleet fetch**: `comparison-view` replaces a sequential `await`-in-loop with `Promise.all`, so fleet computations for all compared cities run concurrently

## Test plan

- [x] `npm run lint` — passes (no type errors)
- [x] `npm run test` — 183/183 tests pass (storage tests updated to reset in-memory cache in `beforeEach`)

Closes #181