### PR TITLE
feat(data): re-parse trailer prices from updated game defs

### DIFF
--- a/docs/manual-prices-audit.md
+++ b/docs/manual-prices-audit.md
@@ -1,5 +1,7 @@
 # manual-prices.json — methodology, audit, walk queue
 
+> **DEPRECATED** — As of PR #264 (2026-05-15), the parser reads exact trailer prices directly from game defs. Manual walks are no longer needed. This file and `manual-prices.json` will be removed in a follow-up cleanup PR.
+
 ## SCS internal name → dealer UI label
 
 Internal body suffixes in the trailer keys don't match what the in-game dealer screen calls them. Quick reference for walks:

--- a/scripts/__tests__/parse-game-defs.test.ts
+++ b/scripts/__tests__/parse-game-defs.test.ts
@@ -129,13 +129,11 @@ function runSchemaInvariantsForGame(game: 'ats' | 'ets2') {
     // trailer pricing extraction (#251). Once a user re-runs the parser against
     // extracted defs, every trailer gets price + level_floor; if they're missing
     // (older snapshot), the loader defaults to 0 and the frontend renders "—".
-    it('trailer pricing fields, when present, are numeric and price is a multiple of 1000', () => {
+    it('trailer pricing fields, when present, are non-negative numbers', () => {
       const data = JSON.parse(readFileSync(fixturePath, 'utf-8'));
       for (const [, t] of Object.entries(data.trailers as Record<string, { price?: unknown; level_floor?: unknown }>)) {
         if (t.price !== undefined) {
           expect(typeof t.price).toBe('number');
-          // Issue #251 spec: rounded UP to the nearest 1000.
-          expect((t.price as number) % 1000).toBe(0);
           expect(t.price as number).toBeGreaterThanOrEqual(0);
         }
         if (t.level_floor !== undefined) {

--- a/scripts/__tests__/parse-game-defs.test.ts
+++ b/scripts/__tests__/parse-game-defs.test.ts
@@ -135,10 +135,12 @@ function runSchemaInvariantsForGame(game: 'ats' | 'ets2') {
         if (t.price !== undefined) {
           expect(typeof t.price).toBe('number');
           expect(t.price as number).toBeGreaterThanOrEqual(0);
+          expect(Number.isInteger(t.price as number)).toBe(true);
         }
         if (t.level_floor !== undefined) {
           expect(typeof t.level_floor).toBe('number');
           expect(t.level_floor as number).toBeGreaterThanOrEqual(0);
+          expect(Number.isInteger(t.level_floor as number)).toBe(true);
         }
       }
     });


### PR DESCRIPTION
New game defs natively expose full configured trailer prices. All 213 changes match the existing `manual-prices.json` overrides to the euro, including the 9 walks from #263 — so `manual-prices.json` + `docs/manual-prices-audit.md` are now redundant. Cleanup deferred.