### PR TITLE
fix: focus restoration race and back-link focus style

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1444,6 +1444,11 @@ a.link:hover {
   text-decoration: underline;
 }
 
+.back-link:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
 .detail-header {
   margin-bottom: 1.5rem;
 }

--- a/src/frontend/main.ts
+++ b/src/frontend/main.ts
@@ -125,14 +125,14 @@ async function showComparison() {
   window.scrollTo(0, 0);
 }
 
-function showRankings() {
+async function showRankings() {
   const restoreCityId = lastViewedCityId;
   currentCityId = null;
   cityView.style.display = 'none';
   if (compareView) compareView.style.display = 'none';
   rankingsView.style.display = 'block';
   window.location.hash = '';
-  renderRankings(state, rankingsContent, citySearch, resultsCount, showCity);
+  await renderRankings(state, rankingsContent, citySearch, resultsCount, showCity);
   if (restoreCityId) {
     const row = rankingsContent.querySelector(`tr[data-city-id="${restoreCityId}"]`) as HTMLElement | null;
     if (row) row.focus();


### PR DESCRIPTION
## Summary

- Make `showRankings` async and `await renderRankings` so focus restoration happens after the DOM rows exist (fixes race on cache miss)
- Add `.back-link:focus-visible` outline using `--accent` + 2px offset for keyboard navigation visibility

## Test plan

- [ ] `npm run lint` passes (TypeScript type check)
- [ ] `npm run test` passes (252 tests)
- [ ] Navigate to a city, then use back link — focus returns to the correct row in the rankings table
- [ ] Tab to back link and confirm focus ring is visible

Closes #197