### PR TITLE
Greedy MC rankings, fleet shared with detail view

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ Euro Truck Simulator 2 and American Truck Simulator trucking company analyzer - 
 - Cities contain depots (company facilities), each spawning random cargo jobs
 - Cargoes have value, spawn probability (prob_coef), and compatible trailer body types
 - Monte Carlo simulation finds best fleet: greedy driver selection maximizing marginal EV
-- City rankings use analytical E[max of N] formula for speed (no MC needed per city)
+- City rankings run the same greedy MC picker as fleet computation (`RANKING_MC_SIMS = 500`); fleet cached on `CityRanking.fleet` and shared with the city detail view
 
 **First-Visit UX**:
 - DLC configuration banner prompts new visitors to set up owned DLCs for accurate results
@@ -138,9 +138,10 @@ Phase 3 — Collapse:
 ```
 
 ### City Ranking Score (`calculateCityRankings()`)
-- Uses analytical E[max of N] formula (`analyticalFirstPickEV()`) — no MC needed
-- For each non-dominated body type: compute expected value of the best job across all depots
-- `score = sum of top RANKING_DRIVERS (5) body type EVs`
+- Runs `computeOptimalFleet` with a reduced sample count (`RANKING_MC_SIMS = 500`) per city
+- `score = totalFleetEV` — sum of all drivers' per-driver EVs after contention/stacking
+- `CityRanking.fleet` caches the full fleet; detail view reads it directly so rankings table and detail panel show identical picks
+- Analytical `analyticalFirstPickEV()` still used as candidate pre-filter inside the picker (top-15) and by `dlc-value.ts` for marginal-value calculations
 - Cities ranked by score descending
 
 ### Analytical E[max of N] (`analyticalFirstPickEV()`)

--- a/README.md
+++ b/README.md
@@ -70,9 +70,8 @@ Each city has company depots that spawn random cargo jobs. Each cargo type has a
 
 1. **Builds a cargo profile** for every depot in every city
 2. **Eliminates dominated trailer types** — if trailer A can haul everything trailer B can (and more), B is dropped
-3. **Simulates 20,000 job boards** per city using Monte Carlo methods
-4. **Greedily selects drivers** — each round picks the trailer type that adds the most marginal expected value
-5. **Ranks cities** using an analytical formula for speed (no simulation needed per city)
+3. **Greedily selects drivers** via Monte Carlo simulation — each round picks the trailer that adds the most marginal expected value on a residual board (20k rounds per city detail, 500 for the rankings table)
+4. **Ranks cities** by total fleet EV from the same greedy picker; the rankings table and the city detail view share one computed fleet for parity
 
 For more detail on the algorithm and game mechanics, see [docs/ALGORITHM-NOTES.md](docs/ALGORITHM-NOTES.md).
 

--- a/src/frontend/__tests__/optimizer.test.ts
+++ b/src/frontend/__tests__/optimizer.test.ts
@@ -361,9 +361,11 @@ describe('optimizer', () => {
 
       expect(paris!.score).toBeGreaterThan(0);
 
-      // Score consistency: sum of topTrailer cityValues ≤ score (top 5 of N drivers)
+      // Score == sum of topTrailer cityValues when |drivers| ≤ TOP_TRAILERS
+      // (the slice keeps all of them). Catches drift between `ev × count`
+      // aggregation and `totalFleetEV`.
       const summedCityValues = paris!.topTrailers.reduce((s, t) => s + t.cityValue, 0);
-      expect(summedCityValues).toBeLessThanOrEqual(paris!.score + 0.001);
+      expect(Math.abs(summedCityValues - paris!.score)).toBeLessThanOrEqual(0.001);
 
       // Top trailer's contention-aware EV must not exceed its standalone analytical EV.
       const topBT = paris!.topTrailers[0].bodyType;

--- a/src/frontend/__tests__/optimizer.test.ts
+++ b/src/frontend/__tests__/optimizer.test.ts
@@ -343,9 +343,13 @@ describe('optimizer', () => {
       expect(dryvanEV).toBeGreaterThan(tankerEV);
     });
 
-    it('returns consistent results with calculateCityRankings', () => {
-      // The ranking score for a city is the sum of top 5 body type EVs
-      // from analyticalFirstPickEV. Verify they agree.
+    it('ranking score equals real fleet EV (sum of per-driver fleet contributions)', () => {
+      // Rankings now run the greedy MC picker per city (with reduced sample
+      // count). Score == sum of topTrailers' cityValue == totalFleetEV from
+      // computeOptimalFleet. The top trailer's cityValue is its profile's
+      // fleet contribution (per-driver EV × count after contention) and is
+      // bounded by the analytical first-pick EV — strictly less when other
+      // drivers compete for the same jobs.
       const data = createMockData();
       const lookups = buildLookups(data);
       const rankings = calculateCityRankings(data, lookups);
@@ -355,15 +359,20 @@ describe('optimizer', () => {
       const paris = rankings.find((r) => r.id === 'paris');
       expect(paris).toBeDefined();
 
-      // Paris should have a positive score
       expect(paris!.score).toBeGreaterThan(0);
 
-      // Compute EV for each body type manually and verify sum matches score
-      // (minus dominated body types, which we can't easily replicate here)
-      // At minimum, the top trailer's cityValue should match analyticalFirstPickEV
+      // Score consistency: sum of topTrailer cityValues ≤ score (top 5 of N drivers)
+      const summedCityValues = paris!.topTrailers.reduce((s, t) => s + t.cityValue, 0);
+      expect(summedCityValues).toBeLessThanOrEqual(paris!.score + 0.001);
+
+      // Top trailer's contention-aware EV must not exceed its standalone analytical EV.
       const topBT = paris!.topTrailers[0].bodyType;
-      const topEV = analyticalFirstPickEV(depots!, topBT);
-      expect(paris!.topTrailers[0].cityValue).toBeCloseTo(topEV, 2);
+      const standaloneEV = analyticalFirstPickEV(depots!, topBT);
+      // cityValue = ev × count; for count=1 it equals contested per-driver EV ≤ standalone.
+      // For stacked profiles (count > 1) the comparison no longer holds, so guard.
+      if (paris!.topTrailers[0].variants === 1) {
+        expect(paris!.topTrailers[0].cityValue).toBeLessThanOrEqual(standaloneEV + 0.001);
+      }
     });
   });
 

--- a/src/frontend/city-detail-view.ts
+++ b/src/frontend/city-detail-view.ts
@@ -97,7 +97,12 @@ export async function renderCity(
     return;
   }
 
-  const optimal = await computeFleetAsync(cityId, state.data, state.lookups);
+  // Prefer the fleet already computed by the rankings pass — same picks,
+  // no MC divergence between the table's "Best Trailers" column and the
+  // detail view's "Recommended Fleet". Fall back to a fresh compute when
+  // the user lands here without rankings being primed yet.
+  const cachedFleet = state.cachedRankings?.find(r => r.id === cityId)?.fleet ?? null;
+  const optimal = cachedFleet ?? await computeFleetAsync(cityId, state.data, state.lookups);
   if (!optimal) {
     const emptyOwned = isOwnedGarage(cityId);
     cityContent.innerHTML = `

--- a/src/frontend/city-detail-view.ts
+++ b/src/frontend/city-detail-view.ts
@@ -97,10 +97,7 @@ export async function renderCity(
     return;
   }
 
-  // Prefer the fleet already computed by the rankings pass — same picks,
-  // no MC divergence between the table's "Best Trailers" column and the
-  // detail view's "Recommended Fleet". Fall back to a fresh compute when
-  // the user lands here without rankings being primed yet.
+  // Use ranking-pass fleet for parity; fall back when direct nav skipped rankings.
   const cachedFleet = state.cachedRankings?.find(r => r.id === cityId)?.fleet ?? null;
   const optimal = cachedFleet ?? await computeFleetAsync(cityId, state.data, state.lookups);
   if (!optimal) {

--- a/src/frontend/optimizer.ts
+++ b/src/frontend/optimizer.ts
@@ -1,18 +1,11 @@
 /**
- * Trailer Set Optimizer for ETS2 Trucker Advisor
+ * Trailer Set Optimizer for ETS2 Trucker Advisor.
  *
- * Model: Best-of-N Monte Carlo fleet optimization
- * - Each depot independently spawns JOBS_PER_DEPOT random jobs from its cargo pool
- * - AI drivers see the combined job board and pick the highest-value job they can haul
- * - Fleet composition determined by greedy selection: each pick maximizes marginal EV
+ * Best-of-N Monte Carlo fleet optimization — depots spawn JOBS_PER_DEPOT random
+ * jobs, drivers greedy-pick the highest-value job they can haul. See CLAUDE.md
+ * "Key Algorithms" for model details and "City Ranking Score" for the rankings path.
  *
- * City rankings run the same greedy MC picker with a reduced sample count
- * (RANKING_MC_SIMS) so the rankings table's "Best Trailers" column matches
- * what the city detail view shows. The analytical E[max of N] formulas are
- * still used as the candidate pre-filter inside the picker (top-15 by
- * analytical EV) and by `dlc-value.ts` for marginal-value calculations.
- *
- * Data source: game-defs.json (authoritative cargo values, spawn coefficients, trailer specs)
+ * Data source: game-defs.json.
  */
 
 import {
@@ -30,12 +23,7 @@ const MAX_DRIVERS = 5;
 /** Monte Carlo simulations for fleet computation (individual city) */
 const MC_SIMS = 20_000;
 
-/**
- * Lower MC count for city rankings — ~370 cities × full greedy needs to stay
- * snappy on DLC toggles. Variance ~1/sqrt(N) ≈ 4-5% per per-driver-EV at this
- * sample count, acceptable for ranking order (sort by score, not absolute fidelity).
- * Bump if borderline picks shuffle between runs.
- */
+/** MC count for city rankings. ~4-5% variance per per-driver-EV. Bump if picks shuffle between runs. */
 const RANKING_MC_SIMS = 500;
 
 /** Number of top trailers shown in rankings summary */
@@ -69,11 +57,7 @@ export interface OptimalFleetEntry {
   bodyTypes: string[];
   trailerId: string;
   trailerSpec: string;
-  /**
-   * Average per-driver EV across all picks of this profile. For stacked
-   * profiles (count > 1), this is the mean of per-driver EVs — multiplying
-   * by `count` recovers the profile's total contribution to fleet EV.
-   */
+  /** Mean per-driver EV across this profile's picks; multiply by `count` for total contribution. */
   ev: number;
   cargoMatched: number;
   count: number;           // 1-5 for drivers (collapsed by profile)
@@ -90,11 +74,7 @@ export interface OptimalFleet {
   totalEstimatedPrice: number;
   /** Highest level floor across all recommended drivers — when the full fleet becomes ownable. */
   fleetLevelFloor: number;
-  /**
-   * Sum of all drivers' per-cycle EVs after contention/stacking. The true
-   * expected haul value the whole fleet captures per job cycle — used as the
-   * city-ranking score and matches what `Phase 2` simulated.
-   */
+  /** Sum of per-driver EVs after contention/stacking — the fleet's expected haul value per cycle. */
   totalFleetEV: number;
 }
 
@@ -109,12 +89,7 @@ export interface CityRanking {
   cargoTypes: number;
   score: number;
   topTrailers: FleetEntry[];
-  /**
-   * Full fleet computed during ranking. The detail view reads this directly
-   * so it sees the exact same picks (no MC-divergence between table and
-   * detail). Detail-view fallback only fires when rankings haven't been
-   * computed yet (direct nav to a city URL bypassing the rankings page).
-   */
+  /** Cached fleet — detail view reads this for parity with the rankings column. */
   fleet: OptimalFleet;
 }
 
@@ -891,18 +866,7 @@ export function computeOptimalFleet(
 // City rankings (analytical)
 // ============================================
 
-/**
- * Rank all cities by total earning potential using the same greedy MC picker
- * as `computeOptimalFleet`, with a reduced MC sample count (RANKING_MC_SIMS).
- *
- * Score = real fleet EV (sum of per-driver EVs after contention/stacking),
- * not the sum-of-standalone-EVs heuristic the previous implementation used.
- *
- * `topTrailers` reflects the actual greedy fleet picks — same profiles, in
- * the same pick order, as the city-detail view shows. The display column is
- * therefore a useful "where can I deploy a chemtank?" query: scan for the
- * trailer profile, find cities where it earns a seat in the recommended fleet.
- */
+/** Rank all cities by greedy fleet EV. See CLAUDE.md "City Ranking Score". */
 export function calculateCityRankings(
   data: AllData, lookups: Lookups,
 ): CityRanking[] {

--- a/src/frontend/optimizer.ts
+++ b/src/frontend/optimizer.ts
@@ -31,9 +31,10 @@ const MAX_DRIVERS = 5;
 const MC_SIMS = 20_000;
 
 /**
- * Lower MC count for city rankings — 234 cities × full greedy needs to stay
- * snappy on DLC toggles. Variance ~1/sqrt(N) ≈ 2-3% per per-driver-EV at 2k
- * sims, acceptable for ranking order (sort by score, not absolute fidelity).
+ * Lower MC count for city rankings — ~370 cities × full greedy needs to stay
+ * snappy on DLC toggles. Variance ~1/sqrt(N) ≈ 4-5% per per-driver-EV at this
+ * sample count, acceptable for ranking order (sort by score, not absolute fidelity).
+ * Bump if borderline picks shuffle between runs.
  */
 const RANKING_MC_SIMS = 500;
 

--- a/src/frontend/optimizer.ts
+++ b/src/frontend/optimizer.ts
@@ -6,7 +6,11 @@
  * - AI drivers see the combined job board and pick the highest-value job they can haul
  * - Fleet composition determined by greedy selection: each pick maximizes marginal EV
  *
- * City rankings use an analytical E[max of N] formula for speed (no MC needed).
+ * City rankings run the same greedy MC picker with a reduced sample count
+ * (RANKING_MC_SIMS) so the rankings table's "Best Trailers" column matches
+ * what the city detail view shows. The analytical E[max of N] formulas are
+ * still used as the candidate pre-filter inside the picker (top-15 by
+ * analytical EV) and by `dlc-value.ts` for marginal-value calculations.
  *
  * Data source: game-defs.json (authoritative cargo values, spawn coefficients, trailer specs)
  */
@@ -26,11 +30,15 @@ const MAX_DRIVERS = 5;
 /** Monte Carlo simulations for fleet computation (individual city) */
 const MC_SIMS = 20_000;
 
+/**
+ * Lower MC count for city rankings — 234 cities × full greedy needs to stay
+ * snappy on DLC toggles. Variance ~1/sqrt(N) ≈ 2-3% per per-driver-EV at 2k
+ * sims, acceptable for ranking order (sort by score, not absolute fidelity).
+ */
+const RANKING_MC_SIMS = 500;
+
 /** Number of top trailers shown in rankings summary */
 const TOP_TRAILERS = 5;
-
-/** Drivers dispatched simultaneously for ranking score */
-const RANKING_DRIVERS = 5;
 
 // ============================================
 // Interfaces
@@ -60,6 +68,11 @@ export interface OptimalFleetEntry {
   bodyTypes: string[];
   trailerId: string;
   trailerSpec: string;
+  /**
+   * Average per-driver EV across all picks of this profile. For stacked
+   * profiles (count > 1), this is the mean of per-driver EVs — multiplying
+   * by `count` recovers the profile's total contribution to fleet EV.
+   */
   ev: number;
   cargoMatched: number;
   count: number;           // 1-5 for drivers (collapsed by profile)
@@ -76,6 +89,12 @@ export interface OptimalFleet {
   totalEstimatedPrice: number;
   /** Highest level floor across all recommended drivers — when the full fleet becomes ownable. */
   fleetLevelFloor: number;
+  /**
+   * Sum of all drivers' per-cycle EVs after contention/stacking. The true
+   * expected haul value the whole fleet captures per job cycle — used as the
+   * city-ranking score and matches what `Phase 2` simulated.
+   */
+  totalFleetEV: number;
 }
 
 export interface CityRanking {
@@ -89,6 +108,13 @@ export interface CityRanking {
   cargoTypes: number;
   score: number;
   topTrailers: FleetEntry[];
+  /**
+   * Full fleet computed during ranking. The detail view reads this directly
+   * so it sees the exact same picks (no MC-divergence between table and
+   * detail). Detail-view fallback only fires when rankings haven't been
+   * computed yet (direct nav to a city URL bypassing the rankings page).
+   */
+  fleet: OptimalFleet;
 }
 
 // ============================================
@@ -693,9 +719,17 @@ function countCityCargoForProfile(depots: CityDepotData[], bodyTypes: string[]):
  * Phase 3: Spare evaluation — for each candidate spare, compute expected
  *          improvement when ANY driver would benefit from swapping.
  */
+export interface ComputeFleetOptions {
+  /** Override MC sample count. Defaults to MC_SIMS (20k). Pass RANKING_MC_SIMS for city rankings. */
+  mcSims?: number;
+}
+
 export function computeOptimalFleet(
   cityId: string, data: AllData, lookups: Lookups,
+  opts?: ComputeFleetOptions,
 ): OptimalFleet | null {
+  const mcSims = opts?.mcSims ?? MC_SIMS;
+
   // Seed PRNG from city ID for deterministic results
   rng = mulberry32(hashString(cityId));
 
@@ -741,13 +775,17 @@ export function computeOptimalFleet(
   const totalSlots = depots.length * JOBS_PER_DEPOT;
   const boardBuffer: DepotCargoItem[] = new Array(totalSlots);
 
-  // Phase 1: Greedy driver selection by profile (body-type set + rep trailer)
+  // Phase 1: Greedy driver selection by profile (body-type set + rep trailer).
+  // Stacking is allowed — a profile already in `fleet` is still evaluated against
+  // the residual board, because a second pick of the same profile picks the
+  // next-best job (not the same one). The greedy keeps stacking only while
+  // marginal EV exceeds every other candidate's residual.
   const fleet: Array<{ key: string; bodyTypes: string[]; repId: string }> = [];
 
   for (let pick = 0; pick < MAX_DRIVERS; pick++) {
     // Generate shared boards for this round
     const rawBoards: DepotCargoItem[][] = [];
-    for (let s = 0; s < MC_SIMS; s++) {
+    for (let s = 0; s < mcSims; s++) {
       const len = fillBoard(boardBuffer, depots);
       rawBoards.push(boardBuffer.slice(0, len));
     }
@@ -774,7 +812,7 @@ export function computeOptimalFleet(
       for (const remaining of baseRemainders) {
         marginalSum += bestJobForRep(remaining, cand.repId).hv;
       }
-      const marginal = marginalSum / MC_SIMS;
+      const marginal = marginalSum / mcSims;
       if (marginal > bestMarginal) {
         bestMarginal = marginal;
         bestProfile = { key: cand.key, bodyTypes: cand.bodyTypes, repId: cand.repId };
@@ -790,7 +828,7 @@ export function computeOptimalFleet(
   // Phase 2: Compute per-driver EVs with final fleet
   const driverEVs = new Array(fleet.length).fill(0);
 
-  for (let s = 0; s < MC_SIMS; s++) {
+  for (let s = 0; s < mcSims; s++) {
     const len = fillBoard(boardBuffer, depots);
     const remaining = boardBuffer.slice(0, len);
     for (let d = 0; d < fleet.length; d++) {
@@ -803,21 +841,27 @@ export function computeOptimalFleet(
     }
   }
 
-  for (let d = 0; d < fleet.length; d++) driverEVs[d] /= MC_SIMS;
+  for (let d = 0; d < fleet.length; d++) driverEVs[d] /= mcSims;
 
-  // Collapse fleet into counts by profile key
-  const driverMap = new Map<string, { ev: number; count: number; bodyTypes: string[] }>();
+  // True fleet EV (sum of per-driver EVs) — used as ranking score below.
+  const totalFleetEV = driverEVs.reduce((s, e) => s + e, 0);
+
+  // Collapse fleet into counts by profile key. For stacked profiles, accumulate
+  // each instance's per-driver EV and average at the end — first-pick alone is
+  // misleading because picks 2+ of the same profile earn meaningfully less.
+  const driverMap = new Map<string, { evSum: number; count: number; bodyTypes: string[] }>();
   for (let d = 0; d < fleet.length; d++) {
     const driver = fleet[d];
     const existing = driverMap.get(driver.key);
     if (existing) {
+      existing.evSum += driverEVs[d];
       existing.count++;
     } else {
-      driverMap.set(driver.key, { ev: driverEVs[d], count: 1, bodyTypes: driver.bodyTypes });
+      driverMap.set(driver.key, { evSum: driverEVs[d], count: 1, bodyTypes: driver.bodyTypes });
     }
   }
 
-  const drivers: OptimalFleetEntry[] = [...driverMap.entries()].map(([key, { ev, count, bodyTypes }]) => {
+  const drivers: OptimalFleetEntry[] = [...driverMap.entries()].map(([key, { evSum, count, bodyTypes }]) => {
     const info = profileInfo.get(key);
     const primary = bodyTypes[0];
     const cargoMatched = countCityCargoForProfile(depots, bodyTypes);
@@ -827,7 +871,7 @@ export function computeOptimalFleet(
       bodyTypes,
       trailerId: info?.trailerId ?? primary,
       trailerSpec: info?.trailerSpec ?? primary,
-      ev,
+      ev: evSum / count,
       cargoMatched,
       count,
       estimatedPrice: info?.estimatedPrice ?? 0,
@@ -839,7 +883,7 @@ export function computeOptimalFleet(
   const totalEstimatedPrice = drivers.reduce((s, d) => s + d.estimatedPrice * d.count, 0);
   const fleetLevelFloor = drivers.reduce((m, d) => Math.max(m, d.levelFloor), 0);
 
-  return { drivers, totalTrailers, totalEstimatedPrice, fleetLevelFloor };
+  return { drivers, totalTrailers, totalEstimatedPrice, fleetLevelFloor, totalFleetEV };
 }
 
 // ============================================
@@ -847,12 +891,16 @@ export function computeOptimalFleet(
 // ============================================
 
 /**
- * Rank all cities by total earning potential using analytical E[max of N].
+ * Rank all cities by total earning potential using the same greedy MC picker
+ * as `computeOptimalFleet`, with a reduced MC sample count (RANKING_MC_SIMS).
  *
- * Score = sum of top RANKING_DRIVERS profiles' analytical first-pick EVs.
- * Profile-aware so multi-body trailers credit toward the city's score
- * (a `[flatbed, container]` trailer counts as a candidate that competes in
- * both pools, matching what `computeOptimalFleet` would actually pick).
+ * Score = real fleet EV (sum of per-driver EVs after contention/stacking),
+ * not the sum-of-standalone-EVs heuristic the previous implementation used.
+ *
+ * `topTrailers` reflects the actual greedy fleet picks — same profiles, in
+ * the same pick order, as the city-detail view shows. The display column is
+ * therefore a useful "where can I deploy a chemtank?" query: scan for the
+ * trailer profile, find cities where it earns a seat in the recommended fleet.
  */
 export function calculateCityRankings(
   data: AllData, lookups: Lookups,
@@ -860,43 +908,15 @@ export function calculateCityRankings(
   const rankings: CityRanking[] = [];
 
   for (const city of data.cities) {
+    const fleet = computeOptimalFleet(city.id, data, lookups, { mcSims: RANKING_MC_SIMS });
+    if (!fleet || fleet.drivers.length === 0) continue;
+
     const depots = buildCityDepotProfiles(city.id, lookups);
     if (!depots) continue;
-
-    const profileInfo = getProfileTrailerInfoForCountry(city.country, data, lookups);
 
     const cityCompanies = lookups.cityCompanyMap.get(city.id) || [];
     let depotCount = 0;
     for (const { count } of cityCompanies) depotCount += count;
-
-    // Body types present in this city's depots; domination still computed at
-    // body-type level (cargo-coverage relation is a single-bt notion).
-    const allBodyTypes = new Set<string>();
-    for (const depot of depots) {
-      for (const c of depot.cargo) {
-        for (const bt of Object.keys(c.bodyHV)) allBodyTypes.add(bt);
-      }
-    }
-
-    const dominated = findDominatedBodyTypes(depots, allBodyTypes);
-    const depotItemsCache = buildDepotItemsCache(depots);
-
-    // Per profile: analytical first-pick EV over the profile's surviving (non-dominated, present) body types.
-    // Use rep-HV (same as fleet picker) so top-N picks match.
-    const profileEVs: Array<{ key: string; bodyTypes: string[]; ev: number }> = [];
-    for (const [key, info] of profileInfo) {
-      const surviving = info.bodyTypes.filter((bt) => allBodyTypes.has(bt) && !dominated.has(bt));
-      if (surviving.length === 0) continue;
-      const ev = analyticalFirstPickEVForRep(depots, info.trailerId, lookups, depotItemsCache);
-      if (ev > 0) profileEVs.push({ key, bodyTypes: surviving, ev });
-    }
-    profileEVs.sort((a, b) => b.ev - a.ev);
-
-    if (profileEVs.length === 0) continue;
-
-    // Score = sum of top N profile EVs
-    const topN = profileEVs.slice(0, RANKING_DRIVERS);
-    const score = topN.reduce((s, e) => s + e.ev, 0);
 
     // Count unique cargo types across all depots
     const cargoIds = new Set<string>();
@@ -904,24 +924,27 @@ export function calculateCityRankings(
       for (const c of depot.cargo) cargoIds.add(c.cargoId);
     }
 
-    // Build top trailer entries for display
-    const topTrailers: FleetEntry[] = profileEVs.slice(0, TOP_TRAILERS).map((e) => {
-      const info = profileInfo.get(e.key);
-      const primary = e.bodyTypes[0];
-      return {
-        trailerId: info?.trailerId ?? primary,
-        bodyType: primary,
-        bodyTypes: e.bodyTypes,
+    const score = fleet.totalFleetEV;
+
+    // Top trailers = the actual fleet picks (pick order ≈ EV desc, but sort
+    // explicitly by per-profile fleet contribution to honour the rankings
+    // table's "sorted by cityValue desc" contract).
+    const topTrailers: FleetEntry[] = fleet.drivers
+      .map<FleetEntry>((d) => ({
+        trailerId: d.trailerId,
+        bodyType: d.bodyType,
+        bodyTypes: d.bodyTypes,
         chainType: 'single',
         countryValidity: [],
-        displayName: profileDisplayName(e.bodyTypes),
-        trailerSpec: info?.trailerSpec ?? primary,
-        cityValue: e.ev,
-        pctOfTotal: score > 0 ? (e.ev / score) * 100 : 0,
-        cargoMatched: countCityCargoForProfile(depots, e.bodyTypes),
-        variants: 1,
-      };
-    });
+        displayName: d.displayName,
+        trailerSpec: d.trailerSpec,
+        cityValue: d.ev * d.count,
+        pctOfTotal: score > 0 ? (d.ev * d.count / score) * 100 : 0,
+        cargoMatched: d.cargoMatched,
+        variants: d.count,
+      }))
+      .sort((a, b) => b.cityValue - a.cityValue)
+      .slice(0, TOP_TRAILERS);
 
     rankings.push({
       id: city.id,
@@ -934,6 +957,7 @@ export function calculateCityRankings(
       cargoTypes: cargoIds.size,
       score,
       topTrailers,
+      fleet,
     });
   }
 

--- a/src/frontend/rankings-view.ts
+++ b/src/frontend/rankings-view.ts
@@ -209,7 +209,9 @@ function updateResultsCount(resultsCount: HTMLElement, shown: number, total: num
 // ============================================
 
 function summarizeTrailers(fleet: FleetEntry[]): string {
-  return fleet.map(e => e.displayName).join(', ');
+  return fleet
+    .map(e => (e.variants > 1 ? `${e.displayName} ×${e.variants}` : e.displayName))
+    .join(', ');
 }
 
 // ============================================
@@ -221,7 +223,7 @@ const SORTABLE_COLUMNS: { col: SortColumn; label: string; tooltip?: string }[] =
   { col: 'country', label: 'Country' },
   { col: 'depotCount', label: 'Depots', tooltip: 'Company facilities in this city' },
   { col: 'cargoTypes', label: 'Cargo', tooltip: 'Distinct cargo types available' },
-  { col: 'score', label: 'Fleet EV', tooltip: 'Sum of top 5 body type EVs \u2014 fleet earning potential' },
+  { col: 'score', label: 'Fleet EV', tooltip: 'Expected haul value per cycle for the recommended 5-driver fleet (contention- and stacking-aware)' },
 ];
 
 export function sortRankings(rankings: CityRanking[], col: SortColumn, dir: SortDirection): CityRanking[] {


### PR DESCRIPTION
## What

City rankings run the same greedy MC picker as the city detail view, share the computed `OptimalFleet`, and render the actual fleet picks (with `×N` for stacks) in the "Best Trailers" column.

## Why

Old rankings used sum of top-5 distinct standalone profile EVs — no contention, no stacking. Column listed profiles that the actual greedy picker would never bundle, and "Fleet EV" overstated by ~10-15%.

## How

- `calculateCityRankings` invokes `computeOptimalFleet({ mcSims: RANKING_MC_SIMS=500 })` per city.
- Result attached as `CityRanking.fleet`.
- `city-detail-view` reads `state.cachedRankings.find(...)?.fleet` first; `computeFleetAsync` fallback only for direct nav.
- `OptimalFleetEntry.ev` is now mean per-driver across this profile's picks (was first-pick only — wrong for stacked profiles).
- `OptimalFleet.totalFleetEV` exposed as the ranking score.

## Costs

Full ranking: ~1-2s → ~10s. Runs in worker, cached. Tunable via `RANKING_MC_SIMS`.