### PR TITLE
fix: keyboard-focusable tooltips and consistent garage labels

### DIFF
--- a/src/frontend/city-detail-view.ts
+++ b/src/frontend/city-detail-view.ts
@@ -16,7 +16,7 @@ import { copyToClipboard } from './clipboard.js';
 import { normalize } from './data.js';
 import type { AllData, Lookups } from './data.js';
 import {
-  formatNumber, getScoreTier, getCityRank, formatRank,
+  formatNumber, getScoreTier, getCityRank, formatRank, updateGarageCount,
   type RankingsState, type ScoreTier,
 } from './rankings-view.js';
 
@@ -103,7 +103,7 @@ export async function renderCity(
       </div>
       <div class="empty-state">No cargo data for this city yet.</div>
     `;
-    wireGarageToggle(cityId, rankingsContent);
+    wireGarageToggle(cityId, rankingsContent, state, citySearch);
     return;
   }
 
@@ -185,7 +185,7 @@ export async function renderCity(
     </div>
   `;
 
-  wireGarageToggle(cityId, rankingsContent);
+  wireGarageToggle(cityId, rankingsContent, state, citySearch);
   wireCopyFleetButton(city.name, optimal.drivers);
   wireExportButtons(city.name, optimal.drivers, depotCount, cargoTypes, score);
 }
@@ -300,7 +300,12 @@ function wireExportButtons(
 // Garage toggle in city detail
 // ============================================
 
-function wireGarageToggle(cityId: string, rankingsContent: HTMLElement) {
+function wireGarageToggle(
+  cityId: string,
+  rankingsContent: HTMLElement,
+  state: { data: AllData; lookups: Lookups },
+  citySearch: HTMLInputElement,
+) {
   const garageToggle = document.getElementById('city-garage-toggle');
   if (garageToggle) {
     garageToggle.addEventListener('click', () => {
@@ -313,13 +318,14 @@ function wireGarageToggle(cityId: string, rankingsContent: HTMLElement) {
       const rankingStar = rankingsContent.querySelector(`.garage-star[data-city-id="${cityId}"]`) as HTMLElement | null;
       if (rankingStar) {
         rankingStar.textContent = nowOwned ? '\u2605' : '\u2606';
-        rankingStar.title = nowOwned ? 'Remove garage' : 'Mark as garage';
+        const cityName = rankingStar.closest('tr')!.querySelector('td:nth-child(3)')!.textContent!;
+        rankingStar.title = `${nowOwned ? 'Remove garage for' : 'Mark as garage for'} ${cityName}`;
+        rankingStar.setAttribute('aria-label', `${nowOwned ? 'Remove garage for' : 'Mark as garage for'} ${cityName}`);
         const row = rankingStar.closest('tr')!;
         row.classList.toggle('owned-garage', nowOwned);
       }
-      // Update garage count badge
-      document.getElementById('garage-count')!.textContent =
-        getOwnedGarages().length.toString();
+      // Update garage count badge using filtered count (consistent with rankings view)
+      updateGarageCount(state.data, state.lookups, citySearch);
     });
   }
 }

--- a/src/frontend/rankings-view.ts
+++ b/src/frontend/rankings-view.ts
@@ -231,7 +231,7 @@ function renderCountryCheckboxes(data: AllData, renderRankings: () => void) {
 // Garage count badge
 // ============================================
 
-function updateGarageCount(data: AllData, lookups: Lookups, citySearch: HTMLInputElement) {
+export function updateGarageCount(data: AllData, lookups: Lookups, citySearch: HTMLInputElement) {
   const ownedGarages = getOwnedGarages();
   const searchTerm = normalize(citySearch.value);
   const selectedCountries = getSelectedCountries();
@@ -328,11 +328,11 @@ export async function renderRankings(
               <th>#</th>
               <th>City</th>
               <th>Country</th>
-              <th class="tooltip" data-tooltip="Company facilities in this city">Depots</th>
-              <th class="tooltip" data-tooltip="Distinct cargo types available">Cargo</th>
-              <th class="tooltip" data-tooltip="Sum of top 5 body type EVs \u2014 fleet earning potential">Fleet EV</th>
-              <th class="tooltip" data-tooltip="Top earning trailer types for this city">Best Trailers</th>
-              <th class="compare-col tooltip" data-tooltip="Select cities to compare side by side">Cmp</th>
+              <th class="tooltip" tabindex="0" data-tooltip="Company facilities in this city">Depots</th>
+              <th class="tooltip" tabindex="0" data-tooltip="Distinct cargo types available">Cargo</th>
+              <th class="tooltip" tabindex="0" data-tooltip="Sum of top 5 body type EVs \u2014 fleet earning potential">Fleet EV</th>
+              <th class="tooltip" tabindex="0" data-tooltip="Top earning trailer types for this city">Best Trailers</th>
+              <th class="compare-col tooltip" tabindex="0" data-tooltip="Select cities to compare side by side">Cmp</th>
             </tr>
           </thead>
           <tbody>
@@ -357,11 +357,11 @@ export async function renderRankings(
             <th>#</th>
             <th>City</th>
             <th>Country</th>
-            <th class="tooltip" data-tooltip="Company facilities in this city">Depots</th>
-            <th class="tooltip" data-tooltip="Distinct cargo types available">Cargo</th>
-            <th class="tooltip" data-tooltip="Sum of top 5 body type EVs \u2014 fleet earning potential">Fleet EV</th>
-            <th class="tooltip" data-tooltip="Top earning trailer types for this city">Best Trailers</th>
-            <th class="compare-col tooltip" data-tooltip="Select cities to compare side by side">Cmp</th>
+            <th class="tooltip" tabindex="0" data-tooltip="Company facilities in this city">Depots</th>
+            <th class="tooltip" tabindex="0" data-tooltip="Distinct cargo types available">Cargo</th>
+            <th class="tooltip" tabindex="0" data-tooltip="Sum of top 5 body type EVs \u2014 fleet earning potential">Fleet EV</th>
+            <th class="tooltip" tabindex="0" data-tooltip="Top earning trailer types for this city">Best Trailers</th>
+            <th class="compare-col tooltip" tabindex="0" data-tooltip="Select cities to compare side by side">Cmp</th>
           </tr>
         </thead>
         <tbody>
@@ -373,7 +373,7 @@ export async function renderRankings(
             const checked = comparisonSet.has(r.id);
             return `
             <tr class="clickable${starred ? ' owned-garage' : ''}" data-city-id="${r.id}" tabindex="0">
-              <td class="garage-star" data-city-id="${r.id}" title="${starred ? 'Remove garage' : 'Mark as garage'}" tabindex="0" role="button" aria-label="${starred ? 'Remove garage for' : 'Toggle garage for'} ${r.name}">${starred ? '\u2605' : '\u2606'}</td>
+              <td class="garage-star" data-city-id="${r.id}" title="${starred ? 'Remove garage for' : 'Mark as garage for'} ${r.name}" tabindex="0" role="button" aria-label="${starred ? 'Remove garage for' : 'Mark as garage for'} ${r.name}">${starred ? '\u2605' : '\u2606'}</td>
               <td>${i + 1}</td>
               <td>${r.name}</td>
               <td class="country">${r.country}</td>
@@ -399,9 +399,9 @@ export async function renderRankings(
       const cityId = el.dataset.cityId!;
       const nowOwned = toggleOwnedGarage(cityId);
       el.textContent = nowOwned ? '\u2605' : '\u2606';
-      el.title = nowOwned ? 'Remove garage' : 'Mark as garage';
       const cityName = el.closest('tr')!.querySelector('td:nth-child(3)')!.textContent!;
-      el.setAttribute('aria-label', `${nowOwned ? 'Remove garage for' : 'Toggle garage for'} ${cityName}`);
+      el.title = `${nowOwned ? 'Remove garage for' : 'Mark as garage for'} ${cityName}`;
+      el.setAttribute('aria-label', `${nowOwned ? 'Remove garage for' : 'Mark as garage for'} ${cityName}`);
       const row = el.closest('tr')!;
       row.classList.toggle('owned-garage', nowOwned);
       updateGarageCount(state.data, state.lookups, citySearch);


### PR DESCRIPTION
## Summary
- Add `tabindex="0"` to all 10 `th.tooltip` elements so tooltip content is accessible via keyboard (Tab + focus)
- Unify garage star `title` and `aria-label` to consistent "Mark as garage for [city]" / "Remove garage for [city]"
- City detail view now uses filter-aware `updateGarageCount()` instead of raw `getOwnedGarages().length`

## Test plan
- [ ] Tab through rankings table headers — tooltips should appear on focus
- [ ] Toggle a garage star — verify title and aria-label both say "Mark/Remove garage for [city]"
- [ ] With a search filter active, toggle garage in city detail — badge count should reflect filtered view

Closes #183