### PR TITLE
fix: announce feedback when comparison max (5) is reached

### DIFF
--- a/src/frontend/city-detail-view.ts
+++ b/src/frontend/city-detail-view.ts
@@ -18,7 +18,7 @@ import { normalize } from './data.js';
 import {
   formatNumber, getScoreTier, getCityRank, formatRank, updateGarageCount,
   applyRankingsFilters,
-  isInComparison, toggleComparison, updateCompareBar,
+  isInComparison, toggleComparison, updateCompareBar, isComparisonFull, announceStatus,
   type RankingsState, type ScoreTier,
 } from './rankings-view.js';
 
@@ -355,7 +355,20 @@ function wireCompareToggle(cityId: string) {
   const btn = document.getElementById('city-compare-toggle') as HTMLButtonElement | null;
   if (!btn) return;
   btn.addEventListener('click', () => {
+    const wasInSet = isInComparison(cityId);
     const added = toggleComparison(cityId);
+    // If we tried to add but the set was full, give feedback
+    if (!added && !wasInSet) {
+      announceStatus('Maximum 5 cities for comparison');
+      const originalText = btn.textContent;
+      btn.textContent = 'Max 5 reached';
+      btn.classList.add('copy-fail');
+      setTimeout(() => {
+        btn.textContent = originalText;
+        btn.classList.remove('copy-fail');
+      }, 2000);
+      return;
+    }
     btn.textContent = added ? '\u2713 In Compare' : '+ Compare';
     btn.setAttribute('aria-pressed', String(added));
     // Sync the rankings table checkbox if visible

--- a/src/frontend/rankings-view.ts
+++ b/src/frontend/rankings-view.ts
@@ -49,12 +49,16 @@ export function isInComparison(cityId: string): boolean {
   return comparisonSet.has(cityId);
 }
 
+export function isComparisonFull(): boolean {
+  return comparisonSet.size >= MAX_COMPARE;
+}
+
 export function toggleComparison(cityId: string): boolean {
   if (comparisonSet.has(cityId)) {
     comparisonSet.delete(cityId);
     return false;
   }
-  if (comparisonSet.size >= MAX_COMPARE) return false; // silently reject
+  if (comparisonSet.size >= MAX_COMPARE) return false; // reject — caller handles feedback
   comparisonSet.add(cityId);
   return true;
 }
@@ -531,10 +535,12 @@ export async function renderRankings(
     cb.addEventListener('change', (e) => {
       const el = e.target as HTMLInputElement;
       const cityId = el.dataset.cityId!;
+      const wasChecked = el.checked;
       const added = toggleComparison(cityId);
-      // If we tried to add but the set was full, uncheck
-      if (el.checked && !added && !comparisonSet.has(cityId)) {
+      // If we tried to add but the set was full, uncheck and announce
+      if (wasChecked && !added && !comparisonSet.has(cityId)) {
         el.checked = false;
+        announceStatus('Maximum 5 cities for comparison');
       }
       updateCompareBar();
     });
@@ -633,6 +639,27 @@ export function showLoading(rankingsContent: HTMLElement): void {
       <div class="skeleton-row"><div class="skeleton-cell narrow"></div><div class="skeleton-cell medium"></div><div class="skeleton-cell medium"></div><div class="skeleton-cell narrow"></div><div class="skeleton-cell narrow"></div><div class="skeleton-cell narrow"></div><div class="skeleton-cell medium"></div></div>
     </div>
   `;
+}
+
+// ============================================
+// Status announcements (aria-live + visual)
+// ============================================
+
+/**
+ * Announces a transient status message to screen readers via an aria-live region,
+ * and briefly shows it as visible text. Clears after 3 seconds.
+ */
+export function announceStatus(message: string): void {
+  let region = document.getElementById('status-announce');
+  if (!region) {
+    region = document.createElement('span');
+    region.id = 'status-announce';
+    region.className = 'sr-only';
+    region.setAttribute('aria-live', 'polite');
+    document.body.appendChild(region);
+  }
+  region.textContent = message;
+  setTimeout(() => { region!.textContent = ''; }, 3000);
 }
 
 export function showError(rankingsContent: HTMLElement, errorMessage: string): void {


### PR DESCRIPTION
## Summary
- City detail "+ Compare" button shows "Max 5 reached" (red, 2s) and announces via aria-live when set is full
- Rankings checkbox announces the same message instead of silently reverting
- Adds `isComparisonFull()` and `announceStatus()` exports for reuse

## Test plan
- [ ] With 5 cities compared, click "+ Compare" on a 6th — button shows "Max 5 reached", screen reader announces
- [ ] With 5 cities compared, check a 6th checkbox — checkbox reverts, screen reader announces
- [ ] All 252 tests pass

Closes #213