### PR TITLE
fix: dead import, SW regex, touch target, aria-label, message consistency

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1460,6 +1460,7 @@ a.link:hover {
   margin-bottom: 1rem;
   display: inline-block;
   text-decoration: none;
+  min-height: 44px;
 }
 
 .back-link:hover {

--- a/public/sw.js
+++ b/public/sw.js
@@ -48,7 +48,7 @@ self.addEventListener('activate', (event) => {
       const requests = await cache.keys();
       await Promise.all(
         requests
-          .filter((req) => new URL(req.url).pathname.match(/\/assets\/.*-[a-zA-Z0-9]{8,}\.js$/))
+          .filter((req) => new URL(req.url).pathname.match(/\/assets\/.*-[a-zA-Z0-9]{8,}\.(js|css)$/))
           .map((req) => cache.delete(req))
       );
 

--- a/src/frontend/city-detail-view.ts
+++ b/src/frontend/city-detail-view.ts
@@ -18,7 +18,7 @@ import { normalize } from './data.js';
 import {
   formatNumber, getScoreTier, getCityRank, formatRank, updateGarageCount,
   applyRankingsFilters,
-  isInComparison, toggleComparison, updateCompareBar, isComparisonFull, announceStatus,
+  isInComparison, toggleComparison, updateCompareBar, announceStatus,
   type RankingsState, type ScoreTier,
 } from './rankings-view.js';
 
@@ -359,9 +359,9 @@ function wireCompareToggle(cityId: string) {
     const added = toggleComparison(cityId);
     // If we tried to add but the set was full, give feedback
     if (!added && !wasInSet) {
-      announceStatus('Maximum 5 cities for comparison');
+      announceStatus('Max 5 cities for comparison');
       const originalText = btn.textContent;
-      btn.textContent = 'Max 5 reached';
+      btn.textContent = 'Max 5 cities';
       btn.classList.add('copy-fail');
       setTimeout(() => {
         btn.textContent = originalText;

--- a/src/frontend/rankings-view.ts
+++ b/src/frontend/rankings-view.ts
@@ -83,7 +83,7 @@ export function updateCompareBar() {
   bar.innerHTML = `
     <span>Compare ${count} cities</span>
     <button class="compare-bar-go" id="compare-bar-go" type="button">Compare</button>
-    <button class="compare-bar-clear" id="compare-bar-clear" type="button">&times;</button>
+    <button class="compare-bar-clear" id="compare-bar-clear" type="button" aria-label="Clear comparison">&times;</button>
   `;
 
   document.getElementById('compare-bar-go')!.addEventListener('click', () => {
@@ -383,17 +383,18 @@ export async function renderRankings(
   const filterMode = getFilterMode();
   const sortCol = getSortColumn();
   const sortDir = getSortDirection();
+  const ownedGarages = getOwnedGarages();
   const displayRankings = applyRankingsFilters(
     rankings,
     searchTerm,
     selectedCountries,
     filterMode,
-    getOwnedGarages(),
+    ownedGarages,
     sortCol,
     sortDir,
   );
   state.displayedRankings = displayRankings;
-  const ownedSet = new Set(getOwnedGarages());
+  const ownedSet = new Set(ownedGarages);
 
   if (filterMode === 'owned' && displayRankings.length === 0) {
     rankingsContent.innerHTML = `


### PR DESCRIPTION
## Summary
- Remove dead `isComparisonFull` import from city-detail-view.ts
- Hoist double `getOwnedGarages()` to single call in renderRankings
- Extend SW eviction regex to `\.(js|css)$` for stale CSS chunks
- Unify compare max feedback: both button and announceStatus say "Max 5 cities"
- Add `min-height: 44px` to `.back-link` for mobile touch target
- Add `aria-label="Clear comparison"` to compare bar × button

## Test plan
- [ ] All 252 tests pass
- [ ] `npm run lint` passes

Closes #222