### PR TITLE
refactor: extract comparison state, remove dead storage code

### DIFF
--- a/src/frontend/__tests__/storage.test.ts
+++ b/src/frontend/__tests__/storage.test.ts
@@ -26,11 +26,9 @@ describe('storage', () => {
       const state = storage.loadState();
 
       expect(state).toEqual({
-        settings: { driverCount: 5 },
         ownedGarages: [],
         garageFilterMode: 'all',
         selectedCountries: [],
-        cityTrailers: {},
         ownedTrailerDLCs: [],
         ownedCargoDLCs: [],
         ownedMapDLCs: [],
@@ -43,73 +41,41 @@ describe('storage', () => {
       localStorageMock.setItem(
         'ets2-trucker-advisor',
         JSON.stringify({
-          settings: { driverCount: 3 },
           ownedGarages: ['berlin', 'paris'],
         }),
       );
 
       const state = storage.loadState();
 
-      expect(state.settings.driverCount).toBe(3);
       expect(state.ownedGarages).toEqual(['berlin', 'paris']);
       expect(state.garageFilterMode).toBe('all');
-      expect(state.cityTrailers).toEqual({});
     });
 
     it('returns defaults on invalid JSON', () => {
       localStorageMock.setItem('ets2-trucker-advisor', 'not valid json');
       const state = storage.loadState();
-      expect(state.settings.driverCount).toBe(5);
+      expect(state.garageFilterMode).toBe('all');
     });
   });
 
   describe('saveState/loadState round-trip', () => {
     it('persists and retrieves state correctly', () => {
       const testState = {
-        settings: { driverCount: 3 },
         ownedGarages: ['berlin', 'paris', 'london'],
         garageFilterMode: 'owned',
         selectedCountries: ['Germany'],
-        cityTrailers: { berlin: ['curtainside', 'dryvan'] },
+        ownedTrailerDLCs: [],
+        ownedCargoDLCs: [],
+        ownedMapDLCs: [],
+        sortColumn: 'score' as const,
+        sortDirection: 'desc' as const,
       };
 
       storage.saveState(testState);
       const loaded = storage.loadState();
 
-      expect(loaded.settings).toEqual(testState.settings);
       expect(loaded.ownedGarages).toEqual(testState.ownedGarages);
       expect(loaded.garageFilterMode).toBe(testState.garageFilterMode);
-      expect(loaded.cityTrailers).toEqual(testState.cityTrailers);
-    });
-  });
-
-  describe('resetToDefaults', () => {
-    it('preserves owned garages when resetting settings', () => {
-      storage.saveState({
-        settings: { driverCount: 3 },
-        ownedGarages: ['berlin', 'paris'],
-        garageFilterMode: 'owned',
-        selectedCountries: ['Germany'],
-        cityTrailers: { berlin: ['curtainside'] },
-      });
-
-      const resetSettings = storage.resetToDefaults();
-      expect(resetSettings.driverCount).toBe(5);
-
-      const state = storage.loadState();
-      expect(state.ownedGarages).toEqual(['berlin', 'paris']);
-    });
-
-    it('returns default settings values', () => {
-      const settings = storage.resetToDefaults();
-      expect(settings.driverCount).toBe(5);
-    });
-  });
-
-  describe('updateSettings', () => {
-    it('updates specific settings while preserving others', () => {
-      const updated = storage.updateSettings({ driverCount: 3 });
-      expect(updated.driverCount).toBe(3);
     });
   });
 
@@ -171,22 +137,6 @@ describe('storage', () => {
     it('remembers banner dismissal', () => {
       storage.dismissBanner();
       expect(storage.isBannerDismissed()).toBe(true);
-    });
-  });
-
-  describe('city trailers', () => {
-    it('manages per-city trailer sets', () => {
-      expect(storage.getCityTrailers('berlin')).toEqual([]);
-
-      storage.addCityTrailer('berlin', 'curtainside');
-      storage.addCityTrailer('berlin', 'dryvan');
-      expect(storage.getCityTrailers('berlin')).toEqual(['curtainside', 'dryvan']);
-
-      storage.removeCityTrailer('berlin', 0);
-      expect(storage.getCityTrailers('berlin')).toEqual(['dryvan']);
-
-      storage.setCityTrailers('berlin', ['flatbed', 'lowbed']);
-      expect(storage.getCityTrailers('berlin')).toEqual(['flatbed', 'lowbed']);
     });
   });
 });

--- a/src/frontend/city-detail-view.ts
+++ b/src/frontend/city-detail-view.ts
@@ -18,9 +18,11 @@ import { normalize } from './data.js';
 import {
   formatNumber, getScoreTier, getCityRank, formatRank, updateGarageCount,
   applyRankingsFilters,
-  isInComparison, toggleComparison, updateCompareBar, announceStatus,
   type RankingsState, type ScoreTier,
 } from './rankings-view.js';
+import {
+  isInComparison, toggleComparison, updateCompareBar, announceStatus,
+} from './comparison-state.js';
 
 // ============================================
 // Ensure rankings are cached

--- a/src/frontend/comparison-state.ts
+++ b/src/frontend/comparison-state.ts
@@ -1,0 +1,93 @@
+/**
+ * Comparison selection state for ETS2 Trucker Advisor
+ *
+ * Manages the session-only set of cities selected for side-by-side comparison,
+ * the floating compare bar DOM element, and aria-live status announcements.
+ */
+
+// ============================================
+// Comparison selection state (session only)
+// ============================================
+
+export const MAX_COMPARE = 5;
+const comparisonSet = new Set<string>();
+
+export function getComparisonCityIds(): string[] {
+  return Array.from(comparisonSet);
+}
+
+export function isInComparison(cityId: string): boolean {
+  return comparisonSet.has(cityId);
+}
+
+export function isComparisonFull(): boolean {
+  return comparisonSet.size >= MAX_COMPARE;
+}
+
+export function toggleComparison(cityId: string): boolean {
+  if (comparisonSet.has(cityId)) {
+    comparisonSet.delete(cityId);
+    return false;
+  }
+  if (comparisonSet.size >= MAX_COMPARE) return false; // reject — caller handles feedback
+  comparisonSet.add(cityId);
+  return true;
+}
+
+export function updateCompareBar() {
+  let bar = document.getElementById('compare-bar');
+  const count = comparisonSet.size;
+
+  if (count < 2) {
+    if (bar) bar.style.display = 'none';
+    return;
+  }
+
+  if (!bar) {
+    bar = document.createElement('div');
+    bar.id = 'compare-bar';
+    bar.className = 'compare-bar';
+    document.body.appendChild(bar);
+  }
+
+  bar.style.display = 'flex';
+  bar.innerHTML = `
+    <span>Compare ${count} cities</span>
+    <button class="compare-bar-go" id="compare-bar-go" type="button">Compare</button>
+    <button class="compare-bar-clear" id="compare-bar-clear" type="button">&times;</button>
+  `;
+
+  document.getElementById('compare-bar-go')!.addEventListener('click', () => {
+    window.location.hash = 'compare';
+  });
+
+  document.getElementById('compare-bar-clear')!.addEventListener('click', () => {
+    comparisonSet.clear();
+    updateCompareBar();
+    // Uncheck all checkboxes
+    document.querySelectorAll('.compare-check').forEach(cb => {
+      (cb as HTMLInputElement).checked = false;
+    });
+  });
+}
+
+// ============================================
+// Status announcements (aria-live + visual)
+// ============================================
+
+/**
+ * Announces a transient status message to screen readers via an aria-live region,
+ * and briefly shows it as visible text. Clears after 3 seconds.
+ */
+export function announceStatus(message: string): void {
+  let region = document.getElementById('status-announce');
+  if (!region) {
+    region = document.createElement('span');
+    region.id = 'status-announce';
+    region.className = 'sr-only';
+    region.setAttribute('aria-live', 'polite');
+    document.body.appendChild(region);
+  }
+  region.textContent = message;
+  setTimeout(() => { region!.textContent = ''; }, 3000);
+}

--- a/src/frontend/main.ts
+++ b/src/frontend/main.ts
@@ -14,9 +14,9 @@ import {
 import {
   renderRankings, initRankingsView,
   showLoading, showError,
-  getComparisonCityIds,
   type RankingsState,
 } from './rankings-view.js';
+import { getComparisonCityIds } from './comparison-state.js';
 import { renderCity } from './city-detail-view.js';
 import { renderComparison } from './comparison-view.js';
 

--- a/src/frontend/rankings-view.ts
+++ b/src/frontend/rankings-view.ts
@@ -17,6 +17,15 @@ import {
 import { normalize } from './data.js';
 import { escapeHtml } from './utils.js';
 import type { AllData, Lookups } from './data.js';
+import {
+  isInComparison, toggleComparison, updateCompareBar, announceStatus,
+} from './comparison-state.js';
+
+// Re-export comparison state functions for consumers that import them from here
+export {
+  getComparisonCityIds, isInComparison, isComparisonFull, toggleComparison,
+  updateCompareBar, announceStatus,
+} from './comparison-state.js';
 
 // ============================================
 // Types
@@ -32,72 +41,6 @@ export interface RankingsState {
   lookups: Lookups | null;
   cachedRankings: CityRanking[] | null;
   displayedRankings: CityRanking[] | null;
-}
-
-// ============================================
-// Comparison selection state (session only)
-// ============================================
-
-const MAX_COMPARE = 5;
-const comparisonSet = new Set<string>();
-
-export function getComparisonCityIds(): string[] {
-  return Array.from(comparisonSet);
-}
-
-export function isInComparison(cityId: string): boolean {
-  return comparisonSet.has(cityId);
-}
-
-export function isComparisonFull(): boolean {
-  return comparisonSet.size >= MAX_COMPARE;
-}
-
-export function toggleComparison(cityId: string): boolean {
-  if (comparisonSet.has(cityId)) {
-    comparisonSet.delete(cityId);
-    return false;
-  }
-  if (comparisonSet.size >= MAX_COMPARE) return false; // reject — caller handles feedback
-  comparisonSet.add(cityId);
-  return true;
-}
-
-export function updateCompareBar() {
-  let bar = document.getElementById('compare-bar');
-  const count = comparisonSet.size;
-
-  if (count < 2) {
-    if (bar) bar.style.display = 'none';
-    return;
-  }
-
-  if (!bar) {
-    bar = document.createElement('div');
-    bar.id = 'compare-bar';
-    bar.className = 'compare-bar';
-    document.body.appendChild(bar);
-  }
-
-  bar.style.display = 'flex';
-  bar.innerHTML = `
-    <span>Compare ${count} cities</span>
-    <button class="compare-bar-go" id="compare-bar-go" type="button">Compare</button>
-    <button class="compare-bar-clear" id="compare-bar-clear" type="button" aria-label="Clear comparison">&times;</button>
-  `;
-
-  document.getElementById('compare-bar-go')!.addEventListener('click', () => {
-    window.location.hash = 'compare';
-  });
-
-  document.getElementById('compare-bar-clear')!.addEventListener('click', () => {
-    comparisonSet.clear();
-    updateCompareBar();
-    // Uncheck all checkboxes
-    document.querySelectorAll('.compare-check').forEach(cb => {
-      (cb as HTMLInputElement).checked = false;
-    });
-  });
 }
 
 // ============================================
@@ -469,7 +412,7 @@ export async function renderRankings(
             const starred = ownedSet.has(r.id);
             const globalIndex = state.cachedRankings!.findIndex(cr => cr.id === r.id);
             const tier = getScoreTier(globalIndex >= 0 ? globalIndex : i, state.cachedRankings!.length);
-            const checked = comparisonSet.has(r.id);
+            const checked = isInComparison(r.id);
             return `
             <tr class="clickable${starred ? ' owned-garage' : ''}" data-city-id="${r.id}" tabindex="0">
               <td class="garage-star" data-city-id="${r.id}" title="${starred ? 'Remove garage for' : 'Mark as garage for'} ${r.name}" tabindex="0" role="button" aria-label="${starred ? 'Remove garage for' : 'Mark as garage for'} ${r.name}">${starred ? '\u2605' : '\u2606'}</td>
@@ -539,7 +482,7 @@ export async function renderRankings(
       const wasChecked = el.checked;
       const added = toggleComparison(cityId);
       // If we tried to add but the set was full, uncheck and announce
-      if (wasChecked && !added && !comparisonSet.has(cityId)) {
+      if (wasChecked && !added && !isInComparison(cityId)) {
         el.checked = false;
         announceStatus('Maximum 5 cities for comparison');
       }
@@ -640,27 +583,6 @@ export function showLoading(rankingsContent: HTMLElement): void {
       <div class="skeleton-row"><div class="skeleton-cell narrow"></div><div class="skeleton-cell medium"></div><div class="skeleton-cell medium"></div><div class="skeleton-cell narrow"></div><div class="skeleton-cell narrow"></div><div class="skeleton-cell narrow"></div><div class="skeleton-cell medium"></div></div>
     </div>
   `;
-}
-
-// ============================================
-// Status announcements (aria-live + visual)
-// ============================================
-
-/**
- * Announces a transient status message to screen readers via an aria-live region,
- * and briefly shows it as visible text. Clears after 3 seconds.
- */
-export function announceStatus(message: string): void {
-  let region = document.getElementById('status-announce');
-  if (!region) {
-    region = document.createElement('span');
-    region.id = 'status-announce';
-    region.className = 'sr-only';
-    region.setAttribute('aria-live', 'polite');
-    document.body.appendChild(region);
-  }
-  region.textContent = message;
-  setTimeout(() => { region!.textContent = ''; }, 3000);
 }
 
 export function showError(rankingsContent: HTMLElement, errorMessage: string): void {

--- a/src/frontend/storage.ts
+++ b/src/frontend/storage.ts
@@ -1,6 +1,6 @@
 /**
  * LocalStorage wrapper for ETS2 Trucker Advisor
- * Persists user settings, garage state, and per-city trailer sets.
+ * Persists garage state, filter/sort preferences, and DLC ownership.
  *
  * DLC registries and maps live in dlc-data.ts (loaded from game-defs.json).
  * This module re-exports them for backward compatibility.
@@ -23,19 +23,13 @@ const BANNER_DISMISSED_KEY = 'ets2-dlc-banner-dismissed';
 const ONBOARDING_COLLAPSED_KEY = 'ets2-onboarding-collapsed';
 const THEME_KEY = 'ets2-theme';
 
-interface Settings {
-  driverCount: number;
-}
-
 export type SortColumn = 'name' | 'country' | 'depotCount' | 'cargoTypes' | 'score';
 export type SortDirection = 'asc' | 'desc';
 
 interface AppState {
-  settings: Settings;
   ownedGarages: string[];
   garageFilterMode: string;
   selectedCountries: string[];
-  cityTrailers: Record<string, string[]>;  // cityId -> array of body type IDs
   ownedTrailerDLCs: string[];              // DLC brand IDs the user owns
   ownedCargoDLCs: string[];               // Cargo DLC pack IDs the user owns
   ownedMapDLCs: string[];                 // Map expansion DLC IDs the user owns
@@ -55,13 +49,9 @@ export function _resetStateCache(): void {
 }
 
 const defaultState: AppState = {
-  settings: {
-    driverCount: 5,
-  },
   ownedGarages: [],
   garageFilterMode: 'all',
   selectedCountries: [],
-  cityTrailers: {},
   ownedTrailerDLCs: [],  // none owned by default — first-time visitors configure on DLC page
   ownedCargoDLCs: [],   // none owned by default
   ownedMapDLCs: [],     // none owned by default
@@ -82,21 +72,12 @@ export function loadState(): AppState {
       const state: AppState = {
         ...defaultState,
         ...parsed,
-        settings: {
-          ...defaultState.settings,
-          ...parsed.settings,
-        },
-        cityTrailers: parsed.cityTrailers ?? {},
         ownedTrailerDLCs: parsed.ownedTrailerDLCs ?? [...ALL_DLC_IDS],
         ownedCargoDLCs: parsed.ownedCargoDLCs ?? [...ALL_CARGO_DLC_IDS],
         ownedMapDLCs: parsed.ownedMapDLCs ?? [...ALL_MAP_DLC_IDS],
         sortColumn: parsed.sortColumn ?? defaultState.sortColumn,
         sortDirection: parsed.sortDirection ?? defaultState.sortDirection,
       };
-      // Migrate legacy settings
-      if (parsed.settings?.maxTrailers && !parsed.settings?.driverCount) {
-        state.settings.driverCount = defaultState.settings.driverCount;
-      }
       // Migrate legacy country filter key into unified state
       if (!parsed.selectedCountries) {
         const legacy = localStorage.getItem(LEGACY_COUNTRIES_KEY);
@@ -127,34 +108,6 @@ export function saveState(state: AppState): void {
   } catch (e) {
     console.warn('Failed to save state to localStorage:', e);
   }
-}
-
-/**
- * Update settings and save
- */
-export function updateSettings(settings: Partial<Settings>): Settings {
-  const state = loadState();
-  state.settings = { ...state.settings, ...settings };
-  saveState(state);
-  return state.settings;
-}
-
-/**
- * Get current settings
- */
-export function getSettings(): Settings {
-  return loadState().settings;
-}
-
-/**
- * Reset to defaults
- */
-export function resetToDefaults(): Settings {
-  const state = loadState();
-  state.settings = { ...defaultState.settings };
-  state.selectedCountries = [];
-  saveState(state);
-  return defaultState.settings;
 }
 
 // ============================================
@@ -223,61 +176,6 @@ export function getSelectedCountries(): string[] {
 export function setSelectedCountries(countries: string[]): void {
   const state = loadState();
   state.selectedCountries = countries;
-  saveState(state);
-}
-
-// ============================================
-// Per-City Trailer Management
-// ============================================
-
-/**
- * Get trailer set (body type IDs) for a city
- */
-export function getCityTrailers(cityId: string): string[] {
-  return loadState().cityTrailers[cityId] || [];
-}
-
-/**
- * Add a trailer (body type) to a city's set
- */
-export function addCityTrailer(cityId: string, bodyType: string): string[] {
-  const state = loadState();
-  if (!state.cityTrailers[cityId]) {
-    state.cityTrailers[cityId] = [];
-  }
-  state.cityTrailers[cityId].push(bodyType);
-  // Auto-add to owned garages
-  if (!state.ownedGarages.includes(cityId)) {
-    state.ownedGarages = [...state.ownedGarages, cityId];
-  }
-  saveState(state);
-  return state.cityTrailers[cityId];
-}
-
-/**
- * Remove a trailer at index from a city's set
- */
-export function removeCityTrailer(cityId: string, index: number): string[] {
-  const state = loadState();
-  const trailers = state.cityTrailers[cityId] || [];
-  if (index >= 0 && index < trailers.length) {
-    trailers.splice(index, 1);
-    state.cityTrailers[cityId] = trailers;
-    // Auto-remove from owned garages if no trailers left
-    if (trailers.length === 0) {
-      state.ownedGarages = state.ownedGarages.filter((id) => id !== cityId);
-    }
-    saveState(state);
-  }
-  return state.cityTrailers[cityId] || [];
-}
-
-/**
- * Set entire trailer set for a city
- */
-export function setCityTrailers(cityId: string, trailers: string[]): void {
-  const state = loadState();
-  state.cityTrailers[cityId] = trailers;
   saveState(state);
 }
 


### PR DESCRIPTION
## Summary
- Create `comparison-state.ts` with comparison set management and announceStatus
- Update imports in rankings-view, city-detail-view, main
- Remove dead `driverCount` setting + `maxTrailers` migration from storage
- Remove dead `cityTrailers` CRUD (4 functions) and related tests
- rankings-view.ts reduced from 672 to ~580 lines
- Test count: 252 → 248 (4 dead tests removed)

## Test plan
- [ ] All 248 tests pass
- [ ] Compare feature works (add/remove cities, compare bar, max 5 feedback)
- [ ] City detail compare toggle still syncs with rankings checkboxes

Closes #223