### PR TITLE
docs: revert manual-prices deprecation banner from #264

### DIFF
--- a/docs/manual-prices-audit.md
+++ b/docs/manual-prices-audit.md
@@ -26,6 +26,10 @@ Internal body suffixes in the trailer keys don't match what the in-game dealer s
 
 ## Walk methodology
 
+### Why the parser alone is insufficient
+
+`extractTrailerPricing()` in `parse-game-defs.ts` walks the dealer-accessory entries in the game defs but cannot recover `chain_base` (a per-brand/chain constant) or the per-chassis `body_fee` scaling — both of which are only visible on the live in-game dealer screen. Without `mergeManualPrices()` applying the walked overrides, ~368 trailers price as 0 and another ~70 underestimate by €5k–€55k. The manual walk queue is load-bearing for any trailer that participates in a winner-tie group.
+
 For each trailer key, record the **cheapest configured-trailer total** the dealer screen shows when every selectable section (chassis / body / paint / wheels / accessories) is set to its lowest-priced option. This becomes the entry's `price`.
 
 **Important — body fees scale with chassis.** When the dealer is on a 1-axle chassis, an insulated body shows e.g. 35k; switch to a 3-axle chassis and the same insulated body shows 50k. So:

--- a/docs/manual-prices-audit.md
+++ b/docs/manual-prices-audit.md
@@ -1,7 +1,5 @@
 # manual-prices.json — methodology, audit, walk queue
 
-> **DEPRECATED** — As of PR #264 (2026-05-15), the parser reads exact trailer prices directly from game defs. Manual walks are no longer needed. This file and `manual-prices.json` will be removed in a follow-up cleanup PR.
-
 ## SCS internal name → dealer UI label
 
 Internal body suffixes in the trailer keys don't match what the in-game dealer screen calls them. Quick reference for walks:

--- a/scripts/parse-game-defs.ts
+++ b/scripts/parse-game-defs.ts
@@ -1404,11 +1404,8 @@ function main() {
   const parsedTrailers = extractTrailers();
   console.log(`  Found ${parsedTrailers.length} trailer definitions`);
 
-  // Required: the dealer-accessory traversal in extractTrailerPricing() misses
-  // chain_base + per-chassis body fees. Without this merge, ~368 walked
-  // trailers price as 0 and another ~70 underestimate by €5k–€55k. PR #264
-  // misread parser-matching-walked output as "parser is exact" and proposed
-  // deleting the merge — verification disproved that. Keep this call.
+  // Load-bearing: parser cannot recover chain_base or per-chassis body fees.
+  // See docs/manual-prices-audit.md → "Why the parser alone is insufficient".
   const manualMerge = mergeManualPrices(parsedTrailers, manualPricesPath, game);
   const trailers = manualMerge.trailers;
   if (manualMerge.applied > 0) {

--- a/scripts/parse-game-defs.ts
+++ b/scripts/parse-game-defs.ts
@@ -1404,6 +1404,11 @@ function main() {
   const parsedTrailers = extractTrailers();
   console.log(`  Found ${parsedTrailers.length} trailer definitions`);
 
+  // Required: the dealer-accessory traversal in extractTrailerPricing() misses
+  // chain_base + per-chassis body fees. Without this merge, ~368 walked
+  // trailers price as 0 and another ~70 underestimate by €5k–€55k. PR #264
+  // misread parser-matching-walked output as "parser is exact" and proposed
+  // deleting the merge — verification disproved that. Keep this call.
   const manualMerge = mergeManualPrices(parsedTrailers, manualPricesPath, game);
   const trailers = manualMerge.trailers;
   if (manualMerge.applied > 0) {


### PR DESCRIPTION
Reverts #264's misleading deprecation banner. The structural gap that makes `mergeManualPrices` load-bearing now lives in `docs/manual-prices-audit.md` → "Why the parser alone is insufficient".