### PR TITLE
feat(scripts): add defs-query CLI for map-keyed game-defs lookups

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "export": "tsx scripts/export-data.ts",
     "test": "vitest run",
     "parse-saves": "node scripts/parse-saves.cjs",
+    "defs-query": "node scripts/defs-query.cjs",
     "lint": "tsc --noEmit -p tsconfig.lint.json",
     "lint:fix": "tsc --noEmit -p tsconfig.lint.json",
     "format": "prettier --write src/frontend/"

--- a/scripts/__tests__/defs-query.test.ts
+++ b/scripts/__tests__/defs-query.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest';
+import { spawnSync } from 'child_process';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+// vitest runs from the repo root, so resolve the CLI and data from cwd.
+const CLI = join(process.cwd(), 'scripts', 'defs-query.cjs');
+const dataFile = (game: string) => join(process.cwd(), 'public', 'data', game, 'game-defs.json');
+const defs = (game: string) => JSON.parse(readFileSync(dataFile(game), 'utf8'));
+
+function run(args: string[]) {
+  const r = spawnSync('node', [CLI, ...args], { encoding: 'utf8' });
+  return { code: r.status, stdout: r.stdout, stderr: r.stderr };
+}
+
+const GAMES = ['ets2', 'ats'] as const;
+// Object.prototype member names — must NOT be mistaken for valid ids (#279 contract).
+const PROTO_KEYS = ['toString', 'constructor', 'valueOf', 'hasOwnProperty', '__proto__'];
+const SUBCOMMANDS = ['cargo', 'companies-for-cargo', 'city', 'city-companies'];
+
+describe.each(GAMES)('defs-query — happy path (%s)', (game) => {
+  const d = defs(game);
+  const firstKey = (section: string) => Object.keys(d[section])[0];
+
+  it('cargo <id> returns the record', () => {
+    const id = firstKey('cargo');
+    const r = run(['cargo', id, '--game', game]);
+    expect(r.code).toBe(0);
+    expect(JSON.parse(r.stdout)).toMatchObject({ id, name: d.cargo[id].name });
+  });
+
+  it('companies-for-cargo <id> reverse-walks cargo_out', () => {
+    const id = firstKey('cargo');
+    const r = run(['companies-for-cargo', id, '--game', game]);
+    expect(r.code).toBe(0);
+    const out = JSON.parse(r.stdout);
+    const expected = Object.values(d.companies).filter(
+      (c: any) => Array.isArray(c.cargo_out) && c.cargo_out.includes(id),
+    ).length;
+    expect(out.count).toBe(expected);
+    expect(out.companies).toHaveLength(expected);
+  });
+
+  it('city <id> returns the record', () => {
+    const id = firstKey('cities');
+    const r = run(['city', id, '--game', game]);
+    expect(r.code).toBe(0);
+    expect(JSON.parse(r.stdout)).toMatchObject({ id, name: d.cities[id].name });
+  });
+
+  it('city-companies <id> resolves the {companyId:count} map', () => {
+    const id = firstKey('city_companies');
+    const r = run(['city-companies', id, '--game', game]);
+    expect(r.code).toBe(0);
+    const out = JSON.parse(r.stdout);
+    expect(out.count).toBe(Object.keys(d.city_companies[id]).length);
+  });
+});
+
+describe('defs-query — unknown-id / arg contract (exit non-zero, no stack trace)', () => {
+  it.each(SUBCOMMANDS)('%s: a genuinely unknown id exits non-zero with a message', (sub) => {
+    const r = run([sub, 'definitely_not_a_real_id']);
+    expect(r.code).not.toBe(0);
+    expect(r.stderr).toMatch(/defs-query: unknown/);
+    expect(r.stderr).not.toMatch(/at .*\(.*:\d+:\d+\)/); // no stack frame
+  });
+
+  // The regression this test exists for: prototype-name ids must be treated as
+  // unknown, not silently resolved to an inherited Object.prototype member.
+  for (const sub of SUBCOMMANDS) {
+    it.each(PROTO_KEYS)(`${sub}: prototype-name id "%s" exits non-zero`, (key) => {
+      const r = run([sub, key]);
+      expect(r.code).not.toBe(0);
+    });
+  }
+
+  it('unknown --game exits non-zero', () => {
+    expect(run(['cargo', 'x', '--game', 'switch']).code).not.toBe(0);
+  });
+
+  it('missing subcommand exits non-zero', () => {
+    expect(run([]).code).not.toBe(0);
+  });
+
+  it('subcommand without an id exits non-zero', () => {
+    expect(run(['cargo']).code).not.toBe(0);
+  });
+
+  it('unknown subcommand exits non-zero', () => {
+    expect(run(['bogus', 'x']).code).not.toBe(0);
+  });
+
+  it('-h prints usage and exits zero', () => {
+    const r = run(['-h']);
+    expect(r.code).toBe(0);
+    expect(r.stdout).toMatch(/Usage:/);
+  });
+});

--- a/scripts/defs-query.cjs
+++ b/scripts/defs-query.cjs
@@ -79,15 +79,23 @@ function emit(obj) {
   process.stdout.write(JSON.stringify(obj, null, 2) + '\n');
 }
 
+// Own-property check, not bracket truthiness. `defs.cargo['toString']` (and
+// other Object.prototype names — constructor, valueOf, hasOwnProperty,
+// __proto__, …) would otherwise resolve to an inherited member, reporting a
+// bogus hit for a prototype-name id: exit 0 instead of the unknown-id error
+// the #279 contract requires. Object.hasOwn keys the check to real data only.
+function has(map, id) {
+  return Object.hasOwn(map, id);
+}
+
 const COMMANDS = {
   cargo(defs, id) {
-    const rec = defs.cargo[id];
-    if (!rec) die(`unknown cargo id '${id}'`);
-    emit({ id, ...rec });
+    if (!has(defs.cargo, id)) die(`unknown cargo id '${id}'`);
+    emit({ id, ...defs.cargo[id] });
   },
 
   'companies-for-cargo'(defs, id) {
-    if (!defs.cargo[id]) die(`unknown cargo id '${id}'`);
+    if (!has(defs.cargo, id)) die(`unknown cargo id '${id}'`);
     const companies = Object.entries(defs.companies)
       .filter(([, c]) => Array.isArray(c.cargo_out) && c.cargo_out.includes(id))
       .map(([cid, c]) => ({ id: cid, name: c.name }));
@@ -95,17 +103,15 @@ const COMMANDS = {
   },
 
   city(defs, id) {
-    const rec = defs.cities[id];
-    if (!rec) die(`unknown city id '${id}'`);
-    emit({ id, ...rec });
+    if (!has(defs.cities, id)) die(`unknown city id '${id}'`);
+    emit({ id, ...defs.cities[id] });
   },
 
   'city-companies'(defs, id) {
-    const present = defs.city_companies[id];
-    if (!present) die(`unknown city id '${id}' (no city_companies entry)`);
-    const companies = Object.entries(present).map(([cid, count]) => ({
+    if (!has(defs.city_companies, id)) die(`unknown city id '${id}' (no city_companies entry)`);
+    const companies = Object.entries(defs.city_companies[id]).map(([cid, count]) => ({
       id: cid,
-      name: defs.companies[cid] ? defs.companies[cid].name : null,
+      name: has(defs.companies, cid) ? defs.companies[cid].name : null,
       count,
     }));
     emit({ city: id, count: companies.length, companies });

--- a/scripts/defs-query.cjs
+++ b/scripts/defs-query.cjs
@@ -1,0 +1,123 @@
+#!/usr/bin/env node
+/**
+ * Query helper over public/data/<game>/game-defs.json.
+ *
+ * The cargo / companies / city_companies / cities sections are all id-keyed
+ * maps, NOT arrays — iterating them as arrays yields the keys (strings), which
+ * is the `'str' has no attribute 'get'` class of bug this tool exists to kill.
+ * Everything here accesses them as maps (obj[id] / Object.entries) only.
+ *
+ * Usage:
+ *   node scripts/defs-query.cjs <subcommand> <id> [--game ets2|ats]
+ *
+ *   cargo <id>                  cargo record
+ *   companies-for-cargo <id>    companies whose cargo_out includes <id>
+ *   city <id>                   city record
+ *   city-companies <id>         companies present in a city ({companyId:count} map)
+ *
+ * Output is JSON on stdout. Unknown ids / args exit non-zero with a one-line
+ * message on stderr — no stack traces.
+ */
+const fs = require('fs');
+const p = require('path');
+
+const GAMES = ['ets2', 'ats'];
+const SUBCOMMANDS = ['cargo', 'companies-for-cargo', 'city', 'city-companies'];
+
+function usage() {
+  return [
+    'Usage: node scripts/defs-query.cjs <subcommand> <id> [--game ets2|ats]',
+    '',
+    'Subcommands:',
+    '  cargo <id>                cargo record',
+    '  companies-for-cargo <id>  companies whose cargo_out includes <id>',
+    '  city <id>                 city record',
+    '  city-companies <id>       companies present in a city',
+    '',
+    `--game defaults to ${GAMES[0]} (one of: ${GAMES.join(', ')})`,
+  ].join('\n');
+}
+
+function die(msg) {
+  process.stderr.write(`defs-query: ${msg}\n`);
+  process.exit(1);
+}
+
+// Parse args: one --game flag (with value, anywhere) + positional subcommand/id.
+function parseArgs(argv) {
+  let game = GAMES[0];
+  const positional = [];
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--game') {
+      game = argv[++i];
+      if (game === undefined) die('--game requires a value (ets2|ats)');
+    } else if (a.startsWith('--game=')) {
+      game = a.slice('--game='.length);
+    } else if (a === '-h' || a === '--help') {
+      process.stdout.write(usage() + '\n');
+      process.exit(0);
+    } else {
+      positional.push(a);
+    }
+  }
+  if (!GAMES.includes(game)) die(`unknown game '${game}' (expected one of: ${GAMES.join(', ')})`);
+  return { game, subcommand: positional[0], id: positional[1] };
+}
+
+function loadDefs(game) {
+  const file = p.join(__dirname, '..', 'public', 'data', game, 'game-defs.json');
+  if (!fs.existsSync(file)) die(`no game-defs.json for game '${game}' at ${file}`);
+  try {
+    return JSON.parse(fs.readFileSync(file, 'utf8'));
+  } catch (e) {
+    die(`failed to parse ${file}: ${e.message}`);
+  }
+}
+
+function emit(obj) {
+  process.stdout.write(JSON.stringify(obj, null, 2) + '\n');
+}
+
+const COMMANDS = {
+  cargo(defs, id) {
+    const rec = defs.cargo[id];
+    if (!rec) die(`unknown cargo id '${id}'`);
+    emit({ id, ...rec });
+  },
+
+  'companies-for-cargo'(defs, id) {
+    if (!defs.cargo[id]) die(`unknown cargo id '${id}'`);
+    const companies = Object.entries(defs.companies)
+      .filter(([, c]) => Array.isArray(c.cargo_out) && c.cargo_out.includes(id))
+      .map(([cid, c]) => ({ id: cid, name: c.name }));
+    emit({ cargo: id, count: companies.length, companies });
+  },
+
+  city(defs, id) {
+    const rec = defs.cities[id];
+    if (!rec) die(`unknown city id '${id}'`);
+    emit({ id, ...rec });
+  },
+
+  'city-companies'(defs, id) {
+    const present = defs.city_companies[id];
+    if (!present) die(`unknown city id '${id}' (no city_companies entry)`);
+    const companies = Object.entries(present).map(([cid, count]) => ({
+      id: cid,
+      name: defs.companies[cid] ? defs.companies[cid].name : null,
+      count,
+    }));
+    emit({ city: id, count: companies.length, companies });
+  },
+};
+
+function main() {
+  const { game, subcommand, id } = parseArgs(process.argv.slice(2));
+  if (!subcommand) die(`missing subcommand\n${usage()}`);
+  if (!SUBCOMMANDS.includes(subcommand)) die(`unknown subcommand '${subcommand}'\n${usage()}`);
+  if (!id) die(`'${subcommand}' requires an <id>\n${usage()}`);
+  COMMANDS[subcommand](loadDefs(game), id);
+}
+
+main();


### PR DESCRIPTION
Closes #279.

`scripts/defs-query.cjs` (+ `npm run defs-query`) — query helper over `public/data/<game>/game-defs.json`. The four sections are id-keyed maps, not arrays; this indexes them correctly so ad-hoc heredocs stop throwing on `.get()`.

Subcommands: `cargo <id>`, `companies-for-cargo <id>`, `city <id>`, `city-companies <id>`. `--game ets2|ats` (default `ets2`).

Verified against committed data for both games: all four subcommands return correct records; reverse lookup (`companies-for-cargo`) and the nested `{companyId:count}` map (`city-companies`) resolve with names; unknown ids/args exit 1 with a one-line message (no stack trace); `-h` prints usage. Lint clean.