### PR TITLE
fix: evict stale Vite JS bundles from SW cache on activate

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -31,17 +31,30 @@ self.addEventListener('install', (event) => {
 });
 
 self.addEventListener('activate', (event) => {
-  // Remove old cache versions
   event.waitUntil(
-    caches.keys().then((keys) =>
-      Promise.all(
-        keys
-          .filter((key) => key !== CACHE_NAME)
-          .map((key) => caches.delete(key))
-      )
-    )
+    (async () => {
+      // Remove old cache versions
+      const keys = await caches.keys();
+      await Promise.all(keys.filter((key) => key !== CACHE_NAME).map((key) => caches.delete(key)));
+
+      // Evict stale Vite JS bundles from the current cache.
+      // Vite outputs content-hashed filenames (e.g. main-Ab3Cd4Ef.js), so each
+      // deploy produces new URLs. Without cleanup the cache grows unboundedly with
+      // bundles from previous deploys that will never be requested again.
+      // HTML is served network-first, so on next load the page references new hashed
+      // filenames; evicting all hashed JS here ensures those new filenames are fetched
+      // fresh rather than hitting a mis-matched stale entry.
+      const cache = await caches.open(CACHE_NAME);
+      const requests = await cache.keys();
+      await Promise.all(
+        requests
+          .filter((req) => new URL(req.url).pathname.match(/\/assets\/.*-[a-zA-Z0-9]{8,}\.js$/))
+          .map((req) => cache.delete(req))
+      );
+
+      await self.clients.claim();
+    })()
   );
-  self.clients.claim();
 });
 
 self.addEventListener('fetch', (event) => {


### PR DESCRIPTION
## Summary

- On each SW `activate` event, scan `trucker-cache-v2` for entries matching Vite's content-hash JS pattern (`/assets/*-<8+hex>.js`) and delete them
- Old cache version cleanup (evicting `trucker-cache-v1`, etc.) is preserved as-is
- `self.clients.claim()` moved inside the async IIFE so it runs after cleanup completes

## Why this works without breaking offline

HTML is served **network-first**, so after a deploy the browser fetches fresh HTML referencing the new hashed filenames. The old hashed JS entries are evicted during SW activation before those new filenames are fetched, so they'll be cache-missed and fetched fresh then re-cached normally. No stale bundle is ever served.

## Test plan

- [ ] `npm run lint` passes (no TS errors)
- [ ] `npm run test` passes (252 tests)
- [ ] Deploy to prod, open DevTools → Application → Cache Storage: old `/assets/*.js` entries absent after SW activates
- [ ] Offline mode still serves HTML and CSS fallbacks

Closes #203