### PR TITLE
refactor: extract shared filter pipeline from rankings/city-detail

### DIFF
--- a/src/frontend/city-detail-view.ts
+++ b/src/frontend/city-detail-view.ts
@@ -16,7 +16,8 @@ import {
 import { copyToClipboard } from './clipboard.js';
 import { normalize } from './data.js';
 import {
-  formatNumber, getScoreTier, getCityRank, formatRank, updateGarageCount, sortRankings,
+  formatNumber, getScoreTier, getCityRank, formatRank, updateGarageCount,
+  applyRankingsFilters,
   isInComparison, toggleComparison, updateCompareBar,
   type RankingsState, type ScoreTier,
 } from './rankings-view.js';
@@ -34,18 +35,15 @@ async function ensureRankingsCached(
   }
   if (state.displayedRankings === null && state.cachedRankings) {
     // Apply current filters to build displayed rankings
-    const searchTerm = normalize(citySearch.value);
-    let filtered = state.cachedRankings.filter(
-      (r) => normalize(r.name).includes(searchTerm) || normalize(r.country).includes(searchTerm)
+    state.displayedRankings = applyRankingsFilters(
+      state.cachedRankings,
+      normalize(citySearch.value),
+      getSelectedCountries(),
+      getFilterMode(),
+      getOwnedGarages(),
+      getSortColumn(),
+      getSortDirection(),
     );
-    const selectedCountries = getSelectedCountries();
-    if (selectedCountries.length > 0) {
-      filtered = filtered.filter((r) => selectedCountries.includes(r.country));
-    }
-    const filterMode = getFilterMode();
-    const ownedSet = new Set(getOwnedGarages());
-    const filteredByMode = filterMode === 'owned' ? filtered.filter((r) => ownedSet.has(r.id)) : filtered;
-    state.displayedRankings = sortRankings(filteredByMode, getSortColumn(), getSortDirection());
   }
 }
 

--- a/src/frontend/rankings-view.ts
+++ b/src/frontend/rankings-view.ts
@@ -292,6 +292,26 @@ export function sortRankings(rankings: CityRanking[], col: SortColumn, dir: Sort
   });
 }
 
+export function applyRankingsFilters(
+  rankings: CityRanking[],
+  searchTerm: string,
+  selectedCountries: string[],
+  filterMode: string,
+  ownedGarages: string[],
+  sortCol: SortColumn,
+  sortDir: SortDirection,
+): CityRanking[] {
+  let filtered = rankings.filter(
+    (r) => normalize(r.name).includes(searchTerm) || normalize(r.country).includes(searchTerm)
+  );
+  if (selectedCountries.length > 0) {
+    filtered = filtered.filter((r) => selectedCountries.includes(r.country));
+  }
+  const ownedSet = new Set(ownedGarages);
+  const displayRankings = filterMode === 'owned' ? filtered.filter((r) => ownedSet.has(r.id)) : filtered;
+  return sortRankings(displayRankings, sortCol, sortDir);
+}
+
 function buildSortableHeader(col: SortColumn, activeSortCol: SortColumn, activeSortDir: SortDirection): string {
   const meta = SORTABLE_COLUMNS.find(c => c.col === col)!;
   const isActive = activeSortCol === col;
@@ -355,24 +375,21 @@ export async function renderRankings(
   }
 
   const searchTerm = normalize(citySearch.value);
-  let filtered = rankings.filter(
-    (r) => normalize(r.name).includes(searchTerm) || normalize(r.country).includes(searchTerm)
-  );
-
   const selectedCountries = getSelectedCountries();
-  if (selectedCountries.length > 0) {
-    filtered = filtered.filter((r) => selectedCountries.includes(r.country));
-  }
-
   const filterMode = getFilterMode();
-  const ownedSet = new Set(getOwnedGarages());
-  const filteredByMode = filterMode === 'owned' ? filtered.filter((r) => ownedSet.has(r.id)) : filtered;
-
-  // Apply sort after filtering
   const sortCol = getSortColumn();
   const sortDir = getSortDirection();
-  const displayRankings = sortRankings(filteredByMode, sortCol, sortDir);
+  const displayRankings = applyRankingsFilters(
+    rankings,
+    searchTerm,
+    selectedCountries,
+    filterMode,
+    getOwnedGarages(),
+    sortCol,
+    sortDir,
+  );
   state.displayedRankings = displayRankings;
+  const ownedSet = new Set(getOwnedGarages());
 
   if (filterMode === 'owned' && displayRankings.length === 0) {
     rankingsContent.innerHTML = `


### PR DESCRIPTION
## Summary

- Extracts a new exported `applyRankingsFilters()` pure function in `rankings-view.ts` that encapsulates the filter+sort pipeline (search term, country filter, owned-garages filter, sort)
- Updates `renderRankings` to call the shared function instead of inline filter/sort code
- Updates `ensureRankingsCached` in `city-detail-view.ts` to call the shared function, eliminating the duplicate implementation

No behavior changes — purely structural refactoring.

Closes #215