### PR TITLE
fix: tooltip AT accessibility, aria-controls, copy feedback

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -161,6 +161,22 @@
 }
 
 /* ============================================
+   Accessibility Utilities
+   ============================================ */
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* ============================================
    Base Styles
    ============================================ */
 

--- a/public/index.html
+++ b/public/index.html
@@ -30,7 +30,7 @@
     <main id="main-content">
     <div class="onboarding" id="onboarding">
       <div class="onboarding-header">
-        <button class="onboarding-toggle" id="onboarding-toggle" aria-expanded="true">
+        <button class="onboarding-toggle" id="onboarding-toggle" aria-expanded="true" aria-controls="onboarding-content">
           <span class="toggle-icon">▼</span>
           <h2>Getting Started</h2>
         </button>
@@ -81,7 +81,7 @@
 
     <div class="how-it-works collapsed">
       <div class="how-it-works-header">
-        <button class="how-it-works-toggle" id="how-it-works-toggle" aria-expanded="false">
+        <button class="how-it-works-toggle" id="how-it-works-toggle" aria-expanded="false" aria-controls="how-it-works-content">
           <span class="toggle-icon">▶</span>
           <h2>How It Works</h2>
         </button>

--- a/src/frontend/city-detail-view.ts
+++ b/src/frontend/city-detail-view.ts
@@ -179,8 +179,8 @@ export async function renderCity(
         <thead>
           <tr>
             <th>Trailer Type</th>
-            <th class="tooltip" data-tooltip="Expected value per job cycle">EV</th>
-            <th class="tooltip" data-tooltip="Cargo types this trailer can haul">Cargo</th>
+            <th class="tooltip" tabindex="0" data-tooltip="Expected value per job cycle" aria-label="EV \u2014 Expected value per job cycle">EV</th>
+            <th class="tooltip" tabindex="0" data-tooltip="Cargo types this trailer can haul" aria-label="Cargo \u2014 Cargo types this trailer can haul">Cargo</th>
           </tr>
         </thead>
         <tbody>

--- a/src/frontend/clipboard.ts
+++ b/src/frontend/clipboard.ts
@@ -12,17 +12,30 @@ export async function copyToClipboard(text: string, button: HTMLButtonElement): 
   const originalText = button.textContent;
   const originalClass = button.className;
 
+  // Find or create aria-live region for screen reader announcement
+  let liveRegion = document.getElementById('copy-status');
+  if (!liveRegion) {
+    liveRegion = document.createElement('span');
+    liveRegion.id = 'copy-status';
+    liveRegion.className = 'sr-only';
+    liveRegion.setAttribute('aria-live', 'polite');
+    document.body.appendChild(liveRegion);
+  }
+
   try {
     await navigator.clipboard.writeText(text);
     button.textContent = '\u2713 Copied!';
     button.classList.add('copy-success');
+    liveRegion.textContent = 'Copied to clipboard';
   } catch {
     button.textContent = 'Failed';
     button.classList.add('copy-fail');
+    liveRegion.textContent = 'Copy failed';
   }
 
   setTimeout(() => {
     button.textContent = originalText;
     button.className = originalClass;
+    liveRegion!.textContent = '';
   }, 2000);
 }

--- a/src/frontend/rankings-view.ts
+++ b/src/frontend/rankings-view.ts
@@ -294,10 +294,11 @@ function buildSortableHeader(col: SortColumn, activeSortCol: SortColumn, activeS
   const indicator = isActive ? (activeSortDir === 'asc' ? ' \u25b2' : ' \u25bc') : '';
   const tooltipClass = meta.tooltip ? ' tooltip' : '';
   const tooltipAttr = meta.tooltip ? ` data-tooltip="${meta.tooltip}"` : '';
+  const ariaLabel = meta.tooltip ? ` aria-label="${meta.label} \u2014 ${meta.tooltip}"` : '';
   const ariaSortAttr = isActive
     ? ` aria-sort="${activeSortDir === 'asc' ? 'ascending' : 'descending'}"`
     : ' aria-sort="none"';
-  return `<th class="sortable${tooltipClass}${isActive ? ' sort-active' : ''}" tabindex="0" data-sort-col="${col}"${ariaSortAttr}${tooltipAttr}>${meta.label}${indicator}</th>`;
+  return `<th class="sortable${tooltipClass}${isActive ? ' sort-active' : ''}" tabindex="0" data-sort-col="${col}"${ariaSortAttr}${tooltipAttr}${ariaLabel}>${meta.label}${indicator}</th>`;
 }
 
 function attachSortHandlers(
@@ -402,8 +403,8 @@ export async function renderRankings(
               ${buildSortableHeader('depotCount', sortCol, sortDir)}
               ${buildSortableHeader('cargoTypes', sortCol, sortDir)}
               ${buildSortableHeader('score', sortCol, sortDir)}
-              <th class="tooltip" tabindex="0" data-tooltip="Top earning trailer types for this city">Best Trailers</th>
-              <th class="compare-col tooltip" tabindex="0" data-tooltip="Select cities to compare side by side">Cmp</th>
+              <th class="tooltip" tabindex="0" data-tooltip="Top earning trailer types for this city" aria-label="Best Trailers \u2014 Top earning trailer types for this city">Best Trailers</th>
+              <th class="compare-col tooltip" tabindex="0" data-tooltip="Select cities to compare side by side" aria-label="Compare \u2014 Select cities to compare side by side">Cmp</th>
             </tr>
           </thead>
           <tbody>
@@ -432,8 +433,8 @@ export async function renderRankings(
             ${buildSortableHeader('depotCount', sortCol, sortDir)}
             ${buildSortableHeader('cargoTypes', sortCol, sortDir)}
             ${buildSortableHeader('score', sortCol, sortDir)}
-            <th class="tooltip" tabindex="0" data-tooltip="Top earning trailer types for this city">Best Trailers</th>
-            <th class="compare-col tooltip" tabindex="0" data-tooltip="Select cities to compare side by side">Cmp</th>
+            <th class="tooltip" tabindex="0" data-tooltip="Top earning trailer types for this city" aria-label="Best Trailers \u2014 Top earning trailer types for this city">Best Trailers</th>
+            <th class="compare-col tooltip" tabindex="0" data-tooltip="Select cities to compare side by side" aria-label="Compare \u2014 Select cities to compare side by side">Cmp</th>
           </tr>
         </thead>
         <tbody>


### PR DESCRIPTION
## Summary
- Add `aria-label` with tooltip text to all `th.tooltip` elements so screen readers announce tooltip definitions
- Add `tabindex="0"` to city-detail fleet table EV/Cargo headers for keyboard access
- Add `aria-controls` to onboarding and How It Works disclosure toggle buttons
- Add `aria-live="polite"` region for copy-to-clipboard screen reader announcement
- Add `.sr-only` CSS utility class for visually hidden but AT-accessible content

## Test plan
- [ ] Screen reader announces tooltip text when focusing table headers
- [ ] Tab reaches EV/Cargo headers in city detail fleet table
- [ ] Copy Fleet button announces "Copied to clipboard" to screen reader
- [ ] All 252 tests pass

Closes #200