### PR TITLE
fix: keyboard activation and aria-sort for sortable headers

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1130,6 +1130,11 @@ th.sortable:hover {
   color: var(--accent);
 }
 
+th.sortable:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
 th.sort-active {
   color: var(--accent);
 }

--- a/src/frontend/rankings-view.ts
+++ b/src/frontend/rankings-view.ts
@@ -298,7 +298,10 @@ function buildSortableHeader(col: SortColumn, activeSortCol: SortColumn, activeS
   const indicator = isActive ? (activeSortDir === 'asc' ? ' \u25b2' : ' \u25bc') : '';
   const tooltipClass = meta.tooltip ? ' tooltip' : '';
   const tooltipAttr = meta.tooltip ? ` data-tooltip="${meta.tooltip}"` : '';
-  return `<th class="sortable${tooltipClass}${isActive ? ' sort-active' : ''}" tabindex="0" data-sort-col="${col}"${tooltipAttr}>${meta.label}${indicator}</th>`;
+  const ariaSortAttr = isActive
+    ? ` aria-sort="${activeSortDir === 'asc' ? 'ascending' : 'descending'}"`
+    : ' aria-sort="none"';
+  return `<th class="sortable${tooltipClass}${isActive ? ' sort-active' : ''}" tabindex="0" data-sort-col="${col}"${ariaSortAttr}${tooltipAttr}>${meta.label}${indicator}</th>`;
 }
 
 function attachSortHandlers(
@@ -323,6 +326,12 @@ function attachSortHandlers(
       }
       setSortPreference(col, newDir);
       renderRankings(state, rankingsContent, citySearch, resultsCount, showCity);
+    });
+    th.addEventListener('keydown', (e) => {
+      if ((e as KeyboardEvent).key === 'Enter' || (e as KeyboardEvent).key === ' ') {
+        e.preventDefault();
+        (th as HTMLElement).click();
+      }
     });
   });
 }


### PR DESCRIPTION
## Summary
- Add `keydown` handler for Enter/Space on `th.sortable` elements for keyboard accessibility
- Add `aria-sort` attribute (ascending/descending/none) to all sortable headers for screen readers
- Add `th.sortable:focus-visible` CSS rule for visible focus indicator

## Test plan
- [ ] Tab to a sortable column header — visible focus ring appears
- [ ] Press Enter or Space — column sorts, ▲/▼ indicator updates
- [ ] Screen reader announces sort direction on focused header
- [ ] All 252 tests pass

Closes #196