### PR TITLE
refactor: type safety and code cleanup

### DIFF
--- a/src/frontend/city-detail-view.ts
+++ b/src/frontend/city-detail-view.ts
@@ -14,7 +14,6 @@ import {
 } from './storage.js';
 import { copyToClipboard } from './clipboard.js';
 import { normalize } from './data.js';
-import type { AllData, Lookups } from './data.js';
 import {
   formatNumber, getScoreTier, getCityRank, formatRank, updateGarageCount,
   type RankingsState, type ScoreTier,
@@ -78,6 +77,11 @@ export async function renderCity(
   citySearch: HTMLInputElement,
 ): Promise<void> {
   await ensureRankingsCached(state, citySearch);
+
+  if (!state.lookups || !state.data) {
+    cityContent.innerHTML = '<div class="empty-state">Data not yet loaded.</div>';
+    return;
+  }
 
   const city = state.lookups.citiesById.get(cityId);
   if (!city) {
@@ -303,7 +307,7 @@ function wireExportButtons(
 function wireGarageToggle(
   cityId: string,
   rankingsContent: HTMLElement,
-  state: { data: AllData; lookups: Lookups },
+  state: RankingsState,
   citySearch: HTMLInputElement,
 ) {
   const garageToggle = document.getElementById('city-garage-toggle');
@@ -325,7 +329,7 @@ function wireGarageToggle(
         row.classList.toggle('owned-garage', nowOwned);
       }
       // Update garage count badge using filtered count (consistent with rankings view)
-      updateGarageCount(state.data, state.lookups, citySearch);
+      if (state.data && state.lookups) updateGarageCount(state.data, state.lookups, citySearch);
     });
   }
 }

--- a/src/frontend/comparison-view.ts
+++ b/src/frontend/comparison-view.ts
@@ -48,7 +48,14 @@ export async function renderComparison(
     return;
   }
 
+  if (!state.data || !state.lookups) {
+    container.innerHTML = '<div class="empty-state">Data not yet loaded.</div>';
+    return;
+  }
+
   container.innerHTML = '<div class="empty-state">Loading comparison...</div>';
+
+  const { data, lookups } = state;
 
   // Gather data for each city — fleet computations run in parallel
   const cities: CityComparisonData[] = (
@@ -57,7 +64,7 @@ export async function renderComparison(
         const ranking = state.cachedRankings?.find(r => r.id === cityId);
         if (!ranking) return null;
 
-        const fleet = await computeFleetAsync(cityId, state.data, state.lookups);
+        const fleet = await computeFleetAsync(cityId, data, lookups);
 
         const globalIndex = state.cachedRankings!.findIndex(r => r.id === cityId);
         const tier = getScoreTier(globalIndex >= 0 ? globalIndex : 0, state.cachedRankings!.length);

--- a/src/frontend/dlc-data.ts
+++ b/src/frontend/dlc-data.ts
@@ -314,11 +314,17 @@ export interface DlcSection {
   garage_cities: string[];
 }
 
+let _dlcInitialized = false;
+
 /**
  * Override fallback DLC data with live data from game-defs.json.
  * Called by loadAllData() when the dlc section exists.
+ * Idempotent — subsequent calls are ignored to prevent accidental re-initialization.
  */
 export function initDlcData(dlc: DlcSection): void {
+  if (_dlcInitialized) return;
+  _dlcInitialized = true;
+
   TRAILER_DLCS = dlc.trailer_dlcs;
   ALL_DLC_IDS = Object.keys(TRAILER_DLCS);
 

--- a/src/frontend/main.ts
+++ b/src/frontend/main.ts
@@ -11,12 +11,10 @@ import {
   isFirstVisit, isBannerDismissed, dismissBanner,
   isOnboardingCollapsed, setOnboardingCollapsed,
 } from './storage.js';
-import type { AllData, Lookups } from './data.js';
-import type { CityRanking } from './optimizer.js';
 import {
   renderRankings, initRankingsView,
   showLoading, showError,
-  getComparisonCityIds, clearComparison,
+  getComparisonCityIds,
   type RankingsState,
 } from './rankings-view.js';
 import { renderCity } from './city-detail-view.js';
@@ -27,10 +25,10 @@ import { renderComparison } from './comparison-view.js';
 // ============================================
 
 const state: RankingsState = {
-  data: null as unknown as AllData,
-  lookups: null as unknown as Lookups,
-  cachedRankings: null as CityRanking[] | null,
-  displayedRankings: null as CityRanking[] | null,
+  data: null,
+  lookups: null,
+  cachedRankings: null,
+  displayedRankings: null,
 };
 
 let currentCityId: string | null = null;

--- a/src/frontend/page-init.ts
+++ b/src/frontend/page-init.ts
@@ -22,14 +22,6 @@ export interface PageData {
 }
 
 /**
- * Load game data, apply DLC ownership filters, and build lookup maps.
- *
- * Every browser page calls this once at startup. The sequence is:
- * 1. loadAllData()       — fetch game-defs.json + observations.json
- * 2. applyDLCFilter()    — remove content from unowned DLCs
- * 3. buildLookups()      — build efficient access maps
- */
-/**
  * Wire up the theme toggle button (present in every page's nav).
  * Safe to call even if the button doesn't exist.
  */
@@ -51,6 +43,14 @@ export function initThemeToggle(): void {
   });
 }
 
+/**
+ * Load game data, apply DLC ownership filters, and build lookup maps.
+ *
+ * Every browser page calls this once at startup. The sequence is:
+ * 1. loadAllData()       — fetch game-defs.json + observations.json
+ * 2. applyDLCFilter()    — remove content from unowned DLCs
+ * 3. buildLookups()      — build efficient access maps
+ */
 export async function initPageData(): Promise<PageData> {
   const ownedCargoAndMap = new Set([...getOwnedCargoDLCs(), ...getOwnedMapDLCs()]);
   const blocked = getBlockedCities(getOwnedMapDLCs(), CITY_DLC_MAP);

--- a/src/frontend/rankings-view.ts
+++ b/src/frontend/rankings-view.ts
@@ -28,8 +28,8 @@ export interface ScoreTier {
 }
 
 export interface RankingsState {
-  data: AllData;
-  lookups: Lookups;
+  data: AllData | null;
+  lookups: Lookups | null;
   cachedRankings: CityRanking[] | null;
   displayedRankings: CityRanking[] | null;
 }
@@ -334,6 +334,7 @@ export async function renderRankings(
   resultsCount: HTMLElement,
   showCity: (cityId: string) => void,
 ): Promise<void> {
+  if (!state.data || !state.lookups) return;
   const rankings = state.cachedRankings ?? await computeRankingsAsync(state.data, state.lookups);
   state.cachedRankings = rankings;
 
@@ -408,7 +409,7 @@ export async function renderRankings(
       </div>
     `;
     attachSortHandlers(rankingsContent, state, rankingsContent, citySearch, resultsCount, showCity);
-    updateGarageCount(state.data, state.lookups, citySearch);
+    if (state.data && state.lookups) updateGarageCount(state.data, state.lookups, citySearch);
     updateResultsCount(resultsCount, 0, rankings.length);
     return;
   }
@@ -471,7 +472,7 @@ export async function renderRankings(
       el.setAttribute('aria-label', `${nowOwned ? 'Remove garage for' : 'Mark as garage for'} ${cityName}`);
       const row = el.closest('tr')!;
       row.classList.toggle('owned-garage', nowOwned);
-      updateGarageCount(state.data, state.lookups, citySearch);
+      if (state.data && state.lookups) updateGarageCount(state.data, state.lookups, citySearch);
     };
     star.addEventListener('click', toggleStar);
     star.addEventListener('keydown', (e) => {
@@ -515,7 +516,7 @@ export async function renderRankings(
 
   attachSortHandlers(rankingsContent, state, rankingsContent, citySearch, resultsCount, showCity);
   updateCompareBar();
-  updateGarageCount(state.data, state.lookups, citySearch);
+  if (state.data && state.lookups) updateGarageCount(state.data, state.lookups, citySearch);
   updateResultsCount(resultsCount, displayRankings.length, rankings.length);
 }
 
@@ -534,7 +535,7 @@ export function initRankingsView(
   const doRender = () => renderRankings(state, rankingsContent, citySearch, resultsCount, showCity);
 
   // Country checkboxes
-  renderCountryCheckboxes(state.data, doRender);
+  if (state.data) renderCountryCheckboxes(state.data, doRender);
   updateCountryButtonText();
 
   // Filter toggle (All / My Garages)
@@ -552,7 +553,7 @@ export function initRankingsView(
   filterToggle.querySelectorAll('.filter-btn').forEach((btn) => {
     btn.classList.toggle('active', btn.getAttribute('data-filter') === savedFilterMode);
   });
-  updateGarageCount(state.data, state.lookups, citySearch);
+  if (state.data && state.lookups) updateGarageCount(state.data, state.lookups, citySearch);
 
   // Country filter dropdown
   const countryFilterBtn = document.getElementById('country-filter-btn')!;


### PR DESCRIPTION
## Summary
- Eliminate `null as unknown as AllData` type casts — `RankingsState.data` and `.lookups` now properly nullable with null guards at all call sites
- Remove unused `clearComparison` import from main.ts
- Fix orphaned JSDoc comment in page-init.ts
- Add `_dlcInitialized` guard to `initDlcData()` for idempotent initialization

## Test plan
- [ ] All existing tests pass (183/183)
- [ ] App loads and renders rankings normally
- [ ] City detail, comparison, and DLC pages function correctly

Closes #184