### PR TITLE
fix(#247): sort Recommended Fleet by descending EV

### DIFF
--- a/src/frontend/optimizer.ts
+++ b/src/frontend/optimizer.ts
@@ -855,6 +855,12 @@ export function computeOptimalFleet(
     };
   });
 
+  // #247: present the fleet in descending EV order. driverMap insertion order
+  // reflects greedy job-assignment sequence, not the displayed per-trailer EV
+  // (evSum / count), so the two diverge without an explicit sort. Shared by the
+  // city-detail fleet table, the rankings cache, and CSV/JSON export.
+  drivers.sort((a, b) => b.ev - a.ev);
+
   const totalTrailers = drivers.reduce((s, d) => s + d.count, 0);
   const totalEstimatedPrice = drivers.reduce((s, d) => s + d.estimatedPrice * d.count, 0);
   const fleetLevelFloor = drivers.reduce((m, d) => Math.max(m, d.levelFloor), 0);


### PR DESCRIPTION
Closes the last open checkbox on #247 (per-city ordering, #7).

`computeOptimalFleet` built `drivers` from `driverMap` insertion order — the greedy job-assignment sequence — and never sorted by the displayed per-trailer EV (`evSum / count`). The two diverge, so the Recommended Fleet table (`city-detail-view.ts`), the shared `CityRanking.fleet` cache, and CSV/JSON export could render rows out of EV order. Prior #247 comments assumed this was already handled by the EV-greedy picker; it wasn't.

One-line sort before the order-independent totals. `npm run lint` clean; optimizer suite 25/25.

Note: 5 failures in `nav-render.test.ts` (`localStorage` undefined) are pre-existing on main, unrelated — missing jsdom env in that file.