### PR TITLE
fix: remove dead baseEVSum + deep-clone saveState cache

### DIFF
--- a/src/frontend/optimizer.ts
+++ b/src/frontend/optimizer.ts
@@ -475,17 +475,14 @@ export function computeOptimalFleet(
 
     // Pre-compute base fleet simulation on each board
     const baseRemainders: DepotCargoItem[][] = [];
-    let baseEVSum = 0;
 
     for (const board of boards) {
       const remaining = [...board];
-      let total = 0;
       for (const bt of fleet) {
         const { hv, idx } = bestJob(remaining, bt);
-        if (hv > 0 && idx >= 0) { total += hv; remaining.splice(idx, 1); }
+        if (hv > 0 && idx >= 0) { remaining.splice(idx, 1); }
       }
       baseRemainders.push(remaining);
-      baseEVSum += total;
     }
 
     // Evaluate each candidate body type's marginal contribution

--- a/src/frontend/storage.ts
+++ b/src/frontend/storage.ts
@@ -121,7 +121,7 @@ export function loadState(): AppState {
  * Save state to localStorage and invalidate the in-memory cache.
  */
 export function saveState(state: AppState): void {
-  _cachedState = { ...state };
+  _cachedState = structuredClone(state);
   try {
     localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
   } catch (e) {


### PR DESCRIPTION
## Summary
- Remove `baseEVSum` accumulator in `optimizer.ts` — variable was incremented across MC simulations but never read anywhere
- Replace `{ ...state }` shallow clone in `saveState()` with `structuredClone(state)` — prevents splice aliasing where `removeCityTrailer()` mutated the cached `cityTrailers` array in-place before reassigning

## Test plan
- [ ] `npm run lint` passes (no type errors)
- [ ] `npm run test` passes (252/252 tests)
- [ ] Optimizer results unchanged — dead code removal only, no logic change

Closes #214