### PR TITLE
feat(fleet): trailer pricing + level floor for recommended fleet (#251)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ Euro Truck Simulator 2 and American Truck Simulator trucking company analyzer - 
 ## Data Model
 
 **JSON Data Sources** (in `/public/data/`):
-- `game-defs.json`: Authoritative game data extracted from ETS2 game files — cargo definitions (value, volume, mass, fragility, prob_coef, body_types, groups), trailer specs (body_type, volume, gross_weight_limit, chain_type, country_validity, ownable, price, xp_floor), company mappings (cargo_out/in, cities), city/country data, cargo-trailer unit counts, economy constants, truck specs, and DLC registry
+- `game-defs.json`: Authoritative game data extracted from ETS2 game files — cargo definitions (value, volume, mass, fragility, prob_coef, body_types, groups), trailer specs (body_type, volume, gross_weight_limit, chain_type, country_validity, ownable, price, level_floor), company mappings (cargo_out/in, cities), city/country data, cargo-trailer unit counts, economy constants, truck specs, and DLC registry
 - `observations.json`: Observed data from save game parsing — city-company mappings, cargo-trailer compatibility, cargo spawn frequencies, unit counts per trailer. Supplements and validates game defs but does NOT override authoritative values
 
 **Data Loading** (`loadAllData()` in `loader.ts`):

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ Euro Truck Simulator 2 and American Truck Simulator trucking company analyzer - 
 ## Data Model
 
 **JSON Data Sources** (in `/public/data/`):
-- `game-defs.json`: Authoritative game data extracted from ETS2 game files — cargo definitions (value, volume, mass, fragility, prob_coef, body_types, groups), trailer specs (body_type, volume, gross_weight_limit, chain_type, country_validity, ownable), company mappings (cargo_out/in, cities), city/country data, cargo-trailer unit counts, economy constants, truck specs, and DLC registry
+- `game-defs.json`: Authoritative game data extracted from ETS2 game files — cargo definitions (value, volume, mass, fragility, prob_coef, body_types, groups), trailer specs (body_type, volume, gross_weight_limit, chain_type, country_validity, ownable, price, xp_floor), company mappings (cargo_out/in, cities), city/country data, cargo-trailer unit counts, economy constants, truck specs, and DLC registry
 - `observations.json`: Observed data from save game parsing — city-company mappings, cargo-trailer compatibility, cargo spawn frequencies, unit counts per trailer. Supplements and validates game defs but does NOT override authoritative values
 
 **Data Loading** (`loadAllData()` in `loader.ts`):

--- a/scripts/__tests__/parse-game-defs.test.ts
+++ b/scripts/__tests__/parse-game-defs.test.ts
@@ -127,20 +127,20 @@ function runSchemaInvariantsForGame(game: 'ats' | 'ets2') {
 
     // Forward-compatible: existing game-defs.json snapshots may pre-date the
     // trailer pricing extraction (#251). Once a user re-runs the parser against
-    // extracted defs, every trailer gets price + xp_floor; if they're missing
+    // extracted defs, every trailer gets price + level_floor; if they're missing
     // (older snapshot), the loader defaults to 0 and the frontend renders "—".
     it('trailer pricing fields, when present, are numeric and price is a multiple of 1000', () => {
       const data = JSON.parse(readFileSync(fixturePath, 'utf-8'));
-      for (const [, t] of Object.entries(data.trailers as Record<string, { price?: unknown; xp_floor?: unknown }>)) {
+      for (const [, t] of Object.entries(data.trailers as Record<string, { price?: unknown; level_floor?: unknown }>)) {
         if (t.price !== undefined) {
           expect(typeof t.price).toBe('number');
           // Issue #251 spec: rounded UP to the nearest 1000.
           expect((t.price as number) % 1000).toBe(0);
           expect(t.price as number).toBeGreaterThanOrEqual(0);
         }
-        if (t.xp_floor !== undefined) {
-          expect(typeof t.xp_floor).toBe('number');
-          expect(t.xp_floor as number).toBeGreaterThanOrEqual(0);
+        if (t.level_floor !== undefined) {
+          expect(typeof t.level_floor).toBe('number');
+          expect(t.level_floor as number).toBeGreaterThanOrEqual(0);
         }
       }
     });

--- a/scripts/__tests__/parse-game-defs.test.ts
+++ b/scripts/__tests__/parse-game-defs.test.ts
@@ -87,4 +87,24 @@ describe('public/data/ats/game-defs.json schema invariants', () => {
       .filter(c => !countryKeys.has(c));
     expect(orphans).toEqual([]);
   });
+
+  // Forward-compatible: existing game-defs.json snapshots may pre-date the
+  // trailer pricing extraction (#251). Once a user re-runs the parser against
+  // extracted defs, every trailer gets price + xp_floor; if they're missing
+  // (older snapshot), the loader defaults to 0 and the frontend renders "—".
+  it('trailer pricing fields, when present, are numeric and price is a multiple of 1000', () => {
+    const data = JSON.parse(readFileSync(fixturePath, 'utf-8'));
+    for (const [, t] of Object.entries(data.trailers as Record<string, { price?: unknown; xp_floor?: unknown }>)) {
+      if (t.price !== undefined) {
+        expect(typeof t.price).toBe('number');
+        // Issue #251 spec: rounded UP to the nearest 1000.
+        expect((t.price as number) % 1000).toBe(0);
+        expect(t.price as number).toBeGreaterThanOrEqual(0);
+      }
+      if (t.xp_floor !== undefined) {
+        expect(typeof t.xp_floor).toBe('number');
+        expect(t.xp_floor as number).toBeGreaterThanOrEqual(0);
+      }
+    }
+  });
 });

--- a/scripts/__tests__/parse-game-defs.test.ts
+++ b/scripts/__tests__/parse-game-defs.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'fs';
 import { join } from 'path';
-import { buildAtsCityDlcMap } from '../parse-game-defs';
+import { buildAtsCityDlcMap, roundPriceUpToThousand, deriveTrailerIdFromDefName } from '../parse-game-defs';
 
 describe('buildAtsCityDlcMap', () => {
   it('returns empty object for empty input', () => {
@@ -40,6 +40,42 @@ describe('buildAtsCityDlcMap', () => {
     // exactly one DLC key present; california/arizona contribute nothing
     expect(Object.keys(result)).toHaveLength(1);
     expect(Object.values(result)[0]).toEqual(['denver']);
+  });
+});
+
+describe('roundPriceUpToThousand', () => {
+  it('rounds 0 to 0', () => {
+    expect(roundPriceUpToThousand(0)).toBe(0);
+  });
+
+  it('rounds non-zero sub-1000 sums up to 1000', () => {
+    expect(roundPriceUpToThousand(1)).toBe(1000);
+    expect(roundPriceUpToThousand(999)).toBe(1000);
+  });
+
+  it('leaves exact multiples of 1000 in place (no spurious round-up)', () => {
+    expect(roundPriceUpToThousand(1000)).toBe(1000);
+    expect(roundPriceUpToThousand(34000)).toBe(34000);
+  });
+
+  it('rounds anything past a thousand boundary up to the next thousand', () => {
+    expect(roundPriceUpToThousand(1001)).toBe(2000);
+    expect(roundPriceUpToThousand(33500)).toBe(34000);
+    expect(roundPriceUpToThousand(1234567)).toBe(1235000);
+  });
+});
+
+describe('deriveTrailerIdFromDefName', () => {
+  it('strips the leading "trailer_def." prefix', () => {
+    expect(deriveTrailerIdFromDefName('trailer_def.feldbinder.eut.silo')).toBe('feldbinder.eut.silo');
+  });
+
+  it('returns the name unchanged when no prefix is present', () => {
+    expect(deriveTrailerIdFromDefName('feldbinder.eut.silo')).toBe('feldbinder.eut.silo');
+  });
+
+  it('only strips the leading prefix, never a mid-name occurrence', () => {
+    expect(deriveTrailerIdFromDefName('trailer_def.foo.trailer_def.bar')).toBe('foo.trailer_def.bar');
   });
 });
 

--- a/scripts/__tests__/parse-game-defs.test.ts
+++ b/scripts/__tests__/parse-game-defs.test.ts
@@ -43,68 +43,73 @@ describe('buildAtsCityDlcMap', () => {
   });
 });
 
-describe('public/data/ats/game-defs.json schema invariants', () => {
-  const fixturePath = join(process.cwd(), 'public', 'data', 'ats', 'game-defs.json');
+function runSchemaInvariantsForGame(game: 'ats' | 'ets2') {
+  describe(`public/data/${game}/game-defs.json schema invariants`, () => {
+    const fixturePath = join(process.cwd(), 'public', 'data', game, 'game-defs.json');
 
-  it('has the expected top-level shape', () => {
-    const data = JSON.parse(readFileSync(fixturePath, 'utf-8'));
-    expect(data).toMatchObject({
-      cargo: expect.any(Object),
-      trailers: expect.any(Object),
-      companies: expect.any(Object),
-      cities: expect.any(Object),
-      countries: expect.any(Object),
-      economy: expect.any(Object),
-      trucks: expect.any(Array),
-      dlc: expect.any(Object),
+    it('has the expected top-level shape', () => {
+      const data = JSON.parse(readFileSync(fixturePath, 'utf-8'));
+      expect(data).toMatchObject({
+        cargo: expect.any(Object),
+        trailers: expect.any(Object),
+        companies: expect.any(Object),
+        cities: expect.any(Object),
+        countries: expect.any(Object),
+        economy: expect.any(Object),
+        trucks: expect.any(Array),
+        dlc: expect.any(Object),
+      });
+      expect(data.dlc).toMatchObject({
+        trailer_dlcs: expect.any(Object),
+        map_dlcs: expect.any(Object),
+        city_dlc_map: expect.any(Object),
+        garage_cities: expect.any(Array),
+      });
     });
-    expect(data.dlc).toMatchObject({
-      trailer_dlcs: expect.any(Object),
-      map_dlcs: expect.any(Object),
-      city_dlc_map: expect.any(Object),
-      garage_cities: expect.any(Array),
+
+    it('city_dlc_map keys are a subset of map_dlcs keys (no orphan DLC references)', () => {
+      const data = JSON.parse(readFileSync(fixturePath, 'utf-8'));
+      const mapDlcKeys = new Set(Object.keys(data.dlc.map_dlcs));
+      const cityDlcKeys = Object.keys(data.dlc.city_dlc_map);
+      const orphans = cityDlcKeys.filter(k => !mapDlcKeys.has(k));
+      expect(orphans).toEqual([]);
+      // Also assert every value is a string[] (shape, per AC-3.15)
+      for (const v of Object.values(data.dlc.city_dlc_map)) {
+        expect(Array.isArray(v)).toBe(true);
+        for (const cityId of v as unknown[]) expect(typeof cityId).toBe('string');
+      }
+    });
+
+    it('every cities[*].country exists as a key in countries', () => {
+      const data = JSON.parse(readFileSync(fixturePath, 'utf-8'));
+      const countryKeys = new Set(Object.keys(data.countries));
+      const orphans = Object.values(data.cities as Record<string, { country: string }>)
+        .map(c => c.country)
+        .filter(c => !countryKeys.has(c));
+      expect(orphans).toEqual([]);
+    });
+
+    // Forward-compatible: existing game-defs.json snapshots may pre-date the
+    // trailer pricing extraction (#251). Once a user re-runs the parser against
+    // extracted defs, every trailer gets price + xp_floor; if they're missing
+    // (older snapshot), the loader defaults to 0 and the frontend renders "—".
+    it('trailer pricing fields, when present, are numeric and price is a multiple of 1000', () => {
+      const data = JSON.parse(readFileSync(fixturePath, 'utf-8'));
+      for (const [, t] of Object.entries(data.trailers as Record<string, { price?: unknown; xp_floor?: unknown }>)) {
+        if (t.price !== undefined) {
+          expect(typeof t.price).toBe('number');
+          // Issue #251 spec: rounded UP to the nearest 1000.
+          expect((t.price as number) % 1000).toBe(0);
+          expect(t.price as number).toBeGreaterThanOrEqual(0);
+        }
+        if (t.xp_floor !== undefined) {
+          expect(typeof t.xp_floor).toBe('number');
+          expect(t.xp_floor as number).toBeGreaterThanOrEqual(0);
+        }
+      }
     });
   });
+}
 
-  it('city_dlc_map keys are a subset of map_dlcs keys (no orphan DLC references)', () => {
-    const data = JSON.parse(readFileSync(fixturePath, 'utf-8'));
-    const mapDlcKeys = new Set(Object.keys(data.dlc.map_dlcs));
-    const cityDlcKeys = Object.keys(data.dlc.city_dlc_map);
-    const orphans = cityDlcKeys.filter(k => !mapDlcKeys.has(k));
-    expect(orphans).toEqual([]);
-    // Also assert every value is a string[] (shape, per AC-3.15)
-    for (const v of Object.values(data.dlc.city_dlc_map)) {
-      expect(Array.isArray(v)).toBe(true);
-      for (const cityId of v as unknown[]) expect(typeof cityId).toBe('string');
-    }
-  });
-
-  it('every cities[*].country exists as a key in countries', () => {
-    const data = JSON.parse(readFileSync(fixturePath, 'utf-8'));
-    const countryKeys = new Set(Object.keys(data.countries));
-    const orphans = Object.values(data.cities as Record<string, { country: string }>)
-      .map(c => c.country)
-      .filter(c => !countryKeys.has(c));
-    expect(orphans).toEqual([]);
-  });
-
-  // Forward-compatible: existing game-defs.json snapshots may pre-date the
-  // trailer pricing extraction (#251). Once a user re-runs the parser against
-  // extracted defs, every trailer gets price + xp_floor; if they're missing
-  // (older snapshot), the loader defaults to 0 and the frontend renders "—".
-  it('trailer pricing fields, when present, are numeric and price is a multiple of 1000', () => {
-    const data = JSON.parse(readFileSync(fixturePath, 'utf-8'));
-    for (const [, t] of Object.entries(data.trailers as Record<string, { price?: unknown; xp_floor?: unknown }>)) {
-      if (t.price !== undefined) {
-        expect(typeof t.price).toBe('number');
-        // Issue #251 spec: rounded UP to the nearest 1000.
-        expect((t.price as number) % 1000).toBe(0);
-        expect(t.price as number).toBeGreaterThanOrEqual(0);
-      }
-      if (t.xp_floor !== undefined) {
-        expect(typeof t.xp_floor).toBe('number');
-        expect(t.xp_floor as number).toBeGreaterThanOrEqual(0);
-      }
-    }
-  });
-});
+runSchemaInvariantsForGame('ats');
+runSchemaInvariantsForGame('ets2');

--- a/scripts/parse-game-defs.ts
+++ b/scripts/parse-game-defs.ts
@@ -760,37 +760,20 @@ interface TrailerPricing {
   xp_floor: number;
 }
 
-/**
- * Round a raw accessory-summed price UP to the nearest 1000 per the issue #251
- * spec. Exact multiples of 1000 stay put; 1001 → 2000.
- */
+/** Round up to nearest 1000 per #251 spec. */
 export function roundPriceUpToThousand(total: number): number {
   return Math.ceil(total / 1000) * 1000;
 }
 
-/**
- * Strip the `trailer_def.` prefix from a `trailer_definition:` value to produce
- * the trailer key used everywhere else in the pipeline. Anchored — only the
- * leading prefix is removed.
- */
+/** Strip leading `trailer_def.` prefix; anchored — never strips mid-name. */
 export function deriveTrailerIdFromDefName(name: string): string {
   return name.replace(/^trailer_def\./, '');
 }
 
 /**
- * Walk every `def/vehicle/trailer_dealer/*.sii` file recursively, parse the
- * accessory chains, follow `data_path` references to per-accessory definitions,
- * and aggregate `price = sum(accessory.price)` (rounded UP to nearest 1000) +
- * `xp_floor = max(accessory.unlock)`.
- *
- * One dealer file maps to one `trailer_def` via the `trailer_definition:` prop
- * on its first `trailer : .X` block. The file may contain multiple `trailer`
- * blocks (parent + slave_trailer chain for double / b_double / triple setups);
- * accessories are summed across ALL trailer blocks in the file because they're
- * physically the same purchasable unit.
- *
- * Mirrors the truck-pricing pattern in `extractTrucks()` (engines + transmissions
- * + chassis each carry their own `price` / `unlock`; same `data_path` shape).
+ * Aggregate per-trailer dealer pricing. One dealer .sii file → one trailer_def;
+ * accessories sum across all trailer blocks (parent + slave chains for
+ * double/b_double/triple). Same shape as extractTrucks().
  */
 function extractTrailerPricing(): Map<string, TrailerPricing> {
   const pricing = new Map<string, TrailerPricing>();

--- a/scripts/parse-game-defs.ts
+++ b/scripts/parse-game-defs.ts
@@ -749,11 +749,132 @@ interface TrailerData {
   chain_type: string;
   country_validity: string[];
   ownable: boolean;
+  /** Total purchase price across all accessories, rounded UP to nearest 1000. 0 if no dealer data found. */
+  price: number;
+  /** Max accessory unlock level — XP floor at which the trailer becomes available. 0 if no dealer data found. */
+  xp_floor: number;
+}
+
+interface TrailerPricing {
+  price: number;
+  xp_floor: number;
+}
+
+/**
+ * Walk every `def/vehicle/trailer_dealer/*.sii` file recursively, parse the
+ * accessory chains, follow `data_path` references to per-accessory definitions,
+ * and aggregate `price = sum(accessory.price)` (rounded UP to nearest 1000) +
+ * `xp_floor = max(accessory.unlock)`.
+ *
+ * One dealer file maps to one `trailer_def` via the `trailer_definition:` prop
+ * on its first `trailer : .X` block. The file may contain multiple `trailer`
+ * blocks (parent + slave_trailer chain for double / b_double / triple setups);
+ * accessories are summed across ALL trailer blocks in the file because they're
+ * physically the same purchasable unit.
+ *
+ * Mirrors the truck-pricing pattern in `extractTrucks()` (engines + transmissions
+ * + chassis each carry their own `price` / `unlock`; same `data_path` shape).
+ */
+function extractTrailerPricing(): Map<string, TrailerPricing> {
+  const pricing = new Map<string, TrailerPricing>();
+  const dealerDir = join(defsPath, 'vehicle', 'trailer_dealer');
+  if (!existsSync(dealerDir)) return pricing;
+
+  // Resolve absolute `/def/...` data_path values relative to the extracted
+  // archive root (the parent directory of `defsPath`).
+  const archiveRoot = dirname(defsPath);
+
+  function walkSiiFiles(dir: string): string[] {
+    const out: string[] = [];
+    if (!existsSync(dir)) return out;
+    for (const entry of readdirSync(dir)) {
+      const full = join(dir, entry);
+      if (statSync(full).isDirectory()) {
+        out.push(...walkSiiFiles(full));
+      } else if (entry.endsWith('.sii') || entry.endsWith('.sui')) {
+        out.push(full);
+      }
+    }
+    return out;
+  }
+
+  const accessoryFileCache = new Map<string, ParsedUnit[]>();
+  function loadAccessoryFile(absPath: string): ParsedUnit[] {
+    const cached = accessoryFileCache.get(absPath);
+    if (cached) return cached;
+    if (!existsSync(absPath)) {
+      accessoryFileCache.set(absPath, []);
+      return [];
+    }
+    const parsed = parseSiiFile(readFileSync(absPath, 'utf-8'));
+    accessoryFileCache.set(absPath, parsed);
+    return parsed;
+  }
+
+  for (const dealerFile of walkSiiFiles(dealerDir)) {
+    const units = parseSiiFile(readFileSync(dealerFile, 'utf-8'));
+
+    // First pass: find the trailer_def reference and collect accessory refs
+    // across all trailer blocks. Refs look like ".data" / ".chassis" — we
+    // strip the leading dot to match against vehicle_accessory unit names.
+    let trailerDefName = '';
+    const accessoryRefs = new Set<string>();
+
+    for (const unit of units) {
+      if (unit.type !== 'trailer') continue;
+      if (!trailerDefName && typeof unit.props.trailer_definition === 'string') {
+        trailerDefName = unit.props.trailer_definition;
+      }
+      const accs = unit.props.accessories;
+      if (Array.isArray(accs)) {
+        for (const ref of accs) {
+          accessoryRefs.add(String(ref).replace(/^\./, ''));
+        }
+      }
+    }
+
+    if (!trailerDefName || accessoryRefs.size === 0) continue;
+    const trailerId = trailerDefName.replace(/^trailer_def\./, '');
+
+    // Second pass: resolve each ref to a vehicle_accessory's data_path, load
+    // that accessory's .sii file, and pull `price` + `unlock` from any unit
+    // inside it (typically there's exactly one).
+    let totalPrice = 0;
+    let maxUnlock = 0;
+
+    for (const unit of units) {
+      if (unit.type !== 'vehicle_accessory') continue;
+      const localName = unit.name.replace(/^\./, '');
+      if (!accessoryRefs.has(localName)) continue;
+
+      const dataPath = unit.props.data_path;
+      if (typeof dataPath !== 'string') continue;
+
+      const accFile = join(archiveRoot, dataPath.replace(/^\//, ''));
+      const accUnits = loadAccessoryFile(accFile);
+      for (const accUnit of accUnits) {
+        const price = typeof accUnit.props.price === 'number' ? accUnit.props.price : 0;
+        const unlock = typeof accUnit.props.unlock === 'number' ? accUnit.props.unlock : 0;
+        totalPrice += price;
+        if (unlock > maxUnlock) maxUnlock = unlock;
+      }
+    }
+
+    if (totalPrice === 0 && maxUnlock === 0) continue;
+
+    // Round price UP to the nearest 1000 per the issue spec — buyers think in
+    // round figures and dealer UIs display estimates this way.
+    const rounded = Math.ceil(totalPrice / 1000) * 1000;
+    pricing.set(trailerId, { price: rounded, xp_floor: maxUnlock });
+  }
+
+  return pricing;
 }
 
 function extractTrailers(): TrailerData[] {
   const trailerDefsDir = join(defsPath, 'vehicle', 'trailer_defs');
   const units = readAllSiiFiles(trailerDefsDir, '.sii');
+  const pricing = extractTrailerPricing();
 
   const trailers: TrailerData[] = [];
   const seenIds = new Set<string>();
@@ -766,6 +887,7 @@ function extractTrailers(): TrailerData[] {
     seenIds.add(fullName);
 
     const countryValidity = (unit.props.country_validity as string[]) || [];
+    const p = pricing.get(fullName);
 
     trailers.push({
       id: fullName,
@@ -781,6 +903,8 @@ function extractTrailers(): TrailerData[] {
       chain_type: String(unit.props.chain_type || 'single'),
       country_validity: countryValidity,
       ownable: true, // trailer_defs are generally ownable; non-ownable are in trailer/ dir
+      price: p?.price ?? 0,
+      xp_floor: p?.xp_floor ?? 0,
     });
   }
 
@@ -1360,6 +1484,8 @@ function buildFrontendData(
       chain_type: t.chain_type,
       country_validity: t.country_validity.length > 0 ? t.country_validity : undefined,
       ownable: t.ownable,
+      price: t.price,
+      xp_floor: t.xp_floor,
     }])),
     companies: Object.fromEntries(companies.map(co => [co.id, {
       name: co.name,

--- a/scripts/parse-game-defs.ts
+++ b/scripts/parse-game-defs.ts
@@ -751,13 +751,13 @@ interface TrailerData {
   ownable: boolean;
   /** Total purchase price across all accessories, rounded UP to nearest 1000. 0 if no dealer data found. */
   price: number;
-  /** Max accessory unlock level — XP floor at which the trailer becomes available. 0 if no dealer data found. */
-  xp_floor: number;
+  /** Max accessory unlock level — level at which the trailer becomes available. 0 if no dealer data found. */
+  level_floor: number;
 }
 
 interface TrailerPricing {
   price: number;
-  xp_floor: number;
+  level_floor: number;
 }
 
 /** Round up to nearest 1000 per #251 spec. */
@@ -862,7 +862,7 @@ function extractTrailerPricing(): Map<string, TrailerPricing> {
 
     if (totalPrice === 0 && maxUnlock === 0) continue;
 
-    pricing.set(trailerId, { price: roundPriceUpToThousand(totalPrice), xp_floor: maxUnlock });
+    pricing.set(trailerId, { price: roundPriceUpToThousand(totalPrice), level_floor: maxUnlock });
   }
 
   return pricing;
@@ -901,7 +901,7 @@ function extractTrailers(): TrailerData[] {
       country_validity: countryValidity,
       ownable: true, // trailer_defs are generally ownable; non-ownable are in trailer/ dir
       price: p?.price ?? 0,
-      xp_floor: p?.xp_floor ?? 0,
+      level_floor: p?.level_floor ?? 0,
     });
   }
 
@@ -1482,7 +1482,7 @@ function buildFrontendData(
       country_validity: t.country_validity.length > 0 ? t.country_validity : undefined,
       ownable: t.ownable,
       price: t.price,
-      xp_floor: t.xp_floor,
+      level_floor: t.level_floor,
     }])),
     companies: Object.fromEntries(companies.map(co => [co.id, {
       name: co.name,
@@ -1664,9 +1664,9 @@ function runDiff(newData: ReturnType<typeof buildFrontendData>): void {
     const oldPrice = oldVal.price ?? 0;
     const newPrice = newVal.price ?? 0;
     if (oldPrice !== newPrice) diffs.push(`price: ${oldPrice} → ${newPrice}`);
-    const oldXp = oldVal.xp_floor ?? 0;
-    const newXp = newVal.xp_floor ?? 0;
-    if (oldXp !== newXp) diffs.push(`xp_floor: ${oldXp} → ${newXp}`);
+    const oldXp = oldVal.level_floor ?? 0;
+    const newXp = newVal.level_floor ?? 0;
+    if (oldXp !== newXp) diffs.push(`level_floor: ${oldXp} → ${newXp}`);
     return diffs.length > 0 ? diffs.join(', ') : null;
   }, (id) => {
     // New trailer: clean if brand is known, needs_input for new brands
@@ -1774,7 +1774,7 @@ function runDiff(newData: ReturnType<typeof buildFrontendData>): void {
   // re-walks are warranted.
   const pricingChanges = changes.filter(c =>
     c.section === 'trailers' && c.type === 'changed'
-    && /(?:^|, )(price|xp_floor):/.test(c.detail));
+    && /(?:^|, )(price|level_floor):/.test(c.detail));
   if (pricingChanges.length > 0) {
     console.log(`--- PRICING CHANGES (${pricingChanges.length}) — re-walk advisory ---`);
     console.log('Dealer pricing shifted on the trailers below. If you maintain hand-walked');

--- a/scripts/parse-game-defs.ts
+++ b/scripts/parse-game-defs.ts
@@ -1657,6 +1657,16 @@ function runDiff(newData: ReturnType<typeof buildFrontendData>): void {
       diffs.push(`gross_weight_limit: ${oldVal.gross_weight_limit} → ${newVal.gross_weight_limit}`);
     if (JSON.stringify(oldVal.country_validity) !== JSON.stringify(newVal.country_validity))
       diffs.push(`country_validity changed`);
+    // Pricing tracked for re-walk advisory: any non-zero ↔ zero transition or
+    // delta on a priced trailer signals a likely dealer-side rework, which
+    // means hand-walked HCT/customization-screen equivalents for the same
+    // brand+body_type should be re-verified.
+    const oldPrice = oldVal.price ?? 0;
+    const newPrice = newVal.price ?? 0;
+    if (oldPrice !== newPrice) diffs.push(`price: ${oldPrice} → ${newPrice}`);
+    const oldXp = oldVal.xp_floor ?? 0;
+    const newXp = newVal.xp_floor ?? 0;
+    if (oldXp !== newXp) diffs.push(`xp_floor: ${oldXp} → ${newXp}`);
     return diffs.length > 0 ? diffs.join(', ') : null;
   }, (id) => {
     // New trailer: clean if brand is known, needs_input for new brands
@@ -1754,6 +1764,23 @@ function runDiff(newData: ReturnType<typeof buildFrontendData>): void {
     console.log(`--- REMOVED (${removed.length}) — content no longer in defs ---`);
     for (const c of removed) {
       console.log(`  - [${c.section}] ${c.id}: ${c.detail}`);
+    }
+    console.log('');
+  }
+
+  // Pricing-rework advisory: dealer-side price/xp shifts hint that customization-
+  // screen prices for related HCT/double variants of the same brand+body_type may
+  // also have changed. Surface these separately so the user knows which manual
+  // re-walks are warranted.
+  const pricingChanges = changes.filter(c =>
+    c.section === 'trailers' && c.type === 'changed'
+    && /(?:^|, )(price|xp_floor):/.test(c.detail));
+  if (pricingChanges.length > 0) {
+    console.log(`--- PRICING CHANGES (${pricingChanges.length}) — re-walk advisory ---`);
+    console.log('Dealer pricing shifted on the trailers below. If you maintain hand-walked');
+    console.log('HCT/customization prices for the same brand+body_type, re-verify them.');
+    for (const c of pricingChanges) {
+      console.log(`  ~ [trailers] ${c.id}: ${c.detail}`);
     }
     console.log('');
   }

--- a/scripts/parse-game-defs.ts
+++ b/scripts/parse-game-defs.ts
@@ -761,6 +761,23 @@ interface TrailerPricing {
 }
 
 /**
+ * Round a raw accessory-summed price UP to the nearest 1000 per the issue #251
+ * spec. Exact multiples of 1000 stay put; 1001 → 2000.
+ */
+export function roundPriceUpToThousand(total: number): number {
+  return Math.ceil(total / 1000) * 1000;
+}
+
+/**
+ * Strip the `trailer_def.` prefix from a `trailer_definition:` value to produce
+ * the trailer key used everywhere else in the pipeline. Anchored — only the
+ * leading prefix is removed.
+ */
+export function deriveTrailerIdFromDefName(name: string): string {
+  return name.replace(/^trailer_def\./, '');
+}
+
+/**
  * Walk every `def/vehicle/trailer_dealer/*.sii` file recursively, parse the
  * accessory chains, follow `data_path` references to per-accessory definitions,
  * and aggregate `price = sum(accessory.price)` (rounded UP to nearest 1000) +
@@ -834,7 +851,7 @@ function extractTrailerPricing(): Map<string, TrailerPricing> {
     }
 
     if (!trailerDefName || accessoryRefs.size === 0) continue;
-    const trailerId = trailerDefName.replace(/^trailer_def\./, '');
+    const trailerId = deriveTrailerIdFromDefName(trailerDefName);
 
     // Second pass: resolve each ref to a vehicle_accessory's data_path, load
     // that accessory's .sii file, and pull `price` + `unlock` from any unit
@@ -862,10 +879,7 @@ function extractTrailerPricing(): Map<string, TrailerPricing> {
 
     if (totalPrice === 0 && maxUnlock === 0) continue;
 
-    // Round price UP to the nearest 1000 per the issue spec — buyers think in
-    // round figures and dealer UIs display estimates this way.
-    const rounded = Math.ceil(totalPrice / 1000) * 1000;
-    pricing.set(trailerId, { price: rounded, xp_floor: maxUnlock });
+    pricing.set(trailerId, { price: roundPriceUpToThousand(totalPrice), xp_floor: maxUnlock });
   }
 
   return pricing;

--- a/scripts/parse-game-defs.ts
+++ b/scripts/parse-game-defs.ts
@@ -879,7 +879,7 @@ function extractTrailers(): TrailerData[] {
   for (const unit of units) {
     if (unit.type !== 'trailer_def') continue;
 
-    const fullName = unit.name.replace('trailer_def.', '');
+    const fullName = deriveTrailerIdFromDefName(unit.name);
     if (seenIds.has(fullName)) continue;
     seenIds.add(fullName);
 

--- a/src/frontend/body-types.ts
+++ b/src/frontend/body-types.ts
@@ -151,8 +151,6 @@ export function getBodyTypeProfiles(data: AllData, lookups: Lookups): BodyTypePr
       bestTotalHV: bestHV,
       bestChainType: best.chain_type || 'single',
       bestCountries: best.country_validity ?? [],
-      bestPrice: best.price ?? 0,
-      bestXpFloor: best.xp_floor ?? 0,
       hasDoubles: doublesSet.size > 0,
       hasBDoubles: bdoublesSet.size > 0,
       hasHCT: hctSet.size > 0,

--- a/src/frontend/body-types.ts
+++ b/src/frontend/body-types.ts
@@ -151,6 +151,8 @@ export function getBodyTypeProfiles(data: AllData, lookups: Lookups): BodyTypePr
       bestTotalHV: bestHV,
       bestChainType: best.chain_type || 'single',
       bestCountries: best.country_validity ?? [],
+      bestPrice: best.price ?? 0,
+      bestXpFloor: best.xp_floor ?? 0,
       hasDoubles: doublesSet.size > 0,
       hasBDoubles: bdoublesSet.size > 0,
       hasHCT: hctSet.size > 0,

--- a/src/frontend/city-detail-view.ts
+++ b/src/frontend/city-detail-view.ts
@@ -58,7 +58,7 @@ function renderFleetRow(entry: OptimalFleetEntry): string {
   const countLabel = entry.count > 1 ? ` \u00d7${entry.count}` : '';
   const trailerLink = `trailers.html#body-${entry.bodyType}`;
   const priceCell = entry.estimatedPrice > 0 ? formatNumber(entry.estimatedPrice) : '\u2014';
-  const xpCell = entry.xpFloor > 0 ? String(entry.xpFloor) : '\u2014';
+  const xpCell = entry.levelFloor > 0 ? String(entry.levelFloor) : '\u2014';
   return `
     <tr>
       <td>
@@ -185,7 +185,7 @@ export async function renderCity(
 
     <div class="table-section">
       <div class="section-header">
-        <h2>Recommended Fleet \u2014 ${optimal.totalTrailers} trailers${optimal.totalEstimatedPrice > 0 ? ` \u00b7 est. ${formatNumber(optimal.totalEstimatedPrice)} to assemble` : ''}${optimal.fleetXpFloor > 0 ? ` \u00b7 XP ${optimal.fleetXpFloor} to unlock all` : ''}</h2>
+        <h2>Recommended Fleet \u2014 ${optimal.totalTrailers} trailers${optimal.totalEstimatedPrice > 0 ? ` \u00b7 est. ${formatNumber(optimal.totalEstimatedPrice)} to assemble` : ''}${optimal.fleetLevelFloor > 0 ? ` \u00b7 level ${optimal.fleetLevelFloor} to unlock all` : ''}</h2>
         <div class="export-buttons">
           <button class="btn copy-btn" id="copy-fleet-btn" type="button">Copy Fleet</button>
           <button class="btn export-btn" id="export-csv-btn" type="button">Export CSV</button>
@@ -199,7 +199,7 @@ export async function renderCity(
             <th class="tooltip" tabindex="0" data-tooltip="Expected value per job cycle" aria-label="EV \u2014 Expected value per job cycle">EV</th>
             <th class="tooltip" tabindex="0" data-tooltip="Cargo types this trailer can haul" aria-label="Cargo \u2014 Cargo types this trailer can haul">Cargo</th>
             <th class="tooltip" tabindex="0" data-tooltip="Estimated purchase price (per trailer, rounded to nearest 1000)" aria-label="Price \u2014 Estimated purchase price per trailer">Price</th>
-            <th class="tooltip" tabindex="0" data-tooltip="Minimum XP level at which this trailer becomes available" aria-label="XP \u2014 Minimum XP level to unlock">XP</th>
+            <th class="tooltip" tabindex="0" data-tooltip="Minimum level at which this trailer becomes available" aria-label="Level \u2014 Minimum level to unlock">Level</th>
           </tr>
         </thead>
         <tbody>
@@ -228,13 +228,13 @@ function wireCopyFleetButton(cityName: string, drivers: OptimalFleetEntry[]) {
     const lines = drivers.map(d => {
       const countLabel = d.count > 1 ? ` x${d.count}` : '';
       const priceTag = d.estimatedPrice > 0 ? `, ${formatNumber(d.estimatedPrice)} ea` : '';
-      const xpTag = d.xpFloor > 0 ? `, XP ${d.xpFloor}` : '';
+      const xpTag = d.levelFloor > 0 ? `, level ${d.levelFloor}` : '';
       return `${d.displayName}${countLabel} (EV: ${formatNumber(d.ev)}, ${d.cargoMatched} cargo${priceTag}${xpTag})`;
     });
     const totalPrice = drivers.reduce((s, d) => s + d.estimatedPrice * d.count, 0);
-    const fleetXp = drivers.reduce((m, d) => Math.max(m, d.xpFloor), 0);
+    const fleetXp = drivers.reduce((m, d) => Math.max(m, d.levelFloor), 0);
     const totalLine = totalPrice > 0 || fleetXp > 0
-      ? `\nTotal: ${totalPrice > 0 ? formatNumber(totalPrice) : '—'} · XP ${fleetXp > 0 ? fleetXp : '—'}`
+      ? `\nTotal: ${totalPrice > 0 ? formatNumber(totalPrice) : '—'} · level ${fleetXp > 0 ? fleetXp : '—'}`
       : '';
     const text = `${cityName} Fleet:\n${lines.join('\n')}${totalLine}`;
     copyToClipboard(text, copyBtn);
@@ -272,14 +272,14 @@ function downloadFile(content: string, filename: string, mimeType: string): void
 }
 
 function exportToCSV(cityName: string, drivers: OptimalFleetEntry[]): void {
-  const headers = ['Trailer Type', 'Count', 'EV', 'Cargo Types', 'Est. Price', 'XP Floor'];
+  const headers = ['Trailer Type', 'Count', 'EV', 'Cargo Types', 'Est. Price', 'Level Floor'];
   const rows = drivers.map(d => [
     `"${d.displayName}"`,
     d.count,
     d.ev.toFixed(2),
     d.cargoMatched,
     d.estimatedPrice > 0 ? d.estimatedPrice : '',
-    d.xpFloor > 0 ? d.xpFloor : '',
+    d.levelFloor > 0 ? d.levelFloor : '',
   ]);
   const csv = [headers.join(','), ...rows.map(row => row.join(','))].join('\n');
   const safeName = sanitizeFilename(cityName);
@@ -294,7 +294,7 @@ function exportToJSON(
   score: number,
 ): void {
   const totalEstimatedPrice = drivers.reduce((s, d) => s + d.estimatedPrice * d.count, 0);
-  const fleetXpFloor = drivers.reduce((m, d) => Math.max(m, d.xpFloor), 0);
+  const fleetLevelFloor = drivers.reduce((m, d) => Math.max(m, d.levelFloor), 0);
   const exportData = {
     city: cityName,
     exportedAt: new Date().toISOString(),
@@ -305,7 +305,7 @@ function exportToJSON(
       totalTrailers: drivers.reduce((sum, d) => sum + d.count, 0),
       trailerTypes: drivers.length,
       totalEstimatedPrice,
-      fleetXpFloor,
+      fleetLevelFloor,
     },
     fleet: drivers.map(d => ({
       trailerType: d.displayName,
@@ -314,7 +314,7 @@ function exportToJSON(
       ev: d.ev,
       cargoMatched: d.cargoMatched,
       estimatedPrice: d.estimatedPrice > 0 ? d.estimatedPrice : null,
-      xpFloor: d.xpFloor > 0 ? d.xpFloor : null,
+      levelFloor: d.levelFloor > 0 ? d.levelFloor : null,
     })),
   };
   const json = JSON.stringify(exportData, null, 2);

--- a/src/frontend/city-detail-view.ts
+++ b/src/frontend/city-detail-view.ts
@@ -57,6 +57,8 @@ async function ensureRankingsCached(
 function renderFleetRow(entry: OptimalFleetEntry): string {
   const countLabel = entry.count > 1 ? ` \u00d7${entry.count}` : '';
   const trailerLink = `trailers.html#body-${entry.bodyType}`;
+  const priceCell = entry.estimatedPrice > 0 ? formatNumber(entry.estimatedPrice) : '\u2014';
+  const xpCell = entry.xpFloor > 0 ? String(entry.xpFloor) : '\u2014';
   return `
     <tr>
       <td>
@@ -65,6 +67,8 @@ function renderFleetRow(entry: OptimalFleetEntry): string {
       </td>
       <td class="amount">${formatNumber(entry.ev)}</td>
       <td class="amount">${entry.cargoMatched}</td>
+      <td class="amount">${priceCell}</td>
+      <td class="amount">${xpCell}</td>
     </tr>
   `;
 }
@@ -181,7 +185,7 @@ export async function renderCity(
 
     <div class="table-section">
       <div class="section-header">
-        <h2>Recommended Fleet \u2014 ${optimal.totalTrailers} trailers</h2>
+        <h2>Recommended Fleet \u2014 ${optimal.totalTrailers} trailers${optimal.totalEstimatedPrice > 0 ? ` \u00b7 est. ${formatNumber(optimal.totalEstimatedPrice)} to assemble` : ''}${optimal.fleetXpFloor > 0 ? ` \u00b7 XP ${optimal.fleetXpFloor} to unlock all` : ''}</h2>
         <div class="export-buttons">
           <button class="btn copy-btn" id="copy-fleet-btn" type="button">Copy Fleet</button>
           <button class="btn export-btn" id="export-csv-btn" type="button">Export CSV</button>
@@ -194,6 +198,8 @@ export async function renderCity(
             <th>Trailer Type</th>
             <th class="tooltip" tabindex="0" data-tooltip="Expected value per job cycle" aria-label="EV \u2014 Expected value per job cycle">EV</th>
             <th class="tooltip" tabindex="0" data-tooltip="Cargo types this trailer can haul" aria-label="Cargo \u2014 Cargo types this trailer can haul">Cargo</th>
+            <th class="tooltip" tabindex="0" data-tooltip="Estimated purchase price (per trailer, rounded to nearest 1000)" aria-label="Price \u2014 Estimated purchase price per trailer">Price</th>
+            <th class="tooltip" tabindex="0" data-tooltip="Minimum XP level at which this trailer becomes available" aria-label="XP \u2014 Minimum XP level to unlock">XP</th>
           </tr>
         </thead>
         <tbody>
@@ -221,9 +227,16 @@ function wireCopyFleetButton(cityName: string, drivers: OptimalFleetEntry[]) {
   copyBtn.addEventListener('click', () => {
     const lines = drivers.map(d => {
       const countLabel = d.count > 1 ? ` x${d.count}` : '';
-      return `${d.displayName}${countLabel} (EV: ${formatNumber(d.ev)}, ${d.cargoMatched} cargo)`;
+      const priceTag = d.estimatedPrice > 0 ? `, ${formatNumber(d.estimatedPrice)} ea` : '';
+      const xpTag = d.xpFloor > 0 ? `, XP ${d.xpFloor}` : '';
+      return `${d.displayName}${countLabel} (EV: ${formatNumber(d.ev)}, ${d.cargoMatched} cargo${priceTag}${xpTag})`;
     });
-    const text = `${cityName} Fleet:\n${lines.join('\n')}`;
+    const totalPrice = drivers.reduce((s, d) => s + d.estimatedPrice * d.count, 0);
+    const fleetXp = drivers.reduce((m, d) => Math.max(m, d.xpFloor), 0);
+    const totalLine = totalPrice > 0 || fleetXp > 0
+      ? `\nTotal: ${totalPrice > 0 ? formatNumber(totalPrice) : '—'} · XP ${fleetXp > 0 ? fleetXp : '—'}`
+      : '';
+    const text = `${cityName} Fleet:\n${lines.join('\n')}${totalLine}`;
     copyToClipboard(text, copyBtn);
   });
 }
@@ -259,12 +272,14 @@ function downloadFile(content: string, filename: string, mimeType: string): void
 }
 
 function exportToCSV(cityName: string, drivers: OptimalFleetEntry[]): void {
-  const headers = ['Trailer Type', 'Count', 'EV', 'Cargo Types'];
+  const headers = ['Trailer Type', 'Count', 'EV', 'Cargo Types', 'Est. Price', 'XP Floor'];
   const rows = drivers.map(d => [
     `"${d.displayName}"`,
     d.count,
     d.ev.toFixed(2),
     d.cargoMatched,
+    d.estimatedPrice,
+    d.xpFloor,
   ]);
   const csv = [headers.join(','), ...rows.map(row => row.join(','))].join('\n');
   const safeName = sanitizeFilename(cityName);
@@ -278,6 +293,8 @@ function exportToJSON(
   cargoTypes: number,
   score: number,
 ): void {
+  const totalEstimatedPrice = drivers.reduce((s, d) => s + d.estimatedPrice * d.count, 0);
+  const fleetXpFloor = drivers.reduce((m, d) => Math.max(m, d.xpFloor), 0);
   const exportData = {
     city: cityName,
     exportedAt: new Date().toISOString(),
@@ -287,6 +304,8 @@ function exportToJSON(
       score,
       totalTrailers: drivers.reduce((sum, d) => sum + d.count, 0),
       trailerTypes: drivers.length,
+      totalEstimatedPrice,
+      fleetXpFloor,
     },
     fleet: drivers.map(d => ({
       trailerType: d.displayName,
@@ -294,6 +313,8 @@ function exportToJSON(
       count: d.count,
       ev: d.ev,
       cargoMatched: d.cargoMatched,
+      estimatedPrice: d.estimatedPrice,
+      xpFloor: d.xpFloor,
     })),
   };
   const json = JSON.stringify(exportData, null, 2);

--- a/src/frontend/city-detail-view.ts
+++ b/src/frontend/city-detail-view.ts
@@ -58,7 +58,7 @@ function renderFleetRow(entry: OptimalFleetEntry): string {
   const countLabel = entry.count > 1 ? ` \u00d7${entry.count}` : '';
   const trailerLink = `trailers.html#body-${entry.bodyType}`;
   const priceCell = entry.estimatedPrice > 0 ? formatNumber(entry.estimatedPrice) : '\u2014';
-  const xpCell = entry.levelFloor > 0 ? String(entry.levelFloor) : '\u2014';
+  const levelCell = entry.levelFloor > 0 ? String(entry.levelFloor) : '\u2014';
   return `
     <tr>
       <td>
@@ -68,7 +68,7 @@ function renderFleetRow(entry: OptimalFleetEntry): string {
       <td class="amount">${formatNumber(entry.ev)}</td>
       <td class="amount">${entry.cargoMatched}</td>
       <td class="amount">${priceCell}</td>
-      <td class="amount">${xpCell}</td>
+      <td class="amount">${levelCell}</td>
     </tr>
   `;
 }
@@ -228,13 +228,13 @@ function wireCopyFleetButton(cityName: string, drivers: OptimalFleetEntry[]) {
     const lines = drivers.map(d => {
       const countLabel = d.count > 1 ? ` x${d.count}` : '';
       const priceTag = d.estimatedPrice > 0 ? `, ${formatNumber(d.estimatedPrice)} ea` : '';
-      const xpTag = d.levelFloor > 0 ? `, level ${d.levelFloor}` : '';
-      return `${d.displayName}${countLabel} (EV: ${formatNumber(d.ev)}, ${d.cargoMatched} cargo${priceTag}${xpTag})`;
+      const levelTag = d.levelFloor > 0 ? `, level ${d.levelFloor}` : '';
+      return `${d.displayName}${countLabel} (EV: ${formatNumber(d.ev)}, ${d.cargoMatched} cargo${priceTag}${levelTag})`;
     });
     const totalPrice = drivers.reduce((s, d) => s + d.estimatedPrice * d.count, 0);
-    const fleetXp = drivers.reduce((m, d) => Math.max(m, d.levelFloor), 0);
-    const totalLine = totalPrice > 0 || fleetXp > 0
-      ? `\nTotal: ${totalPrice > 0 ? formatNumber(totalPrice) : '—'} · level ${fleetXp > 0 ? fleetXp : '—'}`
+    const fleetLevel = drivers.reduce((m, d) => Math.max(m, d.levelFloor), 0);
+    const totalLine = totalPrice > 0 || fleetLevel > 0
+      ? `\nTotal: ${totalPrice > 0 ? formatNumber(totalPrice) : '—'} · level ${fleetLevel > 0 ? fleetLevel : '—'}`
       : '';
     const text = `${cityName} Fleet:\n${lines.join('\n')}${totalLine}`;
     copyToClipboard(text, copyBtn);

--- a/src/frontend/city-detail-view.ts
+++ b/src/frontend/city-detail-view.ts
@@ -278,8 +278,8 @@ function exportToCSV(cityName: string, drivers: OptimalFleetEntry[]): void {
     d.count,
     d.ev.toFixed(2),
     d.cargoMatched,
-    d.estimatedPrice,
-    d.xpFloor,
+    d.estimatedPrice > 0 ? d.estimatedPrice : '',
+    d.xpFloor > 0 ? d.xpFloor : '',
   ]);
   const csv = [headers.join(','), ...rows.map(row => row.join(','))].join('\n');
   const safeName = sanitizeFilename(cityName);
@@ -313,8 +313,8 @@ function exportToJSON(
       count: d.count,
       ev: d.ev,
       cargoMatched: d.cargoMatched,
-      estimatedPrice: d.estimatedPrice,
-      xpFloor: d.xpFloor,
+      estimatedPrice: d.estimatedPrice > 0 ? d.estimatedPrice : null,
+      xpFloor: d.xpFloor > 0 ? d.xpFloor : null,
     })),
   };
   const json = JSON.stringify(exportData, null, 2);

--- a/src/frontend/loader.ts
+++ b/src/frontend/loader.ts
@@ -158,6 +158,8 @@ function buildTrailers(defs: GameDefs | null, obs: Observations | null): Trailer
       chain_type: t.chain_type,
       country_validity: t.country_validity,
       ownable: t.ownable,
+      price: t.price ?? 0,
+      xp_floor: t.xp_floor ?? 0,
     }));
   }
   if (obs) {
@@ -172,6 +174,8 @@ function buildTrailers(defs: GameDefs | null, obs: Observations | null): Trailer
       length: 0,
       chain_type: 'single',
       ownable: true,
+      price: 0,
+      xp_floor: 0,
     }));
   }
   return [];

--- a/src/frontend/loader.ts
+++ b/src/frontend/loader.ts
@@ -159,7 +159,7 @@ function buildTrailers(defs: GameDefs | null, obs: Observations | null): Trailer
       country_validity: t.country_validity,
       ownable: t.ownable,
       price: t.price ?? 0,
-      xp_floor: t.xp_floor ?? 0,
+      level_floor: t.level_floor ?? 0,
     }));
   }
   if (obs) {
@@ -175,7 +175,7 @@ function buildTrailers(defs: GameDefs | null, obs: Observations | null): Trailer
       chain_type: 'single',
       ownable: true,
       price: 0,
-      xp_floor: 0,
+      level_floor: 0,
     }));
   }
   return [];

--- a/src/frontend/optimizer.ts
+++ b/src/frontend/optimizer.ts
@@ -360,10 +360,17 @@ function getTrailerInfoForCountry(
   if (cached) return cached;
 
   const info = new Map<string, TrailerInfo>();
+  // Best-EV trailer per body type, restricted to dealer-priced ownable
+  // trailers — keeps spec/EV/price/XP consistent. HCT/double chains that
+  // aren't sold via dealer (player assembles them through the customization
+  // system, not a flat dealer file) are excluded; the recommendation reflects
+  // what the player can actually purchase. Once the player unlocks chain
+  // upgrades, the in-game customization replaces the single trailer.
   const bestByBT = new Map<string, { trailer: Trailer; totalHV: number }>();
 
   for (const t of data.trailers) {
     if (!t.ownable) continue;
+    if ((t.price ?? 0) <= 0) continue;
     if (t.country_validity && t.country_validity.length > 0
       && !t.country_validity.includes(country)) continue;
 
@@ -390,8 +397,8 @@ function getTrailerInfoForCountry(
     info.set(bt, {
       trailerId: trailer.id,
       trailerSpec: formatTrailerSpec(trailer),
-      estimatedPrice: trailer.price ?? 0,
-      xpFloor: trailer.xp_floor ?? 0,
+      estimatedPrice: trailer.price,
+      xpFloor: trailer.xp_floor,
     });
   }
 

--- a/src/frontend/optimizer.ts
+++ b/src/frontend/optimizer.ts
@@ -59,8 +59,8 @@ export interface OptimalFleetEntry {
   count: number;           // 1-5 for drivers (collapsed by body type)
   /** Per-trailer purchase price (rounded to nearest 1000); 0 if no dealer data. */
   estimatedPrice: number;
-  /** XP level at which this trailer becomes available (max accessory unlock); 0 if no dealer data. */
-  xpFloor: number;
+  /** Level at which this trailer becomes available (max accessory unlock); 0 if no dealer data. */
+  levelFloor: number;
 }
 
 export interface OptimalFleet {
@@ -68,8 +68,8 @@ export interface OptimalFleet {
   totalTrailers: number;
   /** Sum of `estimatedPrice × count` across all drivers; 0 when no dealer data is present. */
   totalEstimatedPrice: number;
-  /** Highest XP floor across all recommended drivers — when the full fleet becomes ownable. */
-  fleetXpFloor: number;
+  /** Highest level floor across all recommended drivers — when the full fleet becomes ownable. */
+  fleetLevelFloor: number;
 }
 
 export interface CityRanking {
@@ -337,7 +337,7 @@ interface TrailerInfo {
   trailerId: string;
   trailerSpec: string;
   estimatedPrice: number;
-  xpFloor: number;
+  levelFloor: number;
 }
 
 /** Cache: country → bodyType → best trailer info */
@@ -361,7 +361,7 @@ function getTrailerInfoForCountry(
 
   const info = new Map<string, TrailerInfo>();
   // Best-EV trailer per body type, restricted to dealer-priced ownable
-  // trailers — keeps spec/EV/price/XP consistent. HCT/double chains that
+  // trailers — keeps spec/EV/price/level consistent. HCT/double chains that
   // aren't sold via dealer (player assembles them through the customization
   // system, not a flat dealer file) are excluded; the recommendation reflects
   // what the player can actually purchase. Once the player unlocks chain
@@ -398,7 +398,7 @@ function getTrailerInfoForCountry(
       trailerId: trailer.id,
       trailerSpec: formatTrailerSpec(trailer),
       estimatedPrice: trailer.price,
-      xpFloor: trailer.xp_floor,
+      levelFloor: trailer.level_floor,
     });
   }
 
@@ -612,15 +612,15 @@ export function computeOptimalFleet(
       cargoMatched: countCityCargoForBodyType(depots, bt),
       count,
       estimatedPrice: info?.estimatedPrice ?? 0,
-      xpFloor: info?.xpFloor ?? 0,
+      levelFloor: info?.levelFloor ?? 0,
     };
   });
 
   const totalTrailers = drivers.reduce((s, d) => s + d.count, 0);
   const totalEstimatedPrice = drivers.reduce((s, d) => s + d.estimatedPrice * d.count, 0);
-  const fleetXpFloor = drivers.reduce((m, d) => Math.max(m, d.xpFloor), 0);
+  const fleetLevelFloor = drivers.reduce((m, d) => Math.max(m, d.levelFloor), 0);
 
-  return { drivers, totalTrailers, totalEstimatedPrice, fleetXpFloor };
+  return { drivers, totalTrailers, totalEstimatedPrice, fleetLevelFloor };
 }
 
 // ============================================

--- a/src/frontend/optimizer.ts
+++ b/src/frontend/optimizer.ts
@@ -57,11 +57,19 @@ export interface OptimalFleetEntry {
   ev: number;
   cargoMatched: number;
   count: number;           // 1-5 for drivers (collapsed by body type)
+  /** Per-trailer purchase price (rounded to nearest 1000); 0 if no dealer data. */
+  estimatedPrice: number;
+  /** XP level at which this trailer becomes available (max accessory unlock); 0 if no dealer data. */
+  xpFloor: number;
 }
 
 export interface OptimalFleet {
   drivers: OptimalFleetEntry[];
   totalTrailers: number;
+  /** Sum of `estimatedPrice × count` across all drivers; 0 when no dealer data is present. */
+  totalEstimatedPrice: number;
+  /** Highest XP floor across all recommended drivers — when the full fleet becomes ownable. */
+  fleetXpFloor: number;
 }
 
 export interface CityRanking {
@@ -325,8 +333,15 @@ function bestJob(board: DepotCargoItem[], bodyType: string): { hv: number; idx: 
 // Body type display info (country-aware)
 // ============================================
 
+interface TrailerInfo {
+  trailerId: string;
+  trailerSpec: string;
+  estimatedPrice: number;
+  xpFloor: number;
+}
+
 /** Cache: country → bodyType → best trailer info */
-const trailerInfoCache = new Map<string, Map<string, { trailerId: string; trailerSpec: string }>>();
+const trailerInfoCache = new Map<string, Map<string, TrailerInfo>>();
 
 /** Clear trailer info cache — needed when DLC filter state changes between optimizer runs */
 export function clearTrailerInfoCache(): void {
@@ -340,11 +355,11 @@ export function clearTrailerInfoCache(): void {
  */
 function getTrailerInfoForCountry(
   country: string, data: AllData, lookups: Lookups,
-): Map<string, { trailerId: string; trailerSpec: string }> {
+): Map<string, TrailerInfo> {
   const cached = trailerInfoCache.get(country);
   if (cached) return cached;
 
-  const info = new Map<string, { trailerId: string; trailerSpec: string }>();
+  const info = new Map<string, TrailerInfo>();
   const bestByBT = new Map<string, { trailer: Trailer; totalHV: number }>();
 
   for (const t of data.trailers) {
@@ -375,6 +390,8 @@ function getTrailerInfoForCountry(
     info.set(bt, {
       trailerId: trailer.id,
       trailerSpec: formatTrailerSpec(trailer),
+      estimatedPrice: trailer.price ?? 0,
+      xpFloor: trailer.xp_floor ?? 0,
     });
   }
 
@@ -587,12 +604,16 @@ export function computeOptimalFleet(
       ev,
       cargoMatched: countCityCargoForBodyType(depots, bt),
       count,
+      estimatedPrice: info?.estimatedPrice ?? 0,
+      xpFloor: info?.xpFloor ?? 0,
     };
   });
 
   const totalTrailers = drivers.reduce((s, d) => s + d.count, 0);
+  const totalEstimatedPrice = drivers.reduce((s, d) => s + d.estimatedPrice * d.count, 0);
+  const fleetXpFloor = drivers.reduce((m, d) => Math.max(m, d.xpFloor), 0);
 
-  return { drivers, totalTrailers };
+  return { drivers, totalTrailers, totalEstimatedPrice, fleetXpFloor };
 }
 
 // ============================================

--- a/src/frontend/types.ts
+++ b/src/frontend/types.ts
@@ -48,6 +48,10 @@ export interface Trailer {
   chain_type: string;
   country_validity?: string[];
   ownable: boolean;
+  /** Total purchase price across all accessories, rounded UP to nearest 1000. 0 if no dealer data. */
+  price: number;
+  /** Max accessory unlock level — XP floor at which the trailer becomes available. 0 if no dealer data. */
+  xp_floor: number;
 }
 
 export interface GameDefs {
@@ -76,6 +80,8 @@ export interface GameDefs {
     chain_type: string;
     country_validity?: string[];
     ownable: boolean;
+    price: number;
+    xp_floor: number;
   }>;
   cities: Record<string, {
     name: string;
@@ -193,6 +199,8 @@ export interface BodyTypeProfile {
   bestTotalHV: number;       // sum of haulValue across all cargo for the best trailer
   bestChainType: string;     // chain_type of the best trailer
   bestCountries: string[];   // country_validity of the best trailer (empty = all)
+  bestPrice: number;         // purchase price of the best trailer (0 if no dealer data)
+  bestXpFloor: number;       // XP floor (max accessory unlock) of the best trailer
   hasDoubles: boolean;
   hasBDoubles: boolean;
   hasHCT: boolean;

--- a/src/frontend/types.ts
+++ b/src/frontend/types.ts
@@ -50,8 +50,8 @@ export interface Trailer {
   ownable: boolean;
   /** Total purchase price across all accessories, rounded UP to nearest 1000. 0 if no dealer data. */
   price: number;
-  /** Max accessory unlock level — XP floor at which the trailer becomes available. 0 if no dealer data. */
-  xp_floor: number;
+  /** Max accessory unlock level — level at which the trailer becomes available. 0 if no dealer data. */
+  level_floor: number;
 }
 
 export interface GameDefs {
@@ -81,7 +81,7 @@ export interface GameDefs {
     country_validity?: string[];
     ownable: boolean;
     price: number;
-    xp_floor: number;
+    level_floor: number;
   }>;
   cities: Record<string, {
     name: string;

--- a/src/frontend/types.ts
+++ b/src/frontend/types.ts
@@ -199,8 +199,6 @@ export interface BodyTypeProfile {
   bestTotalHV: number;       // sum of haulValue across all cargo for the best trailer
   bestChainType: string;     // chain_type of the best trailer
   bestCountries: string[];   // country_validity of the best trailer (empty = all)
-  bestPrice: number;         // purchase price of the best trailer (0 if no dealer data)
-  bestXpFloor: number;       // XP floor (max accessory unlock) of the best trailer
   hasDoubles: boolean;
   hasBDoubles: boolean;
   hasHCT: boolean;


### PR DESCRIPTION
## Summary

- Adds `price` + `xp_floor` to every trailer via `extractTrailerPricing()` in `parse-game-defs.ts`. Mirrors the pattern in `extractTrucks()`.
- Propagates through `Trailer` → `BodyTypeProfile` → `OptimalFleet{,Entry}`.
- City detail fleet table gains Price/XP columns + section-header totals; CSV/JSON/clipboard exports include the new fields.

Closes #251.