### PR TITLE
fix(ci): update build-artifact check for ets2/ats data layout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,9 +72,10 @@ jobs:
           test -f public/dist/cargo.html || (echo "ERROR: cargo.html missing" && exit 1)
           test -f public/dist/trailers.html || (echo "ERROR: trailers.html missing" && exit 1)
 
-          # Check data files copied
+          # Check data files copied (one directory per supported game)
           test -d public/dist/data || (echo "ERROR: data directory missing" && exit 1)
-          test -f public/dist/data/game-defs.json || (echo "ERROR: game-defs.json missing" && exit 1)
+          test -f public/dist/data/ets2/game-defs.json || (echo "ERROR: ets2/game-defs.json missing" && exit 1)
+          test -f public/dist/data/ats/game-defs.json || (echo "ERROR: ats/game-defs.json missing" && exit 1)
 
           # Check assets directory exists
           test -d public/dist/assets || (echo "ERROR: assets directory missing" && exit 1)


### PR DESCRIPTION
## Summary
- CI has been red on `main` since `5b6c669` (2026-04-07, 11 days). That commit moved `public/data/game-defs.json` → `public/data/{ets2,ats}/game-defs.json` for multi-game support, but the `Verify build artifacts exist` step in `ci.yml` still asserts the pre-move path.
- Every merge since (4 dependabot PRs: kysely, flatted, picomatch, vite) rode on top of already-broken CI.
- This PR points the check at the new per-game layout and also asserts the ATS data file.

## Test plan
- [x] Ran `npm run build:frontend` locally — all artifacts emitted.
- [x] Ran the updated `verify build artifacts exist` shell locally against `public/dist/` — passes.
- [x] CI turns green on this PR.