### PR TITLE
fix: sort order in city detail, compare-winner theme, saveState clone

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -77,6 +77,7 @@
   --table-scroll-indicator: rgba(243, 156, 18, 0.3);
 
   --star-inactive: #9e9e9e;
+  --compare-winner-bg: rgba(46, 204, 113, 0.08);
 
   color-scheme: dark;
 }
@@ -154,6 +155,7 @@
   --table-scroll-indicator: rgba(168, 98, 0, 0.2);
 
   --star-inactive: #767676;
+  --compare-winner-bg: rgba(30, 132, 73, 0.1);
 
   color-scheme: light;
 }
@@ -2018,7 +2020,7 @@ tr.owned-garage {
 
 .compare-stat.compare-winner {
   border-left-color: var(--success);
-  background: rgba(46, 204, 113, 0.08);
+  background: var(--compare-winner-bg);
 }
 
 .compare-stat-value {

--- a/src/frontend/city-detail-view.ts
+++ b/src/frontend/city-detail-view.ts
@@ -11,11 +11,12 @@ import {
   getOwnedGarages, toggleOwnedGarage, isOwnedGarage,
   getFilterMode,
   getSelectedCountries,
+  getSortColumn, getSortDirection,
 } from './storage.js';
 import { copyToClipboard } from './clipboard.js';
 import { normalize } from './data.js';
 import {
-  formatNumber, getScoreTier, getCityRank, formatRank, updateGarageCount,
+  formatNumber, getScoreTier, getCityRank, formatRank, updateGarageCount, sortRankings,
   type RankingsState, type ScoreTier,
 } from './rankings-view.js';
 
@@ -42,7 +43,8 @@ async function ensureRankingsCached(
     }
     const filterMode = getFilterMode();
     const ownedSet = new Set(getOwnedGarages());
-    state.displayedRankings = filterMode === 'owned' ? filtered.filter((r) => ownedSet.has(r.id)) : filtered;
+    const filteredByMode = filterMode === 'owned' ? filtered.filter((r) => ownedSet.has(r.id)) : filtered;
+    state.displayedRankings = sortRankings(filteredByMode, getSortColumn(), getSortDirection());
   }
 }
 

--- a/src/frontend/rankings-view.ts
+++ b/src/frontend/rankings-view.ts
@@ -45,10 +45,6 @@ export function getComparisonCityIds(): string[] {
   return Array.from(comparisonSet);
 }
 
-export function clearComparison(): void {
-  comparisonSet.clear();
-}
-
 function toggleComparison(cityId: string): boolean {
   if (comparisonSet.has(cityId)) {
     comparisonSet.delete(cityId);
@@ -280,7 +276,7 @@ const SORTABLE_COLUMNS: { col: SortColumn; label: string; tooltip?: string }[] =
   { col: 'score', label: 'Fleet EV', tooltip: 'Sum of top 5 body type EVs \u2014 fleet earning potential' },
 ];
 
-function sortRankings(rankings: CityRanking[], col: SortColumn, dir: SortDirection): CityRanking[] {
+export function sortRankings(rankings: CityRanking[], col: SortColumn, dir: SortDirection): CityRanking[] {
   return [...rankings].sort((a, b) => {
     let cmp: number;
     if (col === 'name' || col === 'country') {
@@ -302,14 +298,13 @@ function buildSortableHeader(col: SortColumn, activeSortCol: SortColumn, activeS
 }
 
 function attachSortHandlers(
-  container: HTMLElement,
   state: RankingsState,
   rankingsContent: HTMLElement,
   citySearch: HTMLInputElement,
   resultsCount: HTMLElement,
   showCity: (cityId: string) => void,
 ): void {
-  container.querySelectorAll('th.sortable').forEach((th) => {
+  rankingsContent.querySelectorAll('th.sortable').forEach((th) => {
     th.addEventListener('click', () => {
       const col = (th as HTMLElement).dataset.sortCol as SortColumn;
       const currentCol = getSortColumn();
@@ -408,7 +403,7 @@ export async function renderRankings(
         </table>
       </div>
     `;
-    attachSortHandlers(rankingsContent, state, rankingsContent, citySearch, resultsCount, showCity);
+    attachSortHandlers(state, rankingsContent, citySearch, resultsCount, showCity);
     if (state.data && state.lookups) updateGarageCount(state.data, state.lookups, citySearch);
     updateResultsCount(resultsCount, 0, rankings.length);
     return;
@@ -514,7 +509,7 @@ export async function renderRankings(
     });
   });
 
-  attachSortHandlers(rankingsContent, state, rankingsContent, citySearch, resultsCount, showCity);
+  attachSortHandlers(state, rankingsContent, citySearch, resultsCount, showCity);
   updateCompareBar();
   if (state.data && state.lookups) updateGarageCount(state.data, state.lookups, citySearch);
   updateResultsCount(resultsCount, displayRankings.length, rankings.length);

--- a/src/frontend/storage.ts
+++ b/src/frontend/storage.ts
@@ -121,7 +121,7 @@ export function loadState(): AppState {
  * Save state to localStorage and invalidate the in-memory cache.
  */
 export function saveState(state: AppState): void {
-  _cachedState = state;
+  _cachedState = { ...state };
   try {
     localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
   } catch (e) {


### PR DESCRIPTION
## Summary
- `ensureRankingsCached` now applies active sort order (was showing unsorted ranks in city detail)
- Replace hardcoded `rgba(46, 204, 113, 0.08)` in `.compare-winner` with `--compare-winner-bg` CSS variable (theme-aware)
- `saveState` shallow-clones state to prevent reference-sharing cache corruption
- Remove redundant `container` parameter from `attachSortHandlers`
- Remove dead `clearComparison` export

## Test plan
- [ ] Sort by City name, open a city detail — rank badge matches visible sort order
- [ ] Light mode: compare-winner highlight visible (was nearly invisible)
- [ ] All 252 tests pass

Closes #201