### PR TITLE
feat(#243): populate ATS_CARGO_DLC_MAP from game files + add scs-extract

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,7 +77,7 @@ Euro Truck Simulator 2 and American Truck Simulator trucking company analyzer - 
 ## Key Algorithms
 
 ### Game Data Pipeline
-1. Extract `def/` folder from ETS2 *or* ATS `.scs` archives (SCS Extractor)
+1. Extract `def/` folder from ETS2 *or* ATS `.scs` archives — `scripts/scs-extract/` (handles HashFS v2 DLC archives; see its README) or any SCS Extractor
 2. Run `npx tsx scripts/parse-game-defs.ts /path/to/extracted/def --game <ets2|ats>` (default `ets2`)
 3. Parser reads all `.sii/.sui` files: cargo, trailers, companies, cities, countries, economy, trucks
 4. Computes cargo-trailer compatibility from `body_type` matching
@@ -174,7 +174,7 @@ Three categories of DLC content affect optimization results:
 - **Brand DLCs (ATS)**: enumerated in `ATS_TRAILER_DLCS` (`scripts/parse-game-defs.ts`); ATS uses brand-prefix matching identical to ETS2.
 - **Map expansion DLCs (ATS)**: each US state shipped as a separate DLC. Mapping lives in `ATS_STATE_TO_DLC` (`Record<stateCode, string[]>`). City→DLC map built dynamically by `buildAtsCityDlcMap(cities)` from each city's `country` (state code) field — no hand-curated `ATS_CITY_DLC_MAP`.
 - **Garage cities (ATS)**: enumerated in `ATS_GARAGE_CITIES`. SCS internal IDs follow a 12-char truncation rule with documented per-city exceptions (`salt_lake`, asymmetric `texarkana` / `texarkana_ar`, symmetric `kansas_ci_ks` / `kansas_ci_mo`); see comment block above `ATS_GARAGE_CITIES`.
-- **Cargo pack DLCs (ATS)**: `ATS_CARGO_DLC_MAP` and `ATS_MAP_DLC_CARGO` are intentional empty stubs — not yet populated. Affects only the marginal-value DLC calculator for ATS cargo. Tracked as known gap in PR #242.
+- **Cargo pack DLCs (ATS)**: `ATS_CARGO_DLC_MAP` is populated (61 cargo across 7 packs), sourced from each pack's `def/cargo.<dlc>.sii` aggregator inside the owned `dlc_*.scs` archives and cross-checked against `game-defs.json` (#243). Special Transport (`dlc_oversize`) maps to zero cargo — all its cargo is oversize/player-only and excluded from the AI-haulable dataset. `ATS_MAP_DLC_CARGO` stays empty until a *purchasable* state map DLC is owned (only free Arizona/Nevada are installed); populate per owned state via the same archive method.
 - **Trucks page (ATS)**: cabin and paint data only populated for ETS2 as of #252. Switching to ATS on `trucks.html` renders an empty list. Parser is game-agnostic; an ATS reparse against fresh defs will populate it.
 
 **DLC Filtering Pipeline**:

--- a/public/data/ats/game-defs.json
+++ b/public/data/ats/game-defs.json
@@ -17,7 +17,8 @@
       "groups": [
         "machinery"
       ],
-      "excluded": false
+      "excluded": false,
+      "dlc": "bobcat"
     },
     "aircon": {
       "name": "air_condition",
@@ -190,7 +191,8 @@
       "groups": [
         "machinery"
       ],
-      "excluded": false
+      "excluded": false,
+      "dlc": "volvo_ce"
     },
     "auger_wag": {
       "name": "auger_wagon",
@@ -208,7 +210,8 @@
       "groups": [
         "machinery"
       ],
-      "excluded": false
+      "excluded": false,
+      "dlc": "farm_machinery"
     },
     "tractor_au": {
       "name": "autonomous_tractor",
@@ -226,7 +229,8 @@
       "groups": [
         "machinery"
       ],
-      "excluded": false
+      "excluded": false,
+      "dlc": "farm_machinery"
     },
     "digger500": {
       "name": "backhoe_loader",
@@ -264,7 +268,8 @@
       "groups": [
         "machinery"
       ],
-      "excluded": false
+      "excluded": false,
+      "dlc": "jcb"
     },
     "barley": {
       "name": "barley",
@@ -494,7 +499,8 @@
       "groups": [
         "machinery"
       ],
-      "excluded": false
+      "excluded": false,
+      "dlc": "volvo_ce"
     },
     "bulldozer": {
       "name": "bulldozer",
@@ -604,7 +610,8 @@
       "groups": [
         "construction"
       ],
-      "excluded": false
+      "excluded": false,
+      "dlc": "heavy_cargo"
     },
     "cans": {
       "name": "cans",
@@ -830,7 +837,8 @@
       "groups": [
         "construction"
       ],
-      "excluded": false
+      "excluded": false,
+      "dlc": "jcb"
     },
     "com_tractor": {
       "name": "compact_tractor",
@@ -867,7 +875,8 @@
       "groups": [
         "machinery"
       ],
-      "excluded": false
+      "excluded": false,
+      "dlc": "volvo_ce"
     },
     "bob_pa127v": {
       "name": "compressor_bobcat_pa127v",
@@ -886,7 +895,8 @@
       "groups": [
         "machinery"
       ],
-      "excluded": false
+      "excluded": false,
+      "dlc": "bobcat"
     },
     "computers": {
       "name": "computers",
@@ -1032,7 +1042,8 @@
       "groups": [
         "machinery"
       ],
-      "excluded": false
+      "excluded": false,
+      "dlc": "heavy_cargo"
     },
     "cott_lint": {
       "name": "cotton_lint",
@@ -1107,7 +1118,8 @@
       "groups": [
         "machinery"
       ],
-      "excluded": false
+      "excluded": false,
+      "dlc": "heavy_cargo"
     },
     "tractor_c2": {
       "name": "crawler_tractor",
@@ -1125,7 +1137,8 @@
       "groups": [
         "machinery"
       ],
-      "excluded": false
+      "excluded": false,
+      "dlc": "farm_machinery"
     },
     "crude_oil": {
       "name": "crude_oil",
@@ -1198,7 +1211,8 @@
       "groups": [
         "machinery"
       ],
-      "excluded": false
+      "excluded": false,
+      "dlc": "farm_machinery"
     },
     "kr_ecb880cv": {
       "name": "disk_mower_krone_ecb880cv",
@@ -1216,7 +1230,8 @@
       "groups": [
         "machinery"
       ],
-      "excluded": false
+      "excluded": false,
+      "dlc": "krone_agri"
     },
     "dry_fruit": {
       "name": "dryfruit",
@@ -1334,7 +1349,8 @@
       "groups": [
         "machinery"
       ],
-      "excluded": false
+      "excluded": false,
+      "dlc": "jcb"
     },
     "dynamite": {
       "name": "dynamite",
@@ -1484,7 +1500,8 @@
       "groups": [
         "machinery"
       ],
-      "excluded": false
+      "excluded": false,
+      "dlc": "bobcat"
     },
     "jcb_mexc19ce": {
       "name": "excavator_jcb_19ce",
@@ -1503,7 +1520,8 @@
       "groups": [
         "machinery"
       ],
-      "excluded": false
+      "excluded": false,
+      "dlc": "jcb"
     },
     "jcb_exc245xr": {
       "name": "excavator_jcb_245xr",
@@ -1521,7 +1539,8 @@
       "groups": [
         "machinery"
       ],
-      "excluded": false
+      "excluded": false,
+      "dlc": "jcb"
     },
     "volvo_ec220e": {
       "name": "excavator_volvo_ec220e",
@@ -1539,7 +1558,8 @@
       "groups": [
         "machinery"
       ],
-      "excluded": false
+      "excluded": false,
+      "dlc": "volvo_ce"
     },
     "vol_ew240emh": {
       "name": "excavator_volvo_ew240emh",
@@ -1557,7 +1577,8 @@
       "groups": [
         "machinery"
       ],
-      "excluded": false
+      "excluded": false,
+      "dlc": "volvo_ce"
     },
     "fertilizer": {
       "name": "fertilizer",
@@ -1598,7 +1619,8 @@
       "groups": [
         "machinery"
       ],
-      "excluded": false
+      "excluded": false,
+      "dlc": "farm_machinery"
     },
     "fert_tank": {
       "name": "fertilizer_tank",
@@ -1698,7 +1720,8 @@
       "groups": [
         "machinery"
       ],
-      "excluded": false
+      "excluded": false,
+      "dlc": "farm_machinery"
     },
     "kr_bigx1180": {
       "name": "forage_harvester_krone_bigx1180",
@@ -1716,7 +1739,8 @@
       "groups": [
         "machinery"
       ],
-      "excluded": false
+      "excluded": false,
+      "dlc": "krone_agri"
     },
     "forklifts": {
       "name": "forklifts",
@@ -1753,7 +1777,8 @@
       "groups": [
         "machinery"
       ],
-      "excluded": false
+      "excluded": false,
+      "dlc": "bobcat"
     },
     "forwarder": {
       "name": "forwarder",
@@ -1771,7 +1796,8 @@
       "groups": [
         "machinery"
       ],
-      "excluded": false
+      "excluded": false,
+      "dlc": "forest_machinery"
     },
     "frozen_food": {
       "name": "frozen_food",
@@ -2143,7 +2169,8 @@
       "groups": [
         "machinery"
       ],
-      "excluded": false
+      "excluded": false,
+      "dlc": "heavy_cargo"
     },
     "home_acc": {
       "name": "home_acc",
@@ -2347,7 +2374,8 @@
       "groups": [
         "machinery"
       ],
-      "excluded": false
+      "excluded": false,
+      "dlc": "heavy_cargo"
     },
     "lift_truck_s": {
       "name": "lift_truck_chassis",
@@ -2365,7 +2393,8 @@
       "groups": [
         "machinery"
       ],
-      "excluded": false
+      "excluded": false,
+      "dlc": "heavy_cargo"
     },
     "limestone": {
       "name": "limestone",
@@ -2474,7 +2503,8 @@
       "groups": [
         "machinery"
       ],
-      "excluded": false
+      "excluded": false,
+      "dlc": "forest_machinery"
     },
     "log_loader": {
       "name": "log_loader",
@@ -2492,7 +2522,8 @@
       "groups": [
         "machinery"
       ],
-      "excluded": false
+      "excluded": false,
+      "dlc": "forest_machinery"
     },
     "log_stacker": {
       "name": "log_stacker",
@@ -2510,7 +2541,8 @@
       "groups": [
         "machinery"
       ],
-      "excluded": false
+      "excluded": false,
+      "dlc": "forest_machinery"
     },
     "logs": {
       "name": "logs",
@@ -2786,7 +2818,8 @@
       "groups": [
         "machinery"
       ],
-      "excluded": false
+      "excluded": false,
+      "dlc": "heavy_cargo"
     },
     "bob_e10e": {
       "name": "mini_excavator_bobcat_e10e",
@@ -2805,7 +2838,8 @@
       "groups": [
         "machinery"
       ],
-      "excluded": false
+      "excluded": false,
+      "dlc": "bobcat"
     },
     "mixtank": {
       "name": "mix_tank",
@@ -2861,7 +2895,8 @@
       "groups": [
         "machinery"
       ],
-      "excluded": false
+      "excluded": false,
+      "dlc": "heavy_cargo"
     },
     "mob_crusher": {
       "name": "mobile_crusher",
@@ -2879,7 +2914,8 @@
       "groups": [
         "machinery"
       ],
-      "excluded": false
+      "excluded": false,
+      "dlc": "heavy_cargo"
     },
     "mob_screener": {
       "name": "mobile_screener",
@@ -2897,7 +2933,8 @@
       "groups": [
         "machinery"
       ],
-      "excluded": false
+      "excluded": false,
+      "dlc": "heavy_cargo"
     },
     "mob_stacker": {
       "name": "mobile_stacker",
@@ -2915,7 +2952,8 @@
       "groups": [
         "machinery"
       ],
-      "excluded": false
+      "excluded": false,
+      "dlc": "heavy_cargo"
     },
     "moor_buoy": {
       "name": "moor_buoy",
@@ -3005,7 +3043,8 @@
       "groups": [
         "machinery"
       ],
-      "excluded": false
+      "excluded": false,
+      "dlc": "krone_agri"
     },
     "mulcher": {
       "name": "mulcher",
@@ -3023,7 +3062,8 @@
       "groups": [
         "machinery"
       ],
-      "excluded": false
+      "excluded": false,
+      "dlc": "forest_machinery"
     },
     "truck_muni": {
       "name": "municipal_truck",
@@ -3295,7 +3335,8 @@
       "groups": [
         "machinery"
       ],
-      "excluded": false
+      "excluded": false,
+      "dlc": "farm_machinery"
     },
     "plows": {
       "name": "plows",
@@ -3411,7 +3452,8 @@
       "groups": [
         "machinery"
       ],
-      "excluded": false
+      "excluded": false,
+      "dlc": "jcb"
     },
     "hipresstank": {
       "name": "presstank",
@@ -3634,7 +3676,8 @@
       "groups": [
         "machinery"
       ],
-      "excluded": false
+      "excluded": false,
+      "dlc": "krone_agri"
     },
     "ter_forklift": {
       "name": "rough_terrain_forklift",
@@ -3673,7 +3716,8 @@
       "groups": [
         "machinery"
       ],
-      "excluded": false
+      "excluded": false,
+      "dlc": "krone_agri"
     },
     "rye": {
       "name": "rye",
@@ -3878,7 +3922,8 @@
       "groups": [
         "machinery"
       ],
-      "excluded": false
+      "excluded": false,
+      "dlc": "heavy_cargo"
     },
     "truck_servic": {
       "name": "service_truck",
@@ -3950,7 +3995,8 @@
       "groups": [
         "machinery"
       ],
-      "excluded": false
+      "excluded": false,
+      "dlc": "jcb"
     },
     "bob_s86": {
       "name": "skid_steer_loader_bobcat_s86",
@@ -3968,7 +4014,8 @@
       "groups": [
         "machinery"
       ],
-      "excluded": false
+      "excluded": false,
+      "dlc": "bobcat"
     },
     "skidder": {
       "name": "skidder",
@@ -3986,7 +4033,8 @@
       "groups": [
         "machinery"
       ],
-      "excluded": false
+      "excluded": false,
+      "dlc": "forest_machinery"
     },
     "soda_ash": {
       "name": "soda_ash",
@@ -4101,7 +4149,8 @@
       "groups": [
         "machinery"
       ],
-      "excluded": false
+      "excluded": false,
+      "dlc": "farm_machinery"
     },
     "square_baler": {
       "name": "square_baler",
@@ -4119,7 +4168,8 @@
       "groups": [
         "machinery"
       ],
-      "excluded": false
+      "excluded": false,
+      "dlc": "farm_machinery"
     },
     "kr_bigp1290": {
       "name": "square_baler_krone_bigp1290",
@@ -4137,7 +4187,8 @@
       "groups": [
         "machinery"
       ],
-      "excluded": false
+      "excluded": false,
+      "dlc": "krone_agri"
     },
     "sq_tub": {
       "name": "square_tubing",
@@ -4192,7 +4243,8 @@
       "groups": [
         "machinery"
       ],
-      "excluded": false
+      "excluded": false,
+      "dlc": "forest_machinery"
     },
     "sugar": {
       "name": "sugar",
@@ -4387,7 +4439,8 @@
       "groups": [
         "machinery"
       ],
-      "excluded": false
+      "excluded": false,
+      "dlc": "jcb"
     },
     "toys": {
       "name": "toys",
@@ -4446,7 +4499,8 @@
       "groups": [
         "machinery"
       ],
-      "excluded": false
+      "excluded": false,
+      "dlc": "jcb"
     },
     "train_part": {
       "name": "train_parts",
@@ -4501,7 +4555,8 @@
       "groups": [
         "construction"
       ],
-      "excluded": false
+      "excluded": false,
+      "dlc": "heavy_cargo"
     },
     "trees": {
       "name": "trees",
@@ -4659,7 +4714,8 @@
       "groups": [
         "machinery"
       ],
-      "excluded": false
+      "excluded": false,
+      "dlc": "krone_agri"
     },
     "waste_paper": {
       "name": "waste_paper",
@@ -4741,7 +4797,8 @@
       "groups": [
         "machinery"
       ],
-      "excluded": false
+      "excluded": false,
+      "dlc": "bobcat"
     },
     "jcb_wload457": {
       "name": "wheel_loader_jcb_457",
@@ -4759,7 +4816,8 @@
       "groups": [
         "machinery"
       ],
-      "excluded": false
+      "excluded": false,
+      "dlc": "jcb"
     },
     "volvo_l250h": {
       "name": "wheel_loader_volvo_l250h",
@@ -4777,7 +4835,8 @@
       "groups": [
         "machinery"
       ],
-      "excluded": false
+      "excluded": false,
+      "dlc": "volvo_ce"
     },
     "volvo_rims": {
       "name": "wheels_with_volvo_rims",
@@ -4795,7 +4854,8 @@
       "groups": [
         "machinery"
       ],
-      "excluded": false
+      "excluded": false,
+      "dlc": "volvo_ce"
     },
     "windml_eng": {
       "name": "windmill_engine",
@@ -4849,7 +4909,8 @@
       "groups": [
         "machinery"
       ],
-      "excluded": false
+      "excluded": false,
+      "dlc": "farm_machinery"
     },
     "wire_rod": {
       "name": "wire_rod_coil",
@@ -109668,7 +109729,69 @@
         "springfie_il"
       ]
     },
-    "cargo_dlc_map": {},
+    "cargo_dlc_map": {
+      "bob_d30": "bobcat",
+      "bob_e10e": "bobcat",
+      "bob_e60": "bobcat",
+      "bob_l95": "bobcat",
+      "bob_pa127v": "bobcat",
+      "bob_s86": "bobcat",
+      "bob_tl3070a": "bobcat",
+      "jcb_bhl4cx": "jcb",
+      "jcb_dmp6t2": "jcb",
+      "jcb_dmphtd5e": "jcb",
+      "jcb_exc245xr": "jcb",
+      "jcb_ft4220": "jcb",
+      "jcb_g100rs": "jcb",
+      "jcb_mexc19ce": "jcb",
+      "jcb_pw125qe": "jcb",
+      "jcb_th540180": "jcb",
+      "jcb_wload457": "jcb",
+      "asph_miller": "heavy_cargo",
+      "coil": "heavy_cargo",
+      "cott_harvest": "heavy_cargo",
+      "dozer": "heavy_cargo",
+      "lift_truck": "heavy_cargo",
+      "lift_truck_s": "heavy_cargo",
+      "mob_crusher": "heavy_cargo",
+      "mob_screener": "heavy_cargo",
+      "mob_stacker": "heavy_cargo",
+      "mobile_crane": "heavy_cargo",
+      "scraper": "heavy_cargo",
+      "tractor_c": "heavy_cargo",
+      "transformer": "heavy_cargo",
+      "kr_bigm450": "krone_agri",
+      "kr_bigp1290": "krone_agri",
+      "kr_bigx1180": "krone_agri",
+      "kr_ecb880cv": "krone_agri",
+      "kr_gx440": "krone_agri",
+      "kr_stc1370": "krone_agri",
+      "kr_vpv190xc": "krone_agri",
+      "auger_wag": "farm_machinery",
+      "disc_harrows": "farm_machinery",
+      "fert_spread": "farm_machinery",
+      "forage_harv": "farm_machinery",
+      "planter": "farm_machinery",
+      "sprayer": "farm_machinery",
+      "square_baler": "farm_machinery",
+      "tractor_au": "farm_machinery",
+      "tractor_c2": "farm_machinery",
+      "windrower": "farm_machinery",
+      "vol_ew240emh": "volvo_ce",
+      "volvo_a25g": "volvo_ce",
+      "volvo_bucket": "volvo_ce",
+      "volvo_ec220e": "volvo_ce",
+      "volvo_l250h": "volvo_ce",
+      "volvo_rims": "volvo_ce",
+      "volvo_sd160b": "volvo_ce",
+      "forwarder": "forest_machinery",
+      "log_harvest": "forest_machinery",
+      "log_loader": "forest_machinery",
+      "log_stacker": "forest_machinery",
+      "mulcher": "forest_machinery",
+      "skidder": "forest_machinery",
+      "stumper": "forest_machinery"
+    },
     "map_dlc_cargo": {},
     "garage_cities": [
       "abilene",

--- a/scripts/parse-game-defs.ts
+++ b/scripts/parse-game-defs.ts
@@ -468,15 +468,57 @@ const ATS_MAP_DLCS: Record<string, string> = {
 
 /** Cargo → DLC pack mapping (ATS).
  *
- * NOT YET POPULATED — populating per-cargo DLC pack assignments for ATS
- * requires per-pack wiki research (which cargo IDs ship in which pack).
- * Until populated, ATS cargo will report no DLC pack on the marginal-value
- * calculator. Tracked as a follow-up. */
-const ATS_CARGO_DLC_MAP: Record<string, string> = {};
+ * Sourced directly from each pack's `def/cargo.<dlc>.sii` aggregator inside the
+ * owned `dlc_*.scs` archives (HashFS v2). Every id is cross-checked to exist in
+ * `public/data/ats/game-defs.json` `.cargo` and to NOT collide with any base
+ * `def.scs` cargo (so nothing base-game gets wrongly DLC-gated). */
+const ATS_CARGO_DLC_MAP: Record<string, string> = {
+  // Bobcat Cargo Pack (7)
+  bob_d30: 'bobcat', bob_e10e: 'bobcat', bob_e60: 'bobcat', bob_l95: 'bobcat',
+  bob_pa127v: 'bobcat', bob_s86: 'bobcat', bob_tl3070a: 'bobcat',
+  // JCB Equipment Pack (10)
+  jcb_bhl4cx: 'jcb', jcb_dmp6t2: 'jcb', jcb_dmphtd5e: 'jcb', jcb_exc245xr: 'jcb',
+  jcb_ft4220: 'jcb', jcb_g100rs: 'jcb', jcb_mexc19ce: 'jcb', jcb_pw125qe: 'jcb',
+  jcb_th540180: 'jcb', jcb_wload457: 'jcb',
+  // Heavy Cargo Pack (13)
+  asph_miller: 'heavy_cargo', coil: 'heavy_cargo', cott_harvest: 'heavy_cargo',
+  dozer: 'heavy_cargo', lift_truck: 'heavy_cargo', lift_truck_s: 'heavy_cargo',
+  mob_crusher: 'heavy_cargo', mob_screener: 'heavy_cargo', mob_stacker: 'heavy_cargo',
+  mobile_crane: 'heavy_cargo', scraper: 'heavy_cargo', tractor_c: 'heavy_cargo',
+  transformer: 'heavy_cargo',
+  // KRONE Agriculture Equipment (7)
+  kr_bigm450: 'krone_agri', kr_bigp1290: 'krone_agri', kr_bigx1180: 'krone_agri',
+  kr_ecb880cv: 'krone_agri', kr_gx440: 'krone_agri', kr_stc1370: 'krone_agri',
+  kr_vpv190xc: 'krone_agri',
+  // Farm Machinery (10)
+  auger_wag: 'farm_machinery', disc_harrows: 'farm_machinery', fert_spread: 'farm_machinery',
+  forage_harv: 'farm_machinery', planter: 'farm_machinery', sprayer: 'farm_machinery',
+  square_baler: 'farm_machinery', tractor_au: 'farm_machinery', tractor_c2: 'farm_machinery',
+  windrower: 'farm_machinery',
+  // Volvo Construction Equipment (7)
+  vol_ew240emh: 'volvo_ce', volvo_a25g: 'volvo_ce', volvo_bucket: 'volvo_ce',
+  volvo_ec220e: 'volvo_ce', volvo_l250h: 'volvo_ce', volvo_rims: 'volvo_ce',
+  volvo_sd160b: 'volvo_ce',
+  // Forest Machinery (7) — kb_loader and tub_grinder also ship in dlc_forest_harvesting
+  // but are trailer-delivery cargo (body_types _kb_lderkber / _tub_dertuer), excluded by
+  // the parser, so they are absent from the dataset and intentionally omitted here.
+  forwarder: 'forest_machinery', log_harvest: 'forest_machinery', log_loader: 'forest_machinery',
+  log_stacker: 'forest_machinery', mulcher: 'forest_machinery', skidder: 'forest_machinery',
+  stumper: 'forest_machinery',
+  // Special Transport (dlc_oversize): all 16 of its cargo are oversize/player-only (group
+  // 'oversize') and excluded from the AI-haulable dataset — same as ETS2, where only
+  // escort-capable Special Transport cargo qualify. No in-dataset cargo, hence no entries;
+  // the pack still appears in ATS_CARGO_DLCS so its (zero) marginal value renders correctly.
+};
 
-/** Cargo only available with a specific map expansion (ATS).
+/** Cargo only available with a specific map expansion (ATS) — "shadow cargo".
  *
- * NOT YET POPULATED — same reason as ATS_CARGO_DLC_MAP. */
+ * Empty: only the free Arizona/Nevada state DLCs are installed (both map to null
+ * in ATS_STATE_TO_DLC, i.e. base-tier), so no *purchasable* state map DLC is owned
+ * to source state-exclusive cargo from. Populate per owned state by reading that
+ * state's `dlc_<state>.scs` `def/cargo.dlc_<state>.sii` aggregator (same method as
+ * ATS_CARGO_DLC_MAP) and tagging each id with its state DLC id. Grows as map DLCs
+ * are bought; see #243. */
 const ATS_MAP_DLC_CARGO: Record<string, string> = {};
 
 // ─── Game-aware aliases ─────────────────────────────────────────────

--- a/scripts/scs-extract/.gitignore
+++ b/scripts/scs-extract/.gitignore
@@ -1,0 +1,1 @@
+/scs-extract

--- a/scripts/scs-extract/README.md
+++ b/scripts/scs-extract/README.md
@@ -1,0 +1,58 @@
+# scs-extract
+
+Lists or extracts files from an SCS# (HashFS **v2**) archive — the `.scs`
+container format used by ETS2 and ATS. Used to pull the `def/` tree out of game
+and DLC archives for `scripts/parse-game-defs.ts` (CLAUDE.md step 1, "Extract
+`def/` folder … (SCS Extractor)").
+
+## Why not the upstream tool
+
+[`github.com/Luzifer/scs-extract`](https://github.com/Luzifer/scs-extract) parses
+the HashFS v2 metadata table sequentially and aborts with
+`unhandled file type: 0` on the texture/sample/mip entry types packed inside DLC
+archives (e.g. `dlc_bobcat.scs`). This tool never walks the metadata table
+sequentially: the table is a flat array of 4-byte words, and a catalog entry's
+`MetadataIndex` is the word offset of its own record, so it seeks straight to the
+one file it wants. Directory listings drive a recursive walk, so every `.sii`/
+`.sui` def file is reachable without ever decoding a texture entry. It reuses
+that project's `b0rkhash` CityHash64 (Apache-2.0, via `go.mod`) so path→hash
+lookups match the game exactly.
+
+Only plain files (`0x80`) and directories (`0x81`) are decoded; other entry
+types are listed but skipped on extract — exactly the `def/` subset the parser
+needs.
+
+## Usage
+
+```
+go run . [-x] [-o DIR] ARCHIVE.scs [ROOTPATH]
+
+  -x         extract instead of list
+  -o DIR     output directory for -x (default "extracted")
+  ROOTPATH   limit the walk to this subtree (default "def"; "" = whole archive)
+```
+
+List the cargo defs a pack ships:
+
+```sh
+go run . "$ATS/dlc_bobcat.scs" def/cargo
+```
+
+Extract the def tree for a reparse (overlay base + DLC archives into one folder,
+last-write-wins, then point the parser at it):
+
+```sh
+ATS="$HOME/Library/Application Support/Steam/steamapps/common/American Truck Simulator"
+for a in def base base_share dlc_*; do
+  go run . -x -o /tmp/ats_def "$ATS/$a.scs" def
+done
+npx tsx ../parse-game-defs.ts /tmp/ats_def/def --game ats
+```
+
+## Deriving cargo→DLC-pack mappings
+
+Each cargo pack defines its cargo in `def/cargo.<dlc>.sii`, an aggregator of
+`@include "cargo/<id>.<dlc>.sui"` lines. The `<id>` tokens are the cargo IDs.
+This is how `ATS_CARGO_DLC_MAP` in `parse-game-defs.ts` was sourced (#243), and
+the same method populates `ATS_MAP_DLC_CARGO` from a `dlc_<state>.scs` once that
+state map DLC is owned.

--- a/scripts/scs-extract/go.mod
+++ b/scripts/scs-extract/go.mod
@@ -1,0 +1,5 @@
+module trucker/scripts/scs-extract
+
+go 1.24
+
+require github.com/Luzifer/scs-extract v1.0.1

--- a/scripts/scs-extract/go.sum
+++ b/scripts/scs-extract/go.sum
@@ -1,0 +1,2 @@
+github.com/Luzifer/scs-extract v1.0.1 h1:cpCqXy9NLGik2PH52zOojxfJ7/qYwsxPyMNwFOlROq4=
+github.com/Luzifer/scs-extract v1.0.1/go.mod h1:iSfFVqjTkuHeKVxbzxB67trZ04kUQYavCIz0Nq2QGeI=

--- a/scripts/scs-extract/main.go
+++ b/scripts/scs-extract/main.go
@@ -6,8 +6,8 @@
 // HashFS v2 metadata table sequentially and aborts ("unhandled file type") on
 // the texture/sample/mip entry types that ship inside DLC archives. This tool
 // never walks the metadata table sequentially. The metadata table is a flat
-// array of 4-byte words; a catalog entry's MetadataIndex is the word offset of
-// its own metadata record, so we seek straight to meta[MetadataIndex*4] for the
+// array of 4-byte words; a catalog entry's data locator is the last of its
+// MetadataCount records (see metaByteOffset), so we seek straight to it for the
 // one file we want. Directory contents are themselves plain files listing their
 // children, so a recursive walk from a root path reaches every `.sii`/`.sui`
 // def file without ever decoding a texture entry.
@@ -143,13 +143,29 @@ func (a *archive) readFile(p string) ([]byte, error) {
 	return a.readEntry(e)
 }
 
+// metaByteOffset returns the byte offset of an entry's metadata record in the
+// decompressed table. The table is a flat array of 4-byte words; an entry owns
+// MetadataCount consecutive records and its data locator is the last one, at
+// word MetadataIndex+MetadataCount-1. Plain files and directories always have
+// MetadataCount==1 (verified across base + DLC archives: 32k+ entries, no
+// exception), so this reduces to MetadataIndex for everything this tool
+// extracts — the general form just keeps a hypothetical multi-record plain
+// entry from being mis-seeked.
+func (a *archive) metaByteOffset(e catalogEntry) int {
+	return (int(e.MetadataIndex) + int(e.MetadataCount) - 1) * metaWordSize
+}
+
 func (a *archive) entryType(e catalogEntry) byte {
-	return a.meta[int(e.MetadataIndex)*metaWordSize+3]
+	off := a.metaByteOffset(e)
+	if off < 0 || off+4 > len(a.meta) {
+		return 0 // out of range → treated as non-plain, skipped
+	}
+	return a.meta[off+3]
 }
 
 func (a *archive) readEntry(e catalogEntry) ([]byte, error) {
-	off := int(e.MetadataIndex) * metaWordSize
-	if off+20 > len(a.meta) {
+	off := a.metaByteOffset(e)
+	if off < 0 || off+20 > len(a.meta) {
 		return nil, fmt.Errorf("metadata offset out of range")
 	}
 	p := a.meta[off+4 : off+20] // 16-byte payload after the 4-byte type header
@@ -184,11 +200,17 @@ func (a *archive) readDir(dir string) ([]child, error) {
 		return nil, nil
 	}
 	count := binary.LittleEndian.Uint32(data)
+	if 4+int(count) > len(data) {
+		return nil, fmt.Errorf("directory listing truncated: %s", dir)
+	}
 	lengths := data[4 : 4+count]
 	pos := 4 + int(count)
 	out := make([]child, 0, count)
 	for i := uint32(0); i < count; i++ {
 		n := int(lengths[i])
+		if pos+n > len(data) {
+			return nil, fmt.Errorf("directory name overruns listing: %s", dir)
+		}
 		name := string(data[pos : pos+n])
 		pos += n
 		isDir := strings.HasPrefix(name, "/")

--- a/scripts/scs-extract/main.go
+++ b/scripts/scs-extract/main.go
@@ -1,0 +1,292 @@
+// Command scs-extract lists or extracts files from an SCS# (HashFS) archive,
+// the container format used by Euro Truck Simulator 2 and American Truck
+// Simulator `.scs` files.
+//
+// Why this exists: the upstream github.com/Luzifer/scs-extract CLI parses the
+// HashFS v2 metadata table sequentially and aborts ("unhandled file type") on
+// the texture/sample/mip entry types that ship inside DLC archives. This tool
+// never walks the metadata table sequentially. The metadata table is a flat
+// array of 4-byte words; a catalog entry's MetadataIndex is the word offset of
+// its own metadata record, so we seek straight to meta[MetadataIndex*4] for the
+// one file we want. Directory contents are themselves plain files listing their
+// children, so a recursive walk from a root path reaches every `.sii`/`.sui`
+// def file without ever decoding a texture entry.
+//
+// Only plain files (type 0x80) and directories (type 0x81) are decoded; other
+// entry types (textures, samples, mip levels) are listed but skipped on
+// extract, which is exactly what the def/ extraction the data pipeline needs.
+//
+// Usage:
+//
+//	go run . [-x] [-o DIR] ARCHIVE.scs [ROOTPATH]
+//
+//	-x         extract instead of list
+//	-o DIR     output directory for -x (default "extracted")
+//	ROOTPATH   limit the walk to this subtree (default "def"; pass "" for all)
+//
+// Example — extract the def tree the parser reads:
+//
+//	go run . -x -o /tmp/ats_def "$ATS/def.scs" def
+//
+// CityHash64 is the SCS-specific ("b0rked") variant from
+// github.com/Luzifer/scs-extract/b0rkhash (Apache-2.0); reused via go.mod so the
+// path→hash lookups match the game exactly.
+package main
+
+import (
+	"compress/flate"
+	"compress/zlib"
+	"encoding/binary"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/Luzifer/scs-extract/b0rkhash"
+)
+
+const (
+	typePlainFile = 0x80
+	typeDirectory = 0x81
+	metaWordSize  = 4  // metadata table is a flat array of 4-byte words
+	offsetBlock   = 16 // file offsets are stored in 16-byte blocks
+	zipHeader     = 2  // 2-byte zlib header prefixing each compressed payload
+	compressedBit = 0x10
+)
+
+type fileHeader struct {
+	Magic                    [4]byte
+	Version                  uint16
+	Salt                     uint16
+	HashMethod               [4]byte
+	EntryCount               uint32
+	EntryTableLength         uint32
+	MetadataEntriesCount     uint32
+	MetadataTableLength      uint32
+	EntryTableStart          uint64
+	MetadataTableStart       uint64
+	SecurityDescriptorOffset uint32
+	Platform                 byte
+}
+
+type catalogEntry struct {
+	Hash          uint64
+	MetadataIndex uint32
+	MetadataCount uint16
+	Flags         uint16
+}
+
+type archive struct {
+	r       io.ReaderAt
+	entries map[uint64]catalogEntry
+	meta    []byte
+}
+
+func u24(b []byte) uint32 { return uint32(b[0]) | uint32(b[1])<<8 | uint32(b[2])<<16 }
+
+func openArchive(r io.ReaderAt) (*archive, error) {
+	var h fileHeader
+	if err := binary.Read(io.NewSectionReader(r, 0, int64(binary.Size(fileHeader{}))), binary.LittleEndian, &h); err != nil {
+		return nil, fmt.Errorf("reading header: %w", err)
+	}
+	if string(h.Magic[:]) != "SCS#" {
+		return nil, fmt.Errorf("not an SCS# archive (magic %q)", h.Magic)
+	}
+	if h.Version != 2 {
+		return nil, fmt.Errorf("unsupported HashFS version %d (only v2 handled)", h.Version)
+	}
+
+	// Catalog (entry) table: zlib-compressed array of catalogEntry.
+	ez, err := zlib.NewReader(io.NewSectionReader(r, int64(h.EntryTableStart), int64(h.EntryTableLength)))
+	if err != nil {
+		return nil, fmt.Errorf("opening entry table: %w", err)
+	}
+	defer ez.Close()
+	entries := make(map[uint64]catalogEntry, h.EntryCount)
+	for i := uint32(0); i < h.EntryCount; i++ {
+		var e catalogEntry
+		if err := binary.Read(ez, binary.LittleEndian, &e); err != nil {
+			return nil, fmt.Errorf("reading entry %d: %w", i, err)
+		}
+		entries[e.Hash] = e
+	}
+
+	// Metadata table: zlib-compressed flat blob, indexed by word offset.
+	mz, err := zlib.NewReader(io.NewSectionReader(r, int64(h.MetadataTableStart), int64(h.MetadataTableLength)))
+	if err != nil {
+		return nil, fmt.Errorf("opening metadata table: %w", err)
+	}
+	defer mz.Close()
+	meta, err := io.ReadAll(mz)
+	if err != nil {
+		return nil, fmt.Errorf("reading metadata table: %w", err)
+	}
+	return &archive{r: r, entries: entries, meta: meta}, nil
+}
+
+// entryFor returns the catalog entry for a path, or false if absent.
+func (a *archive) entryFor(p string) (catalogEntry, bool) {
+	e, ok := a.entries[b0rkhash.CityHash64([]byte(p))]
+	return e, ok
+}
+
+// readFile decodes and returns the bytes of a plain file at the given path.
+func (a *archive) readFile(p string) ([]byte, error) {
+	e, ok := a.entryFor(p)
+	if !ok {
+		return nil, fmt.Errorf("not in archive: %s", p)
+	}
+	return a.readEntry(e)
+}
+
+func (a *archive) entryType(e catalogEntry) byte {
+	return a.meta[int(e.MetadataIndex)*metaWordSize+3]
+}
+
+func (a *archive) readEntry(e catalogEntry) ([]byte, error) {
+	off := int(e.MetadataIndex) * metaWordSize
+	if off+20 > len(a.meta) {
+		return nil, fmt.Errorf("metadata offset out of range")
+	}
+	p := a.meta[off+4 : off+20] // 16-byte payload after the 4-byte type header
+	compSize := u24(p)
+	flags := p[3]
+	size := binary.LittleEndian.Uint32(p[4:])
+	fileOff := uint64(binary.LittleEndian.Uint32(p[12:])) * offsetBlock
+
+	if flags&compressedBit != 0 {
+		sr := io.NewSectionReader(a.r, int64(fileOff+zipHeader), int64(compSize))
+		return io.ReadAll(flate.NewReader(sr))
+	}
+	out := make([]byte, size)
+	_, err := a.r.ReadAt(out, int64(fileOff))
+	return out, err
+}
+
+type child struct {
+	name  string
+	isDir bool
+}
+
+// readDir parses a directory listing file into its immediate children.
+// Layout: uint32 count, count bytes of name lengths, then the names; a name
+// prefixed with '/' denotes a subdirectory.
+func (a *archive) readDir(dir string) ([]child, error) {
+	data, err := a.readFile(dir)
+	if err != nil {
+		return nil, err
+	}
+	if len(data) < 4 {
+		return nil, nil
+	}
+	count := binary.LittleEndian.Uint32(data)
+	lengths := data[4 : 4+count]
+	pos := 4 + int(count)
+	out := make([]child, 0, count)
+	for i := uint32(0); i < count; i++ {
+		n := int(lengths[i])
+		name := string(data[pos : pos+n])
+		pos += n
+		isDir := strings.HasPrefix(name, "/")
+		out = append(out, child{name: strings.TrimPrefix(name, "/"), isDir: isDir})
+	}
+	return out, nil
+}
+
+// walk visits every file under root, calling fn(path, entry). Directory
+// listings drive the traversal so no sequential metadata parse is needed.
+func (a *archive) walk(root string, fn func(string, catalogEntry)) error {
+	children, err := a.readDir(root)
+	if err != nil {
+		return err
+	}
+	for _, c := range children {
+		full := strings.TrimPrefix(path.Join(root, c.name), "/")
+		if c.isDir {
+			if err := a.walk(full, fn); err != nil {
+				return err
+			}
+			continue
+		}
+		if e, ok := a.entryFor(full); ok {
+			fn(full, e)
+		}
+	}
+	return nil
+}
+
+func main() {
+	extract := flag.Bool("x", false, "extract files instead of listing")
+	outDir := flag.String("o", "extracted", "output directory for -x")
+	flag.Parse()
+	if flag.NArg() < 1 {
+		fmt.Fprintln(os.Stderr, "usage: scs-extract [-x] [-o DIR] ARCHIVE.scs [ROOTPATH]")
+		os.Exit(2)
+	}
+	root := "def"
+	if flag.NArg() >= 2 {
+		root = flag.Arg(1)
+	}
+
+	f, err := os.Open(flag.Arg(0))
+	if err != nil {
+		fatal(err)
+	}
+	defer f.Close()
+	a, err := openArchive(f)
+	if err != nil {
+		fatal(err)
+	}
+
+	// Root may be "" (archives rooted at "") or "locale" for locale.scs.
+	if root != "" {
+		if _, ok := a.entryFor(root); !ok {
+			fatal(fmt.Errorf("root path %q not found in archive", root))
+		}
+	}
+
+	var paths []string
+	var skipped int
+	err = a.walk(root, func(p string, e catalogEntry) {
+		if t := a.entryType(e); t != typePlainFile && t != typeDirectory {
+			skipped++ // texture/sample/mip — not a plain def file
+			return
+		}
+		paths = append(paths, p)
+	})
+	if err != nil {
+		fatal(err)
+	}
+	sort.Strings(paths)
+
+	if !*extract {
+		for _, p := range paths {
+			fmt.Println(p)
+		}
+		fmt.Fprintf(os.Stderr, "%d files (%d non-plain entries skipped)\n", len(paths), skipped)
+		return
+	}
+	for _, p := range paths {
+		data, err := a.readFile(p)
+		if err != nil {
+			fatal(fmt.Errorf("reading %s: %w", p, err))
+		}
+		dest := filepath.Join(*outDir, filepath.FromSlash(p))
+		if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+			fatal(err)
+		}
+		if err := os.WriteFile(dest, data, 0o644); err != nil {
+			fatal(err)
+		}
+	}
+	fmt.Fprintf(os.Stderr, "extracted %d files to %s (%d non-plain entries skipped)\n", len(paths), *outDir, skipped)
+}
+
+func fatal(err error) {
+	fmt.Fprintln(os.Stderr, "error:", err)
+	os.Exit(1)
+}


### PR DESCRIPTION
Closes #243.

## Summary

`ATS_CARGO_DLC_MAP` was an empty stub, so the ATS DLC marginal-value calculator reported zero for every cargo pack and rankings ignored pack cargo when toggling DLCs. Now populated: **61 cargo across 7 packs**, sourced directly from the owned `dlc_*.scs` archives — not the wiki.

| Pack | Cargo |
|---|---|
| Bobcat | 7 |
| JCB | 10 |
| Heavy Cargo | 13 |
| KRONE Agriculture | 7 |
| Farm Machinery | 10 |
| Volvo Construction | 7 |
| Forest Machinery | 7 |
| Special Transport | 0 (see below) |

## Sourcing & verification

Each pack defines its cargo in `def/cargo.<dlc>.sii`, an aggregator of `@include "cargo/<id>.<dlc>.sui"` lines. Read those straight from the archives, then cross-checked every id three ways:

- **exists** in `public/data/ats/game-defs.json` `.cargo`;
- **no collision** with any base `def.scs` cargo (215 base ids) — nothing base-game is wrongly DLC-gated;
- data flow confirmed: the 61 reach the calculator via `initDlcData → COMBINED_CARGO_DLC_MAP` (acceptance criterion 4).

**Special Transport (`dlc_oversize`) = 0 entries**, deliberately: all 16 of its cargo are oversize/player-only (group `oversize`), excluded from the AI-haulable dataset — same shape as ETS2 where only escort-capable cargo qualify. The pack stays declared in `ATS_CARGO_DLCS`; its marginal value renders as a correct zero. `kb_loader`/`tub_grinder` (Forest) are also omitted — trailer-delivery cargo (`_`-prefixed body types), excluded by the parser.

**`ATS_MAP_DLC_CARGO` stays empty**: only the free Arizona/Nevada state DLCs are installed (base-tier), so there is no *purchasable* state map DLC owned to source shadow cargo from. The comment documents the per-state method for when one is bought.

## game-defs.json

Regenerated by applying the new map to the existing data (`.cargo[id].dlc` + `.dlc.cargo_dlc_map`) — byte-identical to a reparse for these fields; trailing bytes unchanged. A full live reparse needs the extracted `def/` folder, which isn't checked in.

## scripts/scs-extract (new)

The upstream `Luzifer/scs-extract` CLI aborts (`unhandled file type`) on the texture entry types inside DLC archives. This Go reader seeks directly to each file's metadata record by word offset and walks directory listings, reaching every def file without a sequential metadata parse. It produced the data here and can drive a real `def/` reparse (verified: extracts the full bobcat def tree, 936 files, content matches the dataset). Reuses upstream's `b0rkhash` CityHash64 (Apache-2.0) so path hashes match the game.

## Tests
`npm run lint` clean. Data tests pass. The 5 `nav-render` failures are pre-existing (jsdom `localStorage` undefined, identical on `main`).