### PR TITLE
fix: move focus into city view on keyboard navigation

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -173,7 +173,7 @@
 
     <div id="city-view" style="display: none;">
       <button class="back-link" id="back-link" type="button">← Back to rankings</button>
-      <div id="city-content" aria-live="polite"></div>
+      <div id="city-content" aria-live="polite" tabindex="-1"></div>
     </div>
     </main>
   </div>

--- a/src/frontend/main.ts
+++ b/src/frontend/main.ts
@@ -110,6 +110,10 @@ async function showCity(cityId: string) {
   }
   await renderCity(cityId, state, cityContent, rankingsContent, citySearch);
   window.scrollTo(0, 0);
+  // Move focus into city view for keyboard users
+  const focusTarget = cityContent.querySelector('button, [tabindex]') as HTMLElement | null;
+  if (focusTarget) focusTarget.focus();
+  else cityContent.focus();
 }
 
 async function showComparison() {


### PR DESCRIPTION
## Summary
- After `renderCity()` resolves in `showCity()`, focus is moved to the first `button` or `[tabindex]` element inside `#city-content`, or `#city-content` itself as fallback
- Added `tabindex="-1"` to `#city-content` div in `index.html` so it can receive programmatic focus
- Keyboard users are no longer stranded on a hidden rankings row when opening city detail

## Test plan
- [ ] Open rankings, tab to a city row, press Enter — focus should land inside the city detail view
- [ ] `npm run lint` passes
- [ ] `npm run test` passes (252 tests)

Closes #212