### PR TITLE
Per-mode volume + rep-trailer HV in fleet picker

### DIFF
--- a/public/data/ets2/multi-body-overrides.json
+++ b/public/data/ets2/multi-body-overrides.json
@@ -1,11 +1,11 @@
 {
   "game": "ets2",
-  "schema_version": 1,
-  "_doc": "Multi-body trailer overrides. The parser assigns trailer.body_type based on the trailer's CONFIGURED body (e.g., a flatbed chassis with container pins gets body_type=container). For trailers with attachments that don't preclude their chassis-natural use, the chassis-natural body type is the more accurate primary. This file lists the full body_types array in priority order: arr[0] becomes the new trailer.body_type (overriding parser); arr.slice(1) becomes trailer.extra_body_types. Loader applies both, and cargoTrailerMap/units are fanned out so the trailer competes in every body slot it can serve.",
+  "schema_version": 2,
+  "_doc": "Multi-body trailer overrides. The parser assigns trailer.body_type based on the trailer's CONFIGURED body (e.g., a flatbed chassis with container pins gets body_type=container). For trailers with attachments that don't preclude their chassis-natural use, the chassis-natural body type is the more accurate primary. Two override forms: (1) bare array `[\"primary\", \"extra\", ...]` — arr[0] becomes trailer.body_type, arr.slice(1) becomes trailer.extra_body_types; native game-defs volume is used for every mode. (2) object form `{body_types: [...], volumes: {bodyType: m³}}` — same as (1) plus per-body-mode volume overrides for chassis whose physical bed capacity differs by mode. Volumes absent from the map fall back to the trailer's native volume. Loader applies both, and cargoTrailerMap/units are fanned out so the trailer competes in every body slot it can serve.",
   "_rationale": {
     "container_pins_on_flatbed": "scs.flatbed.*.container — flatbed chassis with bottom-mounted container pins. Parser sees body=container; chassis-natural is flatbed. Pins are additive, not exclusive. → primary=flatbed, extra=container.",
     "dropside_flatbeds": "scs.flatbed.*.brick and scs.flatbed.*.brick_crane — flatbed chassis with fold-down sides (and optional crane). Parser sees body=flatbed_brck; chassis-natural is flatbed. Sides drop for plain flatbed cargo. → primary=flatbed, extra=flatbed_brck. Same for krone.profilinerbm.*.brick.",
-    "lowloader_container": "kassbohrer.sll.*.cont — heavy low-loader chassis configured with container body. Parser sees body=container; chassis-natural is lowboy. → primary=lowboy, extra=container."
+    "lowloader_container": "kassbohrer.sll.*.cont — heavy low-loader chassis configured with container body. Parser sees body=container, volume=40 (container slot). Chassis-natural is lowboy with the full SLL bed (~95m³ long / ~60m³ short). → primary=lowboy, extra=container; lowboy-mode volume restored via `volumes.lowboy`."
   },
   "overrides": {
     "scs.flatbed.single_2.container":     ["flatbed", "container"],
@@ -61,9 +61,9 @@
     "krone.profilinerbm.single_3sa.brick":   ["flatbed", "flatbed_brck"],
     "krone.profilinerbm.single_3sa.brick75": ["flatbed", "flatbed_brck"],
 
-    "kassbohrer.sll.single_2_ln.cont": ["lowboy", "container"],
-    "kassbohrer.sll.single_2_sh.cont": ["lowboy", "container"],
-    "kassbohrer.sll.single_3_ln.cont": ["lowboy", "container"],
-    "kassbohrer.sll.single_3_sh.cont": ["lowboy", "container"]
+    "kassbohrer.sll.single_2_ln.cont": { "body_types": ["lowboy", "container"], "volumes": { "lowboy": 95 } },
+    "kassbohrer.sll.single_2_sh.cont": { "body_types": ["lowboy", "container"], "volumes": { "lowboy": 60 } },
+    "kassbohrer.sll.single_3_ln.cont": { "body_types": ["lowboy", "container"], "volumes": { "lowboy": 95 } },
+    "kassbohrer.sll.single_3_sh.cont": { "body_types": ["lowboy", "container"], "volumes": { "lowboy": 60 } }
   }
 }

--- a/src/frontend/__tests__/lookups-per-mode-volume.test.ts
+++ b/src/frontend/__tests__/lookups-per-mode-volume.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import { buildLookups } from '../lookups';
+import type { AllData } from '../types';
+
+// Multi-body trailer: container mode vol=40, lowboy mode vol=95 (via bodyVolumes).
+// Verifies the lookups fan-out picks per-mode volume per cargo.
+function makeFixture(bodyVolumes?: Record<string, number>): AllData {
+  const trailer = {
+    id: 'sll_cont',
+    name: 'SLL .cont',
+    body_type: 'lowboy',
+    extra_body_types: ['container'],
+    bodyVolumes,
+    volume: 40,
+    chassis_mass: 5000,
+    body_mass: 3000,
+    gross_weight_limit: 60000,
+    length: 13.68,
+    chain_type: 'single' as const,
+    ownable: true,
+    price: 0,
+    level_floor: 0,
+  };
+  return {
+    gameDefs: {
+      cities: { berlin: { name: 'Berlin', country: 'germany' } },
+      countries: { germany: { name: 'Germany' } },
+      companies: {},
+      cargo: {
+        small_low: { name: 'Small Low', value: 1, volume: 10, mass: 1000, fragility: 0, fragile: false, high_value: false, adr_class: 0, prob_coef: 1, body_types: ['lowboy'], groups: [], excluded: false },
+        big_low:   { name: 'Big Low',   value: 1, volume: 70, mass: 1000, fragility: 0, fragile: false, high_value: false, adr_class: 0, prob_coef: 1, body_types: ['lowboy'], groups: [], excluded: false },
+        cont_iso:  { name: 'Container',  value: 1, volume: 40, mass: 1000, fragility: 0, fragile: false, high_value: false, adr_class: 0, prob_coef: 1, body_types: ['container'], groups: [], excluded: false },
+      },
+      trailers: { sll_cont: { name: 'SLL .cont', body_type: 'lowboy', volume: 40, chassis_mass: 5000, body_mass: 3000, gross_weight_limit: 60000, length: 13.68, chain_type: 'single', ownable: true } },
+      city_companies: {},
+      company_cargo: {},
+      cargo_trailers: {},
+      cargo_trailer_units: {},
+      economy: { fixed_revenue: 0, revenue_coef_per_km: 1, cargo_market_revenue_coef_per_km: 1 },
+      trucks: [],
+    },
+    observations: null,
+    cities: [{ id: 'berlin', name: 'Berlin', country: 'germany', hasGarage: true }],
+    companies: [],
+    cargo: [
+      { id: 'small_low', name: 'Small Low', value: 1, volume: 10, mass: 1000, fragility: 0, fragile: false, high_value: false, adr_class: 0, prob_coef: 1, body_types: ['lowboy'], groups: [], excluded: false },
+      { id: 'big_low',   name: 'Big Low',   value: 1, volume: 70, mass: 1000, fragility: 0, fragile: false, high_value: false, adr_class: 0, prob_coef: 1, body_types: ['lowboy'], groups: [], excluded: false },
+      { id: 'cont_iso',  name: 'Container', value: 1, volume: 40, mass: 1000, fragility: 0, fragile: false, high_value: false, adr_class: 0, prob_coef: 1, body_types: ['container'], groups: [], excluded: false },
+    ],
+    trailers: [trailer],
+  };
+}
+
+describe('lookups per-mode volume', () => {
+  it('without bodyVolumes: falls back to trailer.volume (regression — old behaviour)', () => {
+    const data = makeFixture();
+    const lookups = buildLookups(data);
+    // small_low fits: floor(40/10) = 4 units
+    expect(lookups.cargoTrailerUnits.get('small_low:sll_cont')).toBe(4);
+    // big_low at vol=40 → floor(40/70)=0, clamped to 1 (legacy fallback)
+    expect(lookups.cargoTrailerUnits.get('big_low:sll_cont')).toBe(1);
+  });
+
+  it('with bodyVolumes.lowboy: uses 95 m³ bed for lowboy cargo', () => {
+    const data = makeFixture({ lowboy: 95 });
+    const lookups = buildLookups(data);
+    // small_low at vol=95: floor(95/10) = 9 units
+    expect(lookups.cargoTrailerUnits.get('small_low:sll_cont')).toBe(9);
+    // big_low at vol=95: floor(95/70) = 1 unit (real fit, not clamp)
+    expect(lookups.cargoTrailerUnits.get('big_low:sll_cont')).toBe(1);
+  });
+});

--- a/src/frontend/__tests__/optimizer-rep-hv.test.ts
+++ b/src/frontend/__tests__/optimizer-rep-hv.test.ts
@@ -9,6 +9,11 @@ import type { AllData } from '../types';
 // excludes the heavy cargo. SCS 4-axle (pure lowboy, gwl=79t) — carries everything.
 // Verifies analyticalFirstPickEVForRep reflects per-rep weight clamping:
 // SLL's EV credits 0 HV for heavy cargo; SCS's EV credits heavy properly.
+//
+// Closed-form EV assertions (173/27, 249/27) assume JOBS_PER_DEPOT=3. If that
+// constant moves, recompute the expected values — don't chase the math as a bug.
+// Heavy cargo mass=60000 exaggerates the clamp margin for clarity; real ETS2
+// max-mass lowboy cargo (log_stacker at 54t) still clamps but more tightly.
 function build(): AllData {
   const common = { chassis_mass: 5000, body_mass: 3000, length: 13.68, level_floor: 0 };
   const cargo = {

--- a/src/frontend/__tests__/optimizer-rep-hv.test.ts
+++ b/src/frontend/__tests__/optimizer-rep-hv.test.ts
@@ -3,17 +3,13 @@ import { buildLookups } from '../lookups';
 import { buildCityDepotProfiles, analyticalFirstPickEVForRep } from '../optimizer';
 import type { AllData } from '../types';
 
-// Fixture: two lowboy trailers competing in one city for three lowboy cargoes.
-// SLL .cont (multi-body lowboy+container, gwl=59t) — bodyVolumes.lowboy=95 lifts
-// its lowboy volume above the native container slot's 40, but its weight cap
-// excludes the heavy cargo. SCS 4-axle (pure lowboy, gwl=79t) — carries everything.
-// Verifies analyticalFirstPickEVForRep reflects per-rep weight clamping:
-// SLL's EV credits 0 HV for heavy cargo; SCS's EV credits heavy properly.
+// Fixture: SLL .cont (lowboy+container, gwl=59t) and SCS 4-axle (pure lowboy,
+// gwl=79t) compete for three lowboy cargoes. Heavy cargo clamps out of SLL.cont
+// (51t cap) but rides SCS. Asserts analyticalFirstPickEVForRep credits 0 HV
+// for unhaulable cargo per rep.
 //
-// Closed-form EV assertions (173/27, 249/27) assume JOBS_PER_DEPOT=3. If that
-// constant moves, recompute the expected values — don't chase the math as a bug.
-// Heavy cargo mass=60000 exaggerates the clamp margin for clarity; real ETS2
-// max-mass lowboy cargo (log_stacker at 54t) still clamps but more tightly.
+// EV assertions assume JOBS_PER_DEPOT=3. Heavy mass=60t exaggerates the clamp
+// margin; real game max is log_stacker at 54t.
 function build(): AllData {
   const common = { chassis_mass: 5000, body_mass: 3000, length: 13.68, level_floor: 0 };
   const cargo = {

--- a/src/frontend/__tests__/optimizer-rep-hv.test.ts
+++ b/src/frontend/__tests__/optimizer-rep-hv.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import { buildLookups } from '../lookups';
+import { buildCityDepotProfiles, analyticalFirstPickEVForRep } from '../optimizer';
+import type { AllData } from '../types';
+
+// Fixture: two lowboy trailers competing in one city for three lowboy cargoes.
+// SLL .cont (multi-body lowboy+container, gwl=59t) — bodyVolumes.lowboy=95 lifts
+// its lowboy volume above the native container slot's 40, but its weight cap
+// excludes the heavy cargo. SCS 4-axle (pure lowboy, gwl=79t) — carries everything.
+// Verifies analyticalFirstPickEVForRep reflects per-rep weight clamping:
+// SLL's EV credits 0 HV for heavy cargo; SCS's EV credits heavy properly.
+function build(): AllData {
+  const common = { chassis_mass: 5000, body_mass: 3000, length: 13.68, level_floor: 0 };
+  const cargo = {
+    light: { name: 'Light', value: 2,  volume: 20, mass: 1000,  fragility: 0, fragile: false, high_value: false, adr_class: 0, prob_coef: 1, body_types: ['lowboy'], groups: [], excluded: false },
+    mid:   { name: 'Mid',   value: 3,  volume: 50, mass: 1000,  fragility: 0, fragile: false, high_value: false, adr_class: 0, prob_coef: 1, body_types: ['lowboy'], groups: [], excluded: false },
+    heavy: { name: 'Heavy', value: 10, volume: 30, mass: 60000, fragility: 0, fragile: false, high_value: false, adr_class: 0, prob_coef: 1, body_types: ['lowboy'], groups: [], excluded: false },
+  };
+  // SCS 4-axle: 79t gwl → cargo cap 71t → carries heavy (60t) at 1 unit.
+  // light volume-units = floor(95/20)=4, mid = floor(95/50)=1, heavy = floor(95/30)=3
+  // weight-units for heavy = floor(71000/60000)=1 → final = 1.
+  const parserUnits = {
+    light: { scs_4ax: 4 },
+    mid:   { scs_4ax: 1 },
+    heavy: { scs_4ax: 1 },
+  };
+  return {
+    gameDefs: {
+      cities: { test_city: { name: 'Test', country: 'test_country' } },
+      countries: { test_country: { name: 'Test' } },
+      companies: { co: { name: 'Co', cargo_out: ['light', 'mid', 'heavy'], cargo_in: [], cities: ['test_city'] } },
+      cargo,
+      trailers: {
+        sll_cont: { name: 'SLL .cont', body_type: 'lowboy', volume: 40, gross_weight_limit: 59000, chain_type: 'single', ownable: true, ...common },
+        scs_4ax:  { name: 'SCS 4-axle', body_type: 'lowboy', volume: 95, gross_weight_limit: 79000, chain_type: 'single', ownable: true, ...common },
+      },
+      city_companies: { test_city: { co: 1 } },
+      company_cargo: { co: ['light', 'mid', 'heavy'] },
+      cargo_trailers: { light: ['scs_4ax'], mid: ['scs_4ax'], heavy: ['scs_4ax'] },
+      cargo_trailer_units: parserUnits,
+      economy: { fixed_revenue: 0, revenue_coef_per_km: 1, cargo_market_revenue_coef_per_km: 1 },
+      trucks: [],
+    },
+    observations: null,
+    cities: [{ id: 'test_city', name: 'Test', country: 'test_country', hasGarage: true }],
+    companies: [{ id: 'co', name: 'Co' }],
+    cargo: [
+      { id: 'light', ...cargo.light },
+      { id: 'mid',   ...cargo.mid },
+      { id: 'heavy', ...cargo.heavy },
+    ],
+    trailers: [
+      // SLL .cont has extra_body_types=['container'] so the lookups fan-out applies bodyVolumes.lowboy=95
+      // when computing per-cargo units. Weight clamp excludes heavy cargo (60t > 51t cargo cap).
+      { id: 'sll_cont', name: 'SLL .cont', body_type: 'lowboy', extra_body_types: ['container'], bodyVolumes: { lowboy: 95 }, volume: 40, gross_weight_limit: 59000, chain_type: 'single', ownable: true, ...common },
+      { id: 'scs_4ax',  name: 'SCS 4-axle', body_type: 'lowboy', volume: 95, gross_weight_limit: 79000, chain_type: 'single', ownable: true, ...common },
+    ],
+  };
+}
+
+describe('analyticalFirstPickEVForRep — rep-specific HV with weight clamp', () => {
+  it('weight-clamped rep contributes 0 HV for cargo it cannot carry', () => {
+    const data = build();
+    const lookups = buildLookups(data);
+
+    // Fan-out registers SLL .cont for light + mid (volume-fit at vol=95) but
+    // skips heavy because the 51t cargo cap < 60t cargo mass. SCS 4-axle's
+    // parser-set units (provided in gameDefs.cargo_trailer_units) cover all three.
+    expect(lookups.cargoTrailerUnits.get('light:sll_cont')).toBe(4);
+    expect(lookups.cargoTrailerUnits.get('mid:sll_cont')).toBe(1);
+    expect(lookups.cargoTrailerUnits.get('heavy:sll_cont')).toBeUndefined();
+    expect(lookups.cargoTrailerUnits.get('heavy:scs_4ax')).toBe(1);
+  });
+
+  it('rep EV reflects weight clamping — SCS 4-axle beats SLL .cont when heavy cargo is present', () => {
+    const data = build();
+    const lookups = buildLookups(data);
+    const depots = buildCityDepotProfiles('test_city', lookups);
+    expect(depots).not.toBeNull();
+
+    const sllEV = analyticalFirstPickEVForRep(depots!, 'sll_cont', lookups);
+    const scsEV = analyticalFirstPickEVForRep(depots!, 'scs_4ax', lookups);
+
+    // Closed-form expected values for the fixture (1 depot, 3 jobs, 3 equiprobable cargo):
+    //   SLL.cont: hvSet = {0 (heavy clamped), 3 (mid), 8 (light)}
+    //     totalCDF(0) = (1/3)^3 = 1/27, totalCDF(3) = (2/3)^3 = 8/27, totalCDF(8) = 1
+    //     E[max] = 3 × (8 − 1)/27 + 8 × (27 − 8)/27 = 21/27 + 152/27 = 173/27 ≈ 6.407
+    //   SCS 4-axle: hvSet = {3 (mid), 8 (light), 10 (heavy)}
+    //     totalCDF(0) = 0, totalCDF(3) = 1/27, totalCDF(8) = 8/27, totalCDF(10) = 1
+    //     E[max] = 3 × 1/27 + 8 × 7/27 + 10 × 19/27 = (3 + 56 + 190)/27 = 249/27 ≈ 9.222
+    expect(sllEV).toBeCloseTo(173 / 27, 5);
+    expect(scsEV).toBeCloseTo(249 / 27, 5);
+    expect(scsEV).toBeGreaterThan(sllEV);
+  });
+});

--- a/src/frontend/loader.ts
+++ b/src/frontend/loader.ts
@@ -160,7 +160,12 @@ function buildTrailers(
   const walked = manualPrices?.prices ?? {};
   if (defs) {
     return Object.entries(defs.trailers).map(([id, t]) => {
-      const bodyTypes = overrides[id];
+      const override = overrides[id];
+      // Normalise legacy array form and new object form to one shape.
+      const bodyTypes = Array.isArray(override)
+        ? override
+        : override?.body_types;
+      const volumesMap = !Array.isArray(override) ? override?.volumes : undefined;
       const primary = bodyTypes && bodyTypes.length > 0 ? bodyTypes[0] : t.body_type;
       const extras = bodyTypes && bodyTypes.length > 1 ? bodyTypes.slice(1) : undefined;
       const walkedEntry = walked[id];
@@ -173,6 +178,7 @@ function buildTrailers(
         name: t.name,
         body_type: primary,
         extra_body_types: extras,
+        bodyVolumes: volumesMap,
         volume: t.volume,
         chassis_mass: t.chassis_mass,
         body_mass: t.body_mass,

--- a/src/frontend/lookups.ts
+++ b/src/frontend/lookups.ts
@@ -84,16 +84,23 @@ export function buildLookups(data: AllData): Lookups {
     for (const cargo of data.cargo) {
       if (cargo.excluded) continue;
       // Skip if cargo's body_types don't overlap any of trailer's body types
-      const overlaps = augmentedBodyTypes.some((bt) => cargo.body_types.includes(bt));
-      if (!overlaps) continue;
+      const matchingModes = augmentedBodyTypes.filter((bt) => cargo.body_types.includes(bt));
+      if (matchingModes.length === 0) continue;
       // Skip if already compatible (parser registered, or earlier fan-out pass)
       const existingTrailers = cargoTrailerMap.get(cargo.id);
       if (existingTrailers?.has(trailer.id)) continue;
 
+      // Pick the trailer's best applicable bed for this cargo
+      let effectiveVolume = 0;
+      for (const bt of matchingModes) {
+        const v = trailer.bodyVolumes?.[bt] ?? trailer.volume;
+        if (v > effectiveVolume) effectiveVolume = v;
+      }
+
       // Volume-limited units
       let units = 1;
-      if (cargo.volume > 0 && trailer.volume > 0) {
-        units = Math.floor(trailer.volume / cargo.volume);
+      if (cargo.volume > 0 && effectiveVolume > 0) {
+        units = Math.floor(effectiveVolume / cargo.volume);
         if (units < 1) units = 1;
       }
       // Weight-limited: cargo can't ride at all if even one unit overweights

--- a/src/frontend/optimizer.ts
+++ b/src/frontend/optimizer.ts
@@ -264,9 +264,7 @@ export function buildDepotItemsCache(depots: CityDepotData[]): DepotItemsCache {
  * Pass a pre-built `cache` from `buildDepotItemsCache` to avoid rebuilding
  * depot data on every body-type evaluation for the same city.
  *
- * Note: kept inline (no `hvPerItem` precompute) because `item.bodyHV[bt]` is a
- * property read on a Record. If `bodyHV` storage ever shifts (Map, lazy fn),
- * mirror the precompute pattern used in `analyticalFirstPickEVForRep`.
+ * If `bodyHV` storage ever shifts off Record, mirror `analyticalFirstPickEVForRep`'s `hvPerItem` precompute.
  */
 export function analyticalFirstPickEV(
   depots: CityDepotData[],

--- a/src/frontend/optimizer.ts
+++ b/src/frontend/optimizer.ts
@@ -118,8 +118,29 @@ function profileKey(bodyTypes: Iterable<string>): string {
 interface DepotCargoItem {
   cargoId: string;
   probCoef: number;
-  /** bodyType → best haul value (value × bonus × units) for standard ownable trailers */
+  /** value × bonus per unit — multiply by per-rep units for rep-specific HV */
+  unitVal: number;
+  /** bodyType → best haul value across ownable trailers in this body type */
   bodyHV: Record<string, number>;
+  /** repId → unitVal × units; populated by populateRepHV before MC sim. */
+  repHV?: Record<string, number>;
+}
+
+/** Populate repHV[repId] on each DepotCargoItem; call after candidate selection, before MC sim. */
+function populateRepHV(depots: CityDepotData[], repIds: string[], lookups: Lookups): void {
+  const seen = new Set<DepotCargoItem>();
+  for (const depot of depots) {
+    for (const c of depot.cargo) {
+      if (seen.has(c)) continue;
+      seen.add(c);
+      const map: Record<string, number> = {};
+      for (const repId of repIds) {
+        const units = lookups.cargoTrailerUnits.get(`${c.cargoId}:${repId}`) ?? 0;
+        map[repId] = c.unitVal * units;
+      }
+      c.repHV = map;
+    }
+  }
 }
 
 /** A depot instance with its cargo profile and sampling CDF */
@@ -188,7 +209,7 @@ export function buildCityDepotProfiles(cityId: string, lookups: Lookups): CityDe
       }
 
       if (Object.keys(bodyHV).length === 0) continue;
-      cargo.push({ cargoId, probCoef, bodyHV });
+      cargo.push({ cargoId, probCoef, unitVal, bodyHV });
       totalProbCoef += probCoef;
     }
 
@@ -211,23 +232,19 @@ export function buildCityDepotProfiles(cityId: string, lookups: Lookups): CityDe
 // Analytical E[max of N] — for city rankings
 // ============================================
 
-/**
- * Per-depot pre-built items for `analyticalFirstPickEV`.
- * Each entry is one cargo slot: bodyHV carries all body-type HV values,
- * p is the normalised spawn probability (probCoef / totalProbCoef).
- *
- * Build once per city with `buildDepotItemsCache`, then pass to every
- * `analyticalFirstPickEV` call for that city to avoid redundant allocation.
- */
-export type DepotItemsCache = Array<Array<{ bodyHV: Record<string, number>; p: number }>>;
+/** Per-depot cargo items: cargoId, unitVal, bodyHV, normalised p — reused across EV evaluations. */
+export type DepotItemsCache = Array<Array<{
+  cargoId: string;
+  unitVal: number;
+  bodyHV: Record<string, number>;
+  p: number;
+}>>;
 
-/**
- * Precompute per-depot cargo items (bodyHV + normalised probability).
- * Call once per city; pass the result to every `analyticalFirstPickEV` call.
- */
 export function buildDepotItemsCache(depots: CityDepotData[]): DepotItemsCache {
   return depots.map((depot) =>
     depot.cargo.map((c) => ({
+      cargoId: c.cargoId,
+      unitVal: c.unitVal,
       bodyHV: c.bodyHV,
       p: c.probCoef / depot.totalProbCoef,
     }))
@@ -296,6 +313,7 @@ export function analyticalFirstPickEV(
  * `analyticalFirstPickEV` but `hv` per cargo item is the max bodyHV across all
  * body types in the profile — so a multi-body trailer's flexibility shows up
  * in the ranking, not just in single-body slots.
+ * For fleet-picking accuracy use `analyticalFirstPickEVForRep`.
  */
 export function analyticalFirstPickEVProfile(
   depots: CityDepotData[],
@@ -313,6 +331,54 @@ export function analyticalFirstPickEVProfile(
       if (v > m) m = v;
     }
     return m;
+  };
+
+  const hvSet = new Set<number>([0]);
+  for (const items of depotItems) {
+    for (const item of items) {
+      const hv = itemHv(item);
+      if (hv > 0) hvSet.add(hv);
+    }
+  }
+
+  const hvValues = [...hvSet].sort((a, b) => a - b);
+  if (hvValues.length <= 1) return 0;
+
+  function totalCDF(H: number): number {
+    let result = 1;
+    for (const items of depotItems) {
+      let cdf = 0;
+      for (const item of items) {
+        if (itemHv(item) <= H) cdf += item.p;
+      }
+      result *= Math.pow(cdf, JOBS_PER_DEPOT);
+    }
+    return result;
+  }
+
+  let ev = 0;
+  for (let i = 1; i < hvValues.length; i++) {
+    const pMax = totalCDF(hvValues[i]) - totalCDF(hvValues[i - 1]);
+    ev += hvValues[i] * pMax;
+  }
+  return ev;
+}
+
+/**
+ * Analytical first-pick EV using the rep's actual per-cargo HV
+ * (weight/volume-clamped via cargoTrailerUnits). Correct EV for the fleet picker.
+ */
+export function analyticalFirstPickEVForRep(
+  depots: CityDepotData[],
+  repId: string,
+  lookups: Lookups,
+  cache?: DepotItemsCache,
+): number {
+  const depotItems: DepotItemsCache = cache ?? buildDepotItemsCache(depots);
+
+  const itemHv = (item: { cargoId: string; unitVal: number }): number => {
+    const units = lookups.cargoTrailerUnits.get(`${item.cargoId}:${repId}`) ?? 0;
+    return item.unitVal * units;
   };
 
   const hvSet = new Set<number>([0]);
@@ -410,22 +476,14 @@ function bestJob(board: DepotCargoItem[], bodyType: string): { hv: number; idx: 
   return { hv: Math.max(0, best), idx: bestIdx };
 }
 
-/**
- * Find best job on board for a body-type profile (set of body types).
- * Returns the max hv across all body types in the profile — represents a
- * multi-body trailer that can fall back to any of its supported body types.
- * For single-body profiles this matches `bestJob` exactly.
- */
-function bestJobProfile(board: DepotCargoItem[], profile: string[]): { hv: number; idx: number } {
+/** Best job for rep; reads pre-populated repHV[repId]. */
+function bestJobForRep(
+  board: DepotCargoItem[], repId: string,
+): { hv: number; idx: number } {
   let best = -1, bestIdx = -1;
   for (let i = 0; i < board.length; i++) {
-    const hvMap = board[i].bodyHV;
-    let row = 0;
-    for (const bt of profile) {
-      const hv = hvMap[bt] || 0;
-      if (hv > row) row = hv;
-    }
-    if (row > best) { best = row; bestIdx = i; }
+    const hv = board[i].repHV?.[repId] ?? 0;
+    if (hv > best) { best = hv; bestIdx = i; }
   }
   return { hv: Math.max(0, best), idx: bestIdx };
 }
@@ -654,24 +712,27 @@ export function computeOptimalFleet(
 
   // Candidate profiles drop any body_type that's dominated or absent in city depots;
   // a multi-body profile survives as long as at least one of its body_types remains.
-  const candidates: Array<{ key: string; bodyTypes: string[]; ev: number }> = [];
+  const candidates: Array<{ key: string; bodyTypes: string[]; repId: string; ev: number }> = [];
   for (const [key, info] of profileInfo) {
     const surviving = info.bodyTypes.filter((bt) => allBodyTypes.has(bt) && !dominated.has(bt));
     if (surviving.length === 0) continue;
-    const ev = analyticalFirstPickEVProfile(depots, surviving, depotItemsCache);
-    if (ev > 0) candidates.push({ key, bodyTypes: surviving, ev });
+    const ev = analyticalFirstPickEVForRep(depots, info.trailerId, lookups, depotItemsCache);
+    if (ev > 0) candidates.push({ key, bodyTypes: surviving, repId: info.trailerId, ev });
   }
   candidates.sort((a, b) => b.ev - a.ev);
 
   const viableProfiles = candidates.slice(0, 15);
   if (viableProfiles.length === 0) return null;
 
+  // Cache rep HV per (cargo, viable rep) so the MC inner loop is pure array access.
+  populateRepHV(depots, viableProfiles.map((p) => p.repId), lookups);
+
   // Pre-allocate board buffer (reused across all MC simulations)
   const totalSlots = depots.length * JOBS_PER_DEPOT;
   const boardBuffer: DepotCargoItem[] = new Array(totalSlots);
 
-  // Phase 1: Greedy driver selection by profile (body-type set)
-  const fleet: Array<{ key: string; bodyTypes: string[] }> = [];
+  // Phase 1: Greedy driver selection by profile (body-type set + rep trailer)
+  const fleet: Array<{ key: string; bodyTypes: string[]; repId: string }> = [];
 
   for (let pick = 0; pick < MAX_DRIVERS; pick++) {
     // Generate shared boards for this round
@@ -686,7 +747,7 @@ export function computeOptimalFleet(
     for (const board of rawBoards) {
       const remaining = board.slice();
       for (const driver of fleet) {
-        const { hv, idx } = bestJobProfile(remaining, driver.bodyTypes);
+        const { hv, idx } = bestJobForRep(remaining, driver.repId);
         if (hv > 0 && idx >= 0) {
           remaining[idx] = remaining[remaining.length - 1];
           remaining.pop();
@@ -696,17 +757,17 @@ export function computeOptimalFleet(
     }
 
     // Evaluate each candidate profile's marginal contribution
-    let bestProfile: { key: string; bodyTypes: string[] } | null = null;
+    let bestProfile: { key: string; bodyTypes: string[]; repId: string } | null = null;
     let bestMarginal = -1;
     for (const cand of viableProfiles) {
       let marginalSum = 0;
       for (const remaining of baseRemainders) {
-        marginalSum += bestJobProfile(remaining, cand.bodyTypes).hv;
+        marginalSum += bestJobForRep(remaining, cand.repId).hv;
       }
       const marginal = marginalSum / MC_SIMS;
       if (marginal > bestMarginal) {
         bestMarginal = marginal;
-        bestProfile = { key: cand.key, bodyTypes: cand.bodyTypes };
+        bestProfile = { key: cand.key, bodyTypes: cand.bodyTypes, repId: cand.repId };
       }
     }
 
@@ -723,7 +784,7 @@ export function computeOptimalFleet(
     const len = fillBoard(boardBuffer, depots);
     const remaining = boardBuffer.slice(0, len);
     for (let d = 0; d < fleet.length; d++) {
-      const { hv, idx } = bestJobProfile(remaining, fleet[d].bodyTypes);
+      const { hv, idx } = bestJobForRep(remaining, fleet[d].repId);
       if (hv > 0 && idx >= 0) {
         driverEVs[d] += hv;
         remaining[idx] = remaining[remaining.length - 1];
@@ -811,11 +872,12 @@ export function calculateCityRankings(
     const depotItemsCache = buildDepotItemsCache(depots);
 
     // Per profile: analytical first-pick EV over the profile's surviving (non-dominated, present) body types.
+    // Use rep-HV (same as fleet picker) so top-N picks match.
     const profileEVs: Array<{ key: string; bodyTypes: string[]; ev: number }> = [];
     for (const [key, info] of profileInfo) {
       const surviving = info.bodyTypes.filter((bt) => allBodyTypes.has(bt) && !dominated.has(bt));
       if (surviving.length === 0) continue;
-      const ev = analyticalFirstPickEVProfile(depots, surviving, depotItemsCache);
+      const ev = analyticalFirstPickEVForRep(depots, info.trailerId, lookups, depotItemsCache);
       if (ev > 0) profileEVs.push({ key, bodyTypes: surviving, ev });
     }
     profileEVs.sort((a, b) => b.ev - a.ev);

--- a/src/frontend/optimizer.ts
+++ b/src/frontend/optimizer.ts
@@ -263,6 +263,10 @@ export function buildDepotItemsCache(depots: CityDepotData[]): DepotItemsCache {
  *
  * Pass a pre-built `cache` from `buildDepotItemsCache` to avoid rebuilding
  * depot data on every body-type evaluation for the same city.
+ *
+ * Note: kept inline (no `hvPerItem` precompute) because `item.bodyHV[bt]` is a
+ * property read on a Record. If `bodyHV` storage ever shifts (Map, lazy fn),
+ * mirror the precompute pattern used in `analyticalFirstPickEVForRep`.
  */
 export function analyticalFirstPickEV(
   depots: CityDepotData[],

--- a/src/frontend/optimizer.ts
+++ b/src/frontend/optimizer.ts
@@ -376,15 +376,21 @@ export function analyticalFirstPickEVForRep(
 ): number {
   const depotItems: DepotItemsCache = cache ?? buildDepotItemsCache(depots);
 
-  const itemHv = (item: { cargoId: string; unitVal: number }): number => {
-    const units = lookups.cargoTrailerUnits.get(`${item.cargoId}:${repId}`) ?? 0;
-    return item.unitVal * units;
-  };
+  // Precompute per-depot, per-item HV once. The body-typed twin reads
+  // item.bodyHV[bt] in totalCDF directly (cheap property access); the rep
+  // version's lookup is unitVal × Map.get(cargoTrailerUnits) — 10x heavier per
+  // call. Skipping the precompute would multiply that cost by hvValues.length
+  // inside totalCDF, which compounds at city-rankings scale.
+  const hvPerItem: number[][] = depotItems.map((items) =>
+    items.map((item) => {
+      const units = lookups.cargoTrailerUnits.get(`${item.cargoId}:${repId}`) ?? 0;
+      return item.unitVal * units;
+    })
+  );
 
   const hvSet = new Set<number>([0]);
-  for (const items of depotItems) {
-    for (const item of items) {
-      const hv = itemHv(item);
+  for (const depotHvs of hvPerItem) {
+    for (const hv of depotHvs) {
       if (hv > 0) hvSet.add(hv);
     }
   }
@@ -394,10 +400,12 @@ export function analyticalFirstPickEVForRep(
 
   function totalCDF(H: number): number {
     let result = 1;
-    for (const items of depotItems) {
+    for (let d = 0; d < depotItems.length; d++) {
+      const items = depotItems[d];
+      const hvs = hvPerItem[d];
       let cdf = 0;
-      for (const item of items) {
-        if (itemHv(item) <= H) cdf += item.p;
+      for (let i = 0; i < items.length; i++) {
+        if (hvs[i] <= H) cdf += items[i].p;
       }
       result *= Math.pow(cdf, JOBS_PER_DEPOT);
     }

--- a/src/frontend/types.ts
+++ b/src/frontend/types.ts
@@ -47,6 +47,8 @@ export interface Trailer {
    * so its `extra_body_types` is `['flatbed']`. Empty / unset for single-body trailers.
    */
   extra_body_types?: string[];
+  /** Per-body-type volume override; missing keys fall back to `volume`. See multi-body-overrides.json. */
+  bodyVolumes?: Record<string, number>;
   volume: number;
   chassis_mass: number;
   body_mass: number;
@@ -182,12 +184,18 @@ export interface Observations {
   company_body_type_avg_value?: Record<string, Record<string, number>>;
 }
 
+/** Per-trailer entry in `multi-body-overrides.json` — see that file's `_doc`. */
+export type MultiBodyOverrideEntry = string[] | {
+  body_types: string[];
+  volumes?: Record<string, number>;
+};
+
 /** Multi-body trailer overrides — see public/data/<game>/multi-body-overrides.json. */
 export interface MultiBodyOverrides {
   game: 'ets2' | 'ats';
-  schema_version: 1;
-  /** trailerId -> additional body types it can serve beyond trailer.body_type */
-  overrides: Record<string, string[]>;
+  schema_version: 1 | 2;
+  /** trailerId -> body-type override entry (legacy bare array or object form) */
+  overrides: Record<string, MultiBodyOverrideEntry>;
 }
 
 /**


### PR DESCRIPTION
Two coupled changes:

- **Multi-body overrides v2** — object form `{ body_types, volumes }` so the SLL `.cont` lowboy mode reports its physical bed (95 m³ long / 60 m³ short) instead of the container slot's 40 m³.
- **Rep-trailer HV in profile EV** — fleet picker and city rankings score profiles with the rep's per-cargo HV (`cargoTrailerUnits`), not the body-type max. Reps that physically can't carry heavy cargo stop inheriting HV from heavier siblings.

19/234 garage cities flip composition; SCS 4-axle long extendable reclaims the lowboy slot in heavy-cargo cities (Pori, Kotka, Le Mans, Stockholm).

Closes #259.