### PR TITLE
fix(frontend): ATS chain_type labels and triple tier (#245)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ Euro Truck Simulator 2 and American Truck Simulator trucking company analyzer - 
 **Body Types**:
 - 15-17 body types cover all ~359 cargo types in the game
 - All trailers within a body type haul the SAME cargo set — difference is only volume/units
-- Trailer tiers: Standard, Double, HCT (identified by trailer ID keywords)
+- Trailer tiers: Standard, Double, HCT. `trailers.ts` derives the tier from the `chain_type` field via `tierFromChainType()` (ETS2: `single`/`double`/`b_double`/`hct`; ATS: `single`/`double`/`bdouble`/`rmdouble`/`tpdouble`/`triple`). `body-types.ts` still uses ID-keyword heuristics for the `hasDoubles`/`hasBDoubles`/`hasHCT` profile flags (known gap, tracked in #250)
 - Body type profiles are built dynamically from game-defs.json via `getBodyTypeProfiles()`
 - Optimizer works at body-type level, not individual trailer level
 
@@ -96,7 +96,7 @@ Euro Truck Simulator 2 and American Truck Simulator trucking company analyzer - 
 2. For each body type, collect union of all compatible cargo IDs (via `trailerCargoMap`)
 3. All trailers within a body type haul the SAME cargo set — difference is only volume/capacity
 4. Pick best trailer per body type by total haul value across all compatible cargo
-5. Detect doubles/HCT availability by scanning trailer IDs for `double`/`bdouble`/`hct` keywords
+5. Detect doubles/HCT availability: `body-types.ts` still uses ID-keyword scanning (`double`/`bdouble`/`hct`) to populate `hasDoubles`/`hasBDoubles`/`hasHCT` (known gap — misses ATS `triple`/`rmdouble`/`tpdouble`, tracked in #250). For tier grouping in `trailers.ts`, use `tierFromChainType(chain_type)` instead.
 6. Result: ~15-17 body types covering all ~359 cargo types
 
 ### Dominated Body Type Elimination (`findDominatedBodyTypes()`)

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Game data is extracted directly from game definition files for both Euro Truck S
 npm install              # Install dependencies
 npm run dev:frontend     # Start dev server (http://localhost:5173)
 npm run build:frontend   # Build for production
-npm run test             # Run tests (265 tests)
+npm run test             # Run test suite
 npm run lint             # TypeScript type checking
 ```
 

--- a/docs/game-data-questions.md
+++ b/docs/game-data-questions.md
@@ -29,9 +29,9 @@ Questions to verify once extracted game definition files are received.
 11. [ANSWERED] What `country_validity[]` restrictions exist? Which trailers have them?
     - **Answer**: Parser extracts `country_validity` as string array. Typically restricts certain trailers (e.g., HCT) to specific countries.
 12. [OPEN] What are the `length` values for trailers that have them? Which trailers are "long" (doubles, HCTs)?
-    - Parser extracts `length` field. Doubles/HCT identified by ID keywords (`double`, `bdouble`, `hct`), not by length value.
+    - Parser extracts `length` field. `body-types.ts` still identifies long configurations via ID keywords (`double`, `bdouble`, `hct`) for the `hasDoubles`/`hasHCT`/`hasBDoubles` flags — known gap, tracked in #250.
 13. [ANSWERED] What is `chain_type` and what values does it take? How does it affect job generation?
-    - **Answer**: Parser extracts `chain_type` (defaults to `'single'`). Values include `single`, `double`, `hct`. Used for trailer tier classification.
+    - **Answer**: Parser extracts `chain_type` (defaults to `'single'`). **ETS2 values**: `single`, `double`, `b_double`, `hct`. **ATS values**: `single`, `double`, `bdouble`, `rmdouble`, `tpdouble`, `triple`. Used for trailer tier classification — `trailers.ts` uses `chain_type` directly via `tierFromChainType()`; `body-types.ts` still uses ID-keyword heuristics for `hasHCT`/`hasDoubles`/`hasBDoubles` (known gap, tracked in #250).
 14. [ANSWERED] Can we compute exact unit counts as `floor(trailer_volume / cargo_volume)`? Or does the game use a different formula?
     - **Answer**: Yes. Parser computes `floor(trailer_volume / cargo_volume)` as primary method, with weight-limit cap when `gross_weight_limit` applies.
 15. [ANSWERED] Do weight limits ever cap units below what volume allows? (i.e., `gross_trailer_weight_limit` minus `chassis_mass` minus `body_mass` = max cargo weight, then `max_cargo_weight / cargo_mass` might be less than volume-based units)

--- a/src/frontend/__tests__/utils.test.ts
+++ b/src/frontend/__tests__/utils.test.ts
@@ -1,5 +1,14 @@
 import { describe, it, expect } from 'vitest';
-import { normalize, titleCase, trailerTotalHV, formatTrailerSpec, escapeHtml, tierFromChainType } from '../utils';
+import {
+  normalize,
+  titleCase,
+  trailerTotalHV,
+  formatTrailerSpec,
+  escapeHtml,
+  tierFromChainType,
+  CHAIN_LABELS,
+  TIER_BY_CHAIN_TYPE,
+} from '../utils';
 import type { Trailer, Lookups, Cargo } from '../types';
 
 describe('normalize', () => {
@@ -345,6 +354,13 @@ describe('tierFromChainType', () => {
     expect(tierFromChainType(undefined)).toBe('Standard');
     expect(tierFromChainType('')).toBe('Standard');
     expect(tierFromChainType('mystery')).toBe('Standard');
+  });
+
+  it('CHAIN_LABELS and TIER_BY_CHAIN_TYPE cover the same chain types', () => {
+    // Drift guard: a new ATS/ETS2 chain type added to one map but not the other
+    // would silently produce a label without a tier (or vice versa). This test
+    // fails on any divergence so the second map gets updated alongside.
+    expect(Object.keys(CHAIN_LABELS).sort()).toEqual(Object.keys(TIER_BY_CHAIN_TYPE).sort());
   });
 });
 

--- a/src/frontend/__tests__/utils.test.ts
+++ b/src/frontend/__tests__/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { normalize, titleCase, trailerTotalHV, formatTrailerSpec, escapeHtml } from '../utils';
+import { normalize, titleCase, trailerTotalHV, formatTrailerSpec, escapeHtml, tierFromChainType } from '../utils';
 import type { Trailer, Lookups, Cargo } from '../types';
 
 describe('normalize', () => {
@@ -283,6 +283,38 @@ describe('formatTrailerSpec', () => {
     expect(spec).toContain('2+2-axle');
   });
 
+  it('labels ATS bdouble (no underscore) chain type', () => {
+    const spec = formatTrailerSpec(makeTrailer({
+      id: 'scs.box.bdouble_2_2.dryvan',
+      chain_type: 'bdouble',
+    }));
+    expect(spec).toContain('B-double');
+  });
+
+  it('labels ATS turnpike-double chain type', () => {
+    const spec = formatTrailerSpec(makeTrailer({
+      id: 'scs.box.tp_double_1.dryvan',
+      chain_type: 'tpdouble',
+    }));
+    expect(spec).toContain('Turnpike-double');
+  });
+
+  it('labels ATS rocky-mountain double chain type', () => {
+    const spec = formatTrailerSpec(makeTrailer({
+      id: 'scs.box.rm_double_p.dryvan',
+      chain_type: 'rmdouble',
+    }));
+    expect(spec).toContain('RM-double');
+  });
+
+  it('labels ATS triple chain type', () => {
+    const spec = formatTrailerSpec(makeTrailer({
+      id: 'scs.box.triple_p.dryvan',
+      chain_type: 'triple',
+    }));
+    expect(spec).toContain('Triple');
+  });
+
   it('formats weight in tonnes', () => {
     const spec = formatTrailerSpec(makeTrailer({ gross_weight_limit: 60000 }));
     expect(spec).toContain('60t');
@@ -291,6 +323,28 @@ describe('formatTrailerSpec', () => {
   it('includes length in meters', () => {
     const spec = formatTrailerSpec(makeTrailer({ length: 15.0 }));
     expect(spec).toContain('15m');
+  });
+});
+
+describe('tierFromChainType', () => {
+  it('buckets ETS2 chain types', () => {
+    expect(tierFromChainType('single')).toBe('Standard');
+    expect(tierFromChainType('double')).toBe('Double');
+    expect(tierFromChainType('b_double')).toBe('Double');
+    expect(tierFromChainType('hct')).toBe('HCT');
+  });
+
+  it('buckets ATS chain types', () => {
+    expect(tierFromChainType('bdouble')).toBe('Double');
+    expect(tierFromChainType('tpdouble')).toBe('Double');
+    expect(tierFromChainType('rmdouble')).toBe('Double');
+    expect(tierFromChainType('triple')).toBe('HCT');
+  });
+
+  it('treats unknown / undefined chain types as Standard', () => {
+    expect(tierFromChainType(undefined)).toBe('Standard');
+    expect(tierFromChainType('')).toBe('Standard');
+    expect(tierFromChainType('mystery')).toBe('Standard');
   });
 });
 

--- a/src/frontend/trailers.ts
+++ b/src/frontend/trailers.ts
@@ -11,7 +11,7 @@ import {
   pickBestTrailer, trailerTotalHV, formatTrailerSpec,
   type AllData, type Lookups, type Cargo, type Trailer,
 } from './data';
-import { escapeHtml } from './utils';
+import { escapeHtml, tierFromChainType } from './utils';
 import { COUNTRY_DISPLAY_NAMES } from './display-names';
 
 let data: AllData | null = null;
@@ -67,12 +67,6 @@ function getCargo(cargoIds: Set<string>, trailerId: string): CargoWithUnits[] {
     .sort((a, b) => b.haulValue - a.haulValue);
 }
 
-function tierFromId(id: string): string {
-  if (id.includes('hct')) return 'HCT';
-  if (id.includes('double') || id.includes('bdouble')) return 'Double';
-  return 'Standard';
-}
-
 function tierCountries(trailers: Trailer[]): string {
   const countrySet = new Set<string>();
   let allCountries = false;
@@ -111,7 +105,7 @@ function buildBodyTypes(): BodyTypeSummary[] {
     // Group by tier
     const tierMap = new Map<string, Trailer[]>();
     for (const t of trailers) {
-      const tier = tierFromId(t.id);
+      const tier = tierFromChainType(t.chain_type);
       if (!tierMap.has(tier)) tierMap.set(tier, []);
       tierMap.get(tier)!.push(t);
     }

--- a/src/frontend/utils.ts
+++ b/src/frontend/utils.ts
@@ -29,11 +29,18 @@ export function formatTrailerSpec(t: Trailer): string {
   const brandRaw = idParts[0];
   const brand = brandRaw.charAt(0).toUpperCase() + brandRaw.slice(1);
 
-  // Chain type label for non-single trailers
-  let chainLabel = '';
-  if (t.chain_type === 'hct') chainLabel = 'HCT';
-  else if (t.chain_type === 'b_double') chainLabel = 'B-double';
-  else if (t.chain_type === 'double') chainLabel = 'Double';
+  // Chain type label for non-single trailers.
+  // ETS2 emits b_double / hct; ATS emits bdouble, rmdouble, tpdouble, triple, double.
+  const CHAIN_LABELS: Record<string, string> = {
+    hct: 'HCT',
+    b_double: 'B-double',
+    bdouble: 'B-double',
+    rmdouble: 'RM-double',
+    tpdouble: 'Turnpike-double',
+    triple: 'Triple',
+    double: 'Double',
+  };
+  const chainLabel = CHAIN_LABELS[t.chain_type] ?? '';
 
   // Extract axle count from ID
   let axleStr = '';
@@ -120,6 +127,25 @@ export function pickBestTrailer(candidates: Trailer[], fallback: Trailer, lookup
     }
   }
   return bestTrailer;
+}
+
+// ATS `triple` rides in the HCT bucket until the "configurations not tiers"
+// rework replaces this 3-tier scheme; HCT and triple are distinct real
+// configurations, but both live in the heaviest bucket for now.
+export function tierFromChainType(chainType: string | undefined): string {
+  switch (chainType) {
+    case 'hct':
+    case 'triple':
+      return 'HCT';
+    case 'double':
+    case 'b_double':
+    case 'bdouble':
+    case 'tpdouble':
+    case 'rmdouble':
+      return 'Double';
+    default:
+      return 'Standard';
+  }
 }
 
 /** Convert game ID to display name: "apples_c" -> "Apples C" */

--- a/src/frontend/utils.ts
+++ b/src/frontend/utils.ts
@@ -23,23 +23,25 @@ export function normalize(str: string): string {
   return str.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '');
 }
 
+// Chain type label for non-single trailers.
+// ETS2 emits b_double / hct; ATS emits bdouble, rmdouble, tpdouble, triple, double.
+// Keep keys in sync with TIER_BY_CHAIN_TYPE; utils.test.ts asserts both maps cover the same set.
+export const CHAIN_LABELS: Record<string, string> = {
+  hct: 'HCT',
+  b_double: 'B-double',
+  bdouble: 'B-double',
+  rmdouble: 'RM-double',
+  tpdouble: 'Turnpike-double',
+  triple: 'Triple',
+  double: 'Double',
+};
+
 /** Build a human-readable spec string from trailer properties, e.g. "Kassbohrer 3-axle 79t 16.4m" */
 export function formatTrailerSpec(t: Trailer): string {
   const idParts = t.id.split('.');
   const brandRaw = idParts[0];
   const brand = brandRaw.charAt(0).toUpperCase() + brandRaw.slice(1);
 
-  // Chain type label for non-single trailers.
-  // ETS2 emits b_double / hct; ATS emits bdouble, rmdouble, tpdouble, triple, double.
-  const CHAIN_LABELS: Record<string, string> = {
-    hct: 'HCT',
-    b_double: 'B-double',
-    bdouble: 'B-double',
-    rmdouble: 'RM-double',
-    tpdouble: 'Turnpike-double',
-    triple: 'Triple',
-    double: 'Double',
-  };
   const chainLabel = CHAIN_LABELS[t.chain_type] ?? '';
 
   // Extract axle count from ID
@@ -132,20 +134,20 @@ export function pickBestTrailer(candidates: Trailer[], fallback: Trailer, lookup
 // ATS `triple` rides in the HCT bucket until the "configurations not tiers"
 // rework replaces this 3-tier scheme; HCT and triple are distinct real
 // configurations, but both live in the heaviest bucket for now.
+// Keep keys in sync with CHAIN_LABELS; utils.test.ts asserts both maps cover the same set.
+export const TIER_BY_CHAIN_TYPE: Record<string, string> = {
+  hct: 'HCT',
+  triple: 'HCT',
+  double: 'Double',
+  b_double: 'Double',
+  bdouble: 'Double',
+  tpdouble: 'Double',
+  rmdouble: 'Double',
+};
+
 export function tierFromChainType(chainType: string | undefined): string {
-  switch (chainType) {
-    case 'hct':
-    case 'triple':
-      return 'HCT';
-    case 'double':
-    case 'b_double':
-    case 'bdouble':
-    case 'tpdouble':
-    case 'rmdouble':
-      return 'Double';
-    default:
-      return 'Standard';
-  }
+  if (!chainType) return 'Standard';
+  return TIER_BY_CHAIN_TYPE[chainType] ?? 'Standard';
 }
 
 /** Convert game ID to display name: "apples_c" -> "Apples C" */


### PR DESCRIPTION
## Summary

Fixes the chain-type display gap and `triple → Standard` miscategorization reported in #245. Both bugs share a root cause: the original code derived chain-type semantics from heuristic ID-keyword matching tuned to the ETS2 vocabulary, then ATS shipped a different vocabulary.

### Bug 1 — display labels

`formatTrailerSpec` matched only `hct`, `b_double`, `double`. Counts of ownable trailers per chain_type today:

| game | chain_type counts |
|------|------|
| ETS2 | `single` 343, `hct` 70, `double` 62, `b_double` 39 |
| ATS  | `single` 439, `double` 30, `triple` 26, `tpdouble` 24, `bdouble` 22, `rmdouble` 21 |

So 22 ATS bdoubles + 71 rmdouble/tpdouble/triple trailers all rendered with no chain label.

Replaced the if-chain with a `chain_type → label` map that covers the full ETS2 + ATS vocabulary:
- `hct` → HCT
- `b_double` / `bdouble` → B-double
- `rmdouble` → RM-double
- `tpdouble` → Turnpike-double
- `triple` → Triple
- `double` → Double

### Bug 2 — `triple` misclassified as Standard

`tierFromId` keyword-matched IDs: `'hct' → HCT`, `'double' || 'bdouble' → Double`, else `Standard`. None of the 26 ATS triple IDs contain `double` or `hct`, so they all bucketed into Standard despite being the heaviest configuration.

Replaced with `tierFromChainType(chain_type)` using the authoritative parsed field. Triples bucket alongside `hct` as the heaviest tier — a stopgap acknowledged in code comment until the broader "configurations not tiers" redesign (separate followup issue) replaces the 3-tier model entirely.

Moved the helper into `utils.ts` so it's unit-testable without mocking the trailers page-init DOM globals.

### Out of scope (going into the followup issue)

- Axle-count display for `tpdouble` / `rmdouble` / `triple` IDs (parser doesn't expose `axles` field; would require pipeline changes)
- `body-types.ts` `hasDoubles` / `hasHCT` flags use the same ID-keyword heuristic and have the same ATS gaps — those flags feed the optimizer, so changing them is a behavior change that warrants its own discussion
- The "configurations not tiers" redesign (`(body_type, chain_type, axles)` as first-class) — proper design change

## Test plan

- [x] `npm run lint` clean
- [x] `npm test` — all 279 tests pass; 8 new tests added (4 for `formatTrailerSpec` covering ATS chain types, 3 for `tierFromChainType` ETS2/ATS/unknown, plus the existing matrix)
- [ ] Visual smoke: load trailers browser on ATS, confirm bdouble shows "B-double", triple shows under HCT-tier expansion

Closes #245