### PR TITLE
feat: compare button in city detail for mobile access

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1868,6 +1868,24 @@ th.tooltip::before {
   outline-offset: 2px;
 }
 
+.city-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.compare-toggle {
+  font-size: 0.8rem;
+  padding: 0.3rem 0.7rem;
+  min-height: 44px;
+}
+
+.compare-toggle[aria-pressed="true"] {
+  background: var(--accent);
+  color: var(--accent-on);
+  border-color: var(--accent);
+}
+
 /* Garage star toggle */
 .garage-star {
   cursor: pointer;
@@ -1976,7 +1994,7 @@ tr.owned-garage {
   font-weight: 600;
   cursor: pointer;
   font-size: 0.9rem;
-  min-height: 36px;
+  min-height: 44px;
 }
 
 .compare-bar-go:hover {
@@ -1991,8 +2009,8 @@ tr.owned-garage {
   cursor: pointer;
   padding: 0.25rem;
   line-height: 1;
-  min-width: 36px;
-  min-height: 36px;
+  min-width: 44px;
+  min-height: 44px;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/frontend/city-detail-view.ts
+++ b/src/frontend/city-detail-view.ts
@@ -17,6 +17,7 @@ import { copyToClipboard } from './clipboard.js';
 import { normalize } from './data.js';
 import {
   formatNumber, getScoreTier, getCityRank, formatRank, updateGarageCount, sortRankings,
+  isInComparison, toggleComparison, updateCompareBar,
   type RankingsState, type ScoreTier,
 } from './rankings-view.js';
 
@@ -101,15 +102,21 @@ export async function renderCity(
             <h2>${city.name}</h2>
             <span class="country">${city.country}</span>
           </div>
-          <button class="garage-toggle" id="city-garage-toggle"
-            aria-pressed="${emptyOwned}" aria-label="${emptyOwned ? 'Remove garage' : 'Mark as garage'}"
-            title="${emptyOwned ? 'Remove garage' : 'Mark as garage'}"
-            data-city-id="${cityId}">${emptyOwned ? '\u2605' : '\u2606'}</button>
+          <div class="city-header-actions">
+            <button class="btn btn-sm compare-toggle" id="city-compare-toggle"
+              aria-pressed="${isInComparison(cityId)}"
+              data-city-id="${cityId}">${isInComparison(cityId) ? '\u2713 In Compare' : '+ Compare'}</button>
+            <button class="garage-toggle" id="city-garage-toggle"
+              aria-pressed="${emptyOwned}" aria-label="${emptyOwned ? 'Remove garage' : 'Mark as garage'}"
+              title="${emptyOwned ? 'Remove garage' : 'Mark as garage'}"
+              data-city-id="${cityId}">${emptyOwned ? '\u2605' : '\u2606'}</button>
+          </div>
         </div>
       </div>
       <div class="empty-state">No cargo data for this city yet.</div>
     `;
     wireGarageToggle(cityId, rankingsContent, state, citySearch);
+    wireCompareToggle(cityId);
     return;
   }
 
@@ -140,10 +147,15 @@ export async function renderCity(
           <h2>${city.name}</h2>
           <span class="country">${city.country}</span>
         </div>
-        <button class="garage-toggle" id="city-garage-toggle"
-          aria-pressed="${owned}" aria-label="${owned ? 'Remove garage' : 'Mark as garage'}"
-          title="${owned ? 'Remove garage' : 'Mark as garage'}"
-          data-city-id="${cityId}">${owned ? '\u2605' : '\u2606'}</button>
+        <div class="city-header-actions">
+          <button class="btn btn-sm compare-toggle" id="city-compare-toggle"
+            aria-pressed="${isInComparison(cityId)}"
+            data-city-id="${cityId}">${isInComparison(cityId) ? '\u2713 In Compare' : '+ Compare'}</button>
+          <button class="garage-toggle" id="city-garage-toggle"
+            aria-pressed="${owned}" aria-label="${owned ? 'Remove garage' : 'Mark as garage'}"
+            title="${owned ? 'Remove garage' : 'Mark as garage'}"
+            data-city-id="${cityId}">${owned ? '\u2605' : '\u2606'}</button>
+        </div>
       </div>
     </div>
 
@@ -192,6 +204,7 @@ export async function renderCity(
   `;
 
   wireGarageToggle(cityId, rankingsContent, state, citySearch);
+  wireCompareToggle(cityId);
   wireCopyFleetButton(city.name, optimal.drivers);
   wireExportButtons(city.name, optimal.drivers, depotCount, cargoTypes, score);
 }
@@ -334,4 +347,22 @@ function wireGarageToggle(
       if (state.data && state.lookups) updateGarageCount(state.data, state.lookups, citySearch);
     });
   }
+}
+
+// ============================================
+// Compare toggle in city detail
+// ============================================
+
+function wireCompareToggle(cityId: string) {
+  const btn = document.getElementById('city-compare-toggle') as HTMLButtonElement | null;
+  if (!btn) return;
+  btn.addEventListener('click', () => {
+    const added = toggleComparison(cityId);
+    btn.textContent = added ? '\u2713 In Compare' : '+ Compare';
+    btn.setAttribute('aria-pressed', String(added));
+    // Sync the rankings table checkbox if visible
+    const checkbox = document.querySelector(`.compare-check[data-city-id="${cityId}"]`) as HTMLInputElement | null;
+    if (checkbox) checkbox.checked = added;
+    updateCompareBar();
+  });
 }

--- a/src/frontend/rankings-view.ts
+++ b/src/frontend/rankings-view.ts
@@ -45,7 +45,11 @@ export function getComparisonCityIds(): string[] {
   return Array.from(comparisonSet);
 }
 
-function toggleComparison(cityId: string): boolean {
+export function isInComparison(cityId: string): boolean {
+  return comparisonSet.has(cityId);
+}
+
+export function toggleComparison(cityId: string): boolean {
   if (comparisonSet.has(cityId)) {
     comparisonSet.delete(cityId);
     return false;
@@ -55,7 +59,7 @@ function toggleComparison(cityId: string): boolean {
   return true;
 }
 
-function updateCompareBar() {
+export function updateCompareBar() {
   let bar = document.getElementById('compare-bar');
   const count = comparisonSet.size;
 


### PR DESCRIPTION
## Summary
- Add "Compare" toggle button in city detail header — works at all viewport sizes
- Mobile users can now: browse rankings → tap city → tap "+ Compare" → repeat → compare
- Button syncs with rankings table checkboxes and compare bar
- Fix compare bar button touch targets (36px → 44px, WCAG 2.5.5)

## Test plan
- [ ] Open city detail, tap "+ Compare" — button shows "✓ In Compare"
- [ ] Add 2+ cities, compare bar appears at bottom
- [ ] Tap "✓ In Compare" to remove — syncs with rankings checkbox
- [ ] Mobile (390px): compare flow works end-to-end without Cmp column
- [ ] Compare bar buttons: comfortable tap target on mobile

Closes #199