### PR TITLE
feat: add column sorting to rankings table

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1114,6 +1114,26 @@ tr:last-child td {
   border-bottom: none;
 }
 
+/* Sortable column headers */
+th.sortable {
+  cursor: pointer;
+  user-select: none;
+}
+
+/* Sortable tooltips override the default cursor:help on .tooltip */
+th.sortable.tooltip {
+  cursor: pointer;
+}
+
+th.sortable:hover {
+  background: var(--accent-overlay);
+  color: var(--accent);
+}
+
+th.sort-active {
+  color: var(--accent);
+}
+
 tr.clickable {
   cursor: pointer;
   transition: background-color 0.15s ease;

--- a/src/frontend/__tests__/storage.test.ts
+++ b/src/frontend/__tests__/storage.test.ts
@@ -34,6 +34,8 @@ describe('storage', () => {
         ownedTrailerDLCs: [],
         ownedCargoDLCs: [],
         ownedMapDLCs: [],
+        sortColumn: 'score',
+        sortDirection: 'desc',
       });
     });
 

--- a/src/frontend/rankings-view.ts
+++ b/src/frontend/rankings-view.ts
@@ -11,6 +11,8 @@ import {
   getOwnedGarages, toggleOwnedGarage,
   getFilterMode, setFilterMode,
   getSelectedCountries, setSelectedCountries,
+  getSortColumn, getSortDirection, setSortPreference,
+  type SortColumn, type SortDirection,
 } from './storage.js';
 import { normalize } from './data.js';
 import { escapeHtml } from './utils.js';
@@ -266,6 +268,65 @@ function summarizeTrailers(fleet: FleetEntry[]): string {
   return fleet.map(e => e.displayName).join(', ');
 }
 
+// ============================================
+// Sorting
+// ============================================
+
+const SORTABLE_COLUMNS: { col: SortColumn; label: string; tooltip?: string }[] = [
+  { col: 'name', label: 'City' },
+  { col: 'country', label: 'Country' },
+  { col: 'depotCount', label: 'Depots', tooltip: 'Company facilities in this city' },
+  { col: 'cargoTypes', label: 'Cargo', tooltip: 'Distinct cargo types available' },
+  { col: 'score', label: 'Fleet EV', tooltip: 'Sum of top 5 body type EVs \u2014 fleet earning potential' },
+];
+
+function sortRankings(rankings: CityRanking[], col: SortColumn, dir: SortDirection): CityRanking[] {
+  return [...rankings].sort((a, b) => {
+    let cmp: number;
+    if (col === 'name' || col === 'country') {
+      cmp = a[col].localeCompare(b[col]);
+    } else {
+      cmp = a[col] - b[col];
+    }
+    return dir === 'asc' ? cmp : -cmp;
+  });
+}
+
+function buildSortableHeader(col: SortColumn, activeSortCol: SortColumn, activeSortDir: SortDirection): string {
+  const meta = SORTABLE_COLUMNS.find(c => c.col === col)!;
+  const isActive = activeSortCol === col;
+  const indicator = isActive ? (activeSortDir === 'asc' ? ' \u25b2' : ' \u25bc') : '';
+  const tooltipClass = meta.tooltip ? ' tooltip' : '';
+  const tooltipAttr = meta.tooltip ? ` data-tooltip="${meta.tooltip}"` : '';
+  return `<th class="sortable${tooltipClass}${isActive ? ' sort-active' : ''}" tabindex="0" data-sort-col="${col}"${tooltipAttr}>${meta.label}${indicator}</th>`;
+}
+
+function attachSortHandlers(
+  container: HTMLElement,
+  state: RankingsState,
+  rankingsContent: HTMLElement,
+  citySearch: HTMLInputElement,
+  resultsCount: HTMLElement,
+  showCity: (cityId: string) => void,
+): void {
+  container.querySelectorAll('th.sortable').forEach((th) => {
+    th.addEventListener('click', () => {
+      const col = (th as HTMLElement).dataset.sortCol as SortColumn;
+      const currentCol = getSortColumn();
+      const currentDir = getSortDirection();
+      let newDir: SortDirection;
+      if (col === currentCol) {
+        newDir = currentDir === 'asc' ? 'desc' : 'asc';
+      } else {
+        // Numeric columns default desc, alpha columns default asc
+        newDir = (col === 'name' || col === 'country') ? 'asc' : 'desc';
+      }
+      setSortPreference(col, newDir);
+      renderRankings(state, rankingsContent, citySearch, resultsCount, showCity);
+    });
+  });
+}
+
 export async function renderRankings(
   state: RankingsState,
   rankingsContent: HTMLElement,
@@ -295,7 +356,12 @@ export async function renderRankings(
 
   const filterMode = getFilterMode();
   const ownedSet = new Set(getOwnedGarages());
-  const displayRankings = filterMode === 'owned' ? filtered.filter((r) => ownedSet.has(r.id)) : filtered;
+  const filteredByMode = filterMode === 'owned' ? filtered.filter((r) => ownedSet.has(r.id)) : filtered;
+
+  // Apply sort after filtering
+  const sortCol = getSortColumn();
+  const sortDir = getSortDirection();
+  const displayRankings = sortRankings(filteredByMode, sortCol, sortDir);
   state.displayedRankings = displayRankings;
 
   if (filterMode === 'owned' && displayRankings.length === 0) {
@@ -326,11 +392,11 @@ export async function renderRankings(
             <tr>
               <th></th>
               <th>#</th>
-              <th>City</th>
-              <th>Country</th>
-              <th class="tooltip" tabindex="0" data-tooltip="Company facilities in this city">Depots</th>
-              <th class="tooltip" tabindex="0" data-tooltip="Distinct cargo types available">Cargo</th>
-              <th class="tooltip" tabindex="0" data-tooltip="Sum of top 5 body type EVs \u2014 fleet earning potential">Fleet EV</th>
+              ${buildSortableHeader('name', sortCol, sortDir)}
+              ${buildSortableHeader('country', sortCol, sortDir)}
+              ${buildSortableHeader('depotCount', sortCol, sortDir)}
+              ${buildSortableHeader('cargoTypes', sortCol, sortDir)}
+              ${buildSortableHeader('score', sortCol, sortDir)}
               <th class="tooltip" tabindex="0" data-tooltip="Top earning trailer types for this city">Best Trailers</th>
               <th class="compare-col tooltip" tabindex="0" data-tooltip="Select cities to compare side by side">Cmp</th>
             </tr>
@@ -341,6 +407,7 @@ export async function renderRankings(
         </table>
       </div>
     `;
+    attachSortHandlers(rankingsContent, state, rankingsContent, citySearch, resultsCount, showCity);
     updateGarageCount(state.data, state.lookups, citySearch);
     updateResultsCount(resultsCount, 0, rankings.length);
     return;
@@ -355,11 +422,11 @@ export async function renderRankings(
           <tr>
             <th></th>
             <th>#</th>
-            <th>City</th>
-            <th>Country</th>
-            <th class="tooltip" tabindex="0" data-tooltip="Company facilities in this city">Depots</th>
-            <th class="tooltip" tabindex="0" data-tooltip="Distinct cargo types available">Cargo</th>
-            <th class="tooltip" tabindex="0" data-tooltip="Sum of top 5 body type EVs \u2014 fleet earning potential">Fleet EV</th>
+            ${buildSortableHeader('name', sortCol, sortDir)}
+            ${buildSortableHeader('country', sortCol, sortDir)}
+            ${buildSortableHeader('depotCount', sortCol, sortDir)}
+            ${buildSortableHeader('cargoTypes', sortCol, sortDir)}
+            ${buildSortableHeader('score', sortCol, sortDir)}
             <th class="tooltip" tabindex="0" data-tooltip="Top earning trailer types for this city">Best Trailers</th>
             <th class="compare-col tooltip" tabindex="0" data-tooltip="Select cities to compare side by side">Cmp</th>
           </tr>
@@ -446,6 +513,7 @@ export async function renderRankings(
     });
   });
 
+  attachSortHandlers(rankingsContent, state, rankingsContent, citySearch, resultsCount, showCity);
   updateCompareBar();
   updateGarageCount(state.data, state.lookups, citySearch);
   updateResultsCount(resultsCount, displayRankings.length, rankings.length);

--- a/src/frontend/storage.ts
+++ b/src/frontend/storage.ts
@@ -27,6 +27,9 @@ interface Settings {
   driverCount: number;
 }
 
+export type SortColumn = 'name' | 'country' | 'depotCount' | 'cargoTypes' | 'score';
+export type SortDirection = 'asc' | 'desc';
+
 interface AppState {
   settings: Settings;
   ownedGarages: string[];
@@ -36,6 +39,8 @@ interface AppState {
   ownedTrailerDLCs: string[];              // DLC brand IDs the user owns
   ownedCargoDLCs: string[];               // Cargo DLC pack IDs the user owns
   ownedMapDLCs: string[];                 // Map expansion DLC IDs the user owns
+  sortColumn: SortColumn;
+  sortDirection: SortDirection;
 }
 
 const LEGACY_COUNTRIES_KEY = 'ets2-selected-countries';
@@ -60,6 +65,8 @@ const defaultState: AppState = {
   ownedTrailerDLCs: [],  // none owned by default — first-time visitors configure on DLC page
   ownedCargoDLCs: [],   // none owned by default
   ownedMapDLCs: [],     // none owned by default
+  sortColumn: 'score',
+  sortDirection: 'desc',
 };
 
 /**
@@ -83,6 +90,8 @@ export function loadState(): AppState {
         ownedTrailerDLCs: parsed.ownedTrailerDLCs ?? [...ALL_DLC_IDS],
         ownedCargoDLCs: parsed.ownedCargoDLCs ?? [...ALL_CARGO_DLC_IDS],
         ownedMapDLCs: parsed.ownedMapDLCs ?? [...ALL_MAP_DLC_IDS],
+        sortColumn: parsed.sortColumn ?? defaultState.sortColumn,
+        sortDirection: parsed.sortDirection ?? defaultState.sortDirection,
       };
       // Migrate legacy settings
       if (parsed.settings?.maxTrailers && !parsed.settings?.driverCount) {
@@ -352,6 +361,25 @@ export function toggleMapDLC(dlcId: string): boolean {
   }
   saveState(state);
   return idx < 0;
+}
+
+// ============================================
+// Sort Preference Management
+// ============================================
+
+export function getSortColumn(): SortColumn {
+  return loadState().sortColumn ?? 'score';
+}
+
+export function getSortDirection(): SortDirection {
+  return loadState().sortDirection ?? 'desc';
+}
+
+export function setSortPreference(column: SortColumn, direction: SortDirection): void {
+  const state = loadState();
+  state.sortColumn = column;
+  state.sortDirection = direction;
+  saveState(state);
 }
 
 // ============================================


### PR DESCRIPTION
## Summary

- Adds clickable sort to City, Country, Depots, Cargo, and Fleet EV columns
- Click header to sort; click again to toggle ascending/descending
- Active sort column shows ▲ or ▼ indicator appended to header text
- Default sort: Fleet EV descending (preserves current behavior)
- Sort preference persisted in localStorage (`sortColumn`/`sortDirection`)
- Sort applied after filtering (search + country + garage mode), before render
- Row `#` numbering reflects the current sort order
- Sortable headers with tooltip still show tooltip on hover; `cursor: pointer` overrides `cursor: help`

## Test plan

- [ ] Click Fleet EV header — already sorted desc, toggles to asc
- [ ] Click City header — sorts alpha asc, click again → desc
- [ ] Click Country, Depots, Cargo — each sorts correctly with toggle
- [ ] Search/filter then sort — sort applies to filtered subset
- [ ] Reload page — sort preference is restored from localStorage
- [ ] Depots/Cargo/Fleet EV headers still show tooltip on hover
- [ ] `npm run lint && npm run test` both pass

Closes #67