### PR TITLE
feat(dlc-value): per-body-type win breakdown for trailer DLCs

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -569,6 +569,32 @@ nav {
   padding-top: 0.3rem;
   border-top: 1px solid var(--border-primary);
 }
+.dlc-breakdown > summary {
+  cursor: pointer;
+  color: var(--text-secondary);
+  min-height: 24px;
+  display: flex;
+  align-items: center;
+}
+.dlc-breakdown > ul {
+  list-style: none;
+  margin: 0.4rem 0 0.1rem;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+.dlc-breakdown > ul li {
+  line-height: 1.4;
+}
+.dlc-bt-name {
+  font-weight: 500;
+  color: var(--text-primary);
+}
+.dlc-breakdown code {
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+}
 
 /* First-Visit DLC Banner */
 .dlc-banner {

--- a/src/frontend/__tests__/dlc-value.test.ts
+++ b/src/frontend/__tests__/dlc-value.test.ts
@@ -18,7 +18,7 @@ vi.mock('../storage', () => ({
 }));
 
 // Import after mocking
-import { sumGarageScores, computeAllDLCValues } from '../dlc-value';
+import { sumGarageScores, computeAllDLCValues, computeDLCValuesCore } from '../dlc-value';
 import { applyDLCFilter, getBlockedCities } from '../dlc-filter';
 import { buildLookups } from '../lookups';
 import type { AllData } from '../types';
@@ -236,5 +236,92 @@ describe('computeAllDLCValues', () => {
 
     const highPower = results.find((r) => r.dlcId === 'high_power');
     expect(highPower!.newGarageCities).toHaveLength(0);
+  });
+});
+
+/**
+ * Body-type breakdown (#257). `boxes` (dryvan) and `chilled` (reefer) ship from
+ * one Berlin company. Base `scs` trailers: dryvan vol 100 (HV 200), reefer vol 80
+ * (HV 240). `krone` adds a dryvan vol 150 (HV 300 — strict win) AND a reefer vol 80
+ * (HV 240 — exact tie). `tieonly` adds a dryvan vol 100 (HV 200 — exact tie). So
+ * krone wins exactly one body type (dryvan), and tieonly wins none.
+ */
+function createBreakdownTestData(): AllData {
+  const cargo = [
+    { id: 'boxes', name: 'Boxes', value: 2, volume: 1, mass: 100, fragility: 0, fragile: false, high_value: false, adr_class: 0, prob_coef: 1, body_types: ['dryvan'], groups: [], excluded: false },
+    { id: 'chilled', name: 'Chilled', value: 3, volume: 1, mass: 100, fragility: 0, fragile: false, high_value: false, adr_class: 0, prob_coef: 1, body_types: ['reefer'], groups: [], excluded: false },
+  ];
+  const trailers = [
+    { id: 'scs.dryvan.s3', name: 'SCS Dryvan', body_type: 'dryvan', volume: 100, chassis_mass: 5000, body_mass: 3000, gross_weight_limit: 40000, length: 13.6, chain_type: 'single', ownable: true },
+    { id: 'scs.reefer.s3', name: 'SCS Reefer', body_type: 'reefer', volume: 80, chassis_mass: 5000, body_mass: 3000, gross_weight_limit: 40000, length: 13.6, chain_type: 'single', ownable: true },
+    { id: 'krone.dryvan.xl', name: 'Krone Dryvan XL', body_type: 'dryvan', volume: 150, chassis_mass: 5000, body_mass: 3000, gross_weight_limit: 40000, length: 13.6, chain_type: 'single', ownable: true },
+    { id: 'krone.reefer.s3', name: 'Krone Reefer', body_type: 'reefer', volume: 80, chassis_mass: 5000, body_mass: 3000, gross_weight_limit: 40000, length: 13.6, chain_type: 'single', ownable: true },
+    { id: 'tieonly.dryvan.s3', name: 'TieOnly Dryvan', body_type: 'dryvan', volume: 100, chassis_mass: 5000, body_mass: 3000, gross_weight_limit: 40000, length: 13.6, chain_type: 'single', ownable: true },
+  ];
+  return {
+    gameDefs: {
+      cities: { berlin: { name: 'Berlin', country: 'germany', has_garage: true } },
+      countries: { germany: { name: 'Germany' } },
+      companies: { co: { name: 'Co', cargo_out: ['boxes', 'chilled'], cargo_in: [], cities: ['berlin'] } },
+      cargo: Object.fromEntries(cargo.map(c => [c.id, { name: c.name, value: c.value, volume: c.volume, mass: c.mass, fragility: c.fragility, fragile: c.fragile, high_value: c.high_value, adr_class: c.adr_class, prob_coef: c.prob_coef, body_types: c.body_types, groups: c.groups, excluded: c.excluded }])),
+      trailers: Object.fromEntries(trailers.map(t => [t.id, { name: t.name, body_type: t.body_type, volume: t.volume, chassis_mass: t.chassis_mass, body_mass: t.body_mass, gross_weight_limit: t.gross_weight_limit, length: t.length, chain_type: t.chain_type, ownable: t.ownable }])),
+      city_companies: { berlin: { co: 2 } },
+      company_cargo: { co: ['boxes', 'chilled'] },
+      cargo_trailers: {
+        boxes: ['scs.dryvan.s3', 'krone.dryvan.xl', 'tieonly.dryvan.s3'],
+        chilled: ['scs.reefer.s3', 'krone.reefer.s3'],
+      },
+      cargo_trailer_units: {
+        boxes: { 'scs.dryvan.s3': 100, 'krone.dryvan.xl': 150, 'tieonly.dryvan.s3': 100 },
+        chilled: { 'scs.reefer.s3': 80, 'krone.reefer.s3': 80 },
+      },
+      economy: { fixed_revenue: 0, revenue_coef_per_km: 1, cargo_market_revenue_coef_per_km: 1 },
+      trucks: [],
+    },
+    observations: null,
+    cities: [{ id: 'berlin', name: 'Berlin', country: 'germany', hasGarage: true }],
+    companies: [{ id: 'co', name: 'Co' }],
+    cargo,
+    trailers,
+  };
+}
+
+describe('computeDLCValuesCore — body-type breakdown (#257)', () => {
+  const ownership = {
+    ownedTrailer: [], ownedCargo: [], ownedMap: [],
+    activeGarages: new Set(['berlin']),
+    garageCities: new Set(['berlin']),
+    unowned: [
+      { id: 'krone', type: 'trailer' as const, name: 'Krone' },
+      { id: 'tieonly', type: 'trailer' as const, name: 'Tie Only' },
+    ],
+    cityDlcMap: {}, combinedCargoDlcMap: {},
+  };
+
+  it('breaks down the body type a DLC wins, with runner-up and HV margin', () => {
+    const results = computeDLCValuesCore(createBreakdownTestData(), ownership);
+    const krone = results.find(r => r.dlcId === 'krone')!;
+
+    expect(krone.bodyTypeBreakdown).toBeDefined();
+    const dryvan = krone.bodyTypeBreakdown!.find(b => b.bodyType === 'dryvan');
+    expect(dryvan).toBeDefined();
+    expect(dryvan!.marginHV).toBe(100);            // 300 (krone) − 200 (scs)
+    expect(dryvan!.runnerUpTrailerSpec).toBeTruthy();
+    expect(dryvan!.countries).toBe(1);
+    expect(krone.totalDelta).toBeGreaterThan(0);   // the win flows through to EV
+  });
+
+  it('excludes body types the DLC only ties (no unique haul value)', () => {
+    const results = computeDLCValuesCore(createBreakdownTestData(), ownership);
+    const krone = results.find(r => r.dlcId === 'krone')!;
+    // krone.reefer.s3 ties scs.reefer.s3 → reefer must NOT appear
+    expect(krone.bodyTypeBreakdown!.some(b => b.bodyType === 'reefer')).toBe(false);
+  });
+
+  it('a pure-tie DLC yields no breakdown and ~0 EV delta (deterministic seed)', () => {
+    const results = computeDLCValuesCore(createBreakdownTestData(), ownership);
+    const tie = results.find(r => r.dlcId === 'tieonly')!;
+    expect(tie.bodyTypeBreakdown).toBeUndefined();
+    expect(Math.abs(tie.totalDelta)).toBeLessThan(1e-6);
   });
 });

--- a/src/frontend/__tests__/dlc-value.test.ts
+++ b/src/frontend/__tests__/dlc-value.test.ts
@@ -407,6 +407,41 @@ function createMultiCountryTestData(): AllData {
   };
 }
 
+/**
+ * DLC enables the FIRST trailer for a demanded body type. Berlin ships `boxes`
+ * (dryvan, served by scs) and `special` (silo) — but scs has NO silo trailer, so
+ * baseline can't haul `special`. feldbinder adds the only silo trailer.
+ */
+function createNewlyEnabledTestData(): AllData {
+  const cargo = [
+    { id: 'boxes', name: 'Boxes', value: 2, volume: 1, mass: 100, fragility: 0, fragile: false, high_value: false, adr_class: 0, prob_coef: 1, body_types: ['dryvan'], groups: [], excluded: false },
+    { id: 'special', name: 'Special', value: 4, volume: 1, mass: 100, fragility: 0, fragile: false, high_value: false, adr_class: 0, prob_coef: 1, body_types: ['silo'], groups: [], excluded: false },
+  ];
+  const trailers = [
+    { id: 'scs.dryvan.s3', name: 'SCS Dryvan', body_type: 'dryvan', volume: 100, chassis_mass: 5000, body_mass: 3000, gross_weight_limit: 40000, length: 13.6, chain_type: 'single', ownable: true },
+    { id: 'feldbinder.silo.s3', name: 'Feldbinder Silo', body_type: 'silo', volume: 80, chassis_mass: 5000, body_mass: 3000, gross_weight_limit: 40000, length: 13.6, chain_type: 'single', ownable: true },
+  ];
+  return {
+    gameDefs: {
+      cities: { berlin: { name: 'Berlin', country: 'germany', has_garage: true } },
+      countries: { germany: { name: 'Germany' } },
+      companies: { co: { name: 'Co', cargo_out: ['boxes', 'special'], cargo_in: [], cities: ['berlin'] } },
+      cargo: Object.fromEntries(cargo.map(c => [c.id, { ...c }])),
+      trailers: Object.fromEntries(trailers.map(t => [t.id, { ...t }])),
+      city_companies: { berlin: { co: 2 } },
+      company_cargo: { co: ['boxes', 'special'] },
+      cargo_trailers: { boxes: ['scs.dryvan.s3'], special: ['feldbinder.silo.s3'] },
+      cargo_trailer_units: { boxes: { 'scs.dryvan.s3': 100 }, special: { 'feldbinder.silo.s3': 80 } },
+      economy: { fixed_revenue: 0, revenue_coef_per_km: 1, cargo_market_revenue_coef_per_km: 1 },
+      trucks: [],
+    },
+    observations: null,
+    cities: [{ id: 'berlin', name: 'Berlin', country: 'germany', hasGarage: true }],
+    companies: [{ id: 'co', name: 'Co' }],
+    cargo, trailers,
+  };
+}
+
 describe('computeDLCValuesCore — breakdown demand-scoping + multi-country (#257)', () => {
   it('omits body types the garages do not demand (no false win, ~0 delta)', () => {
     const results = computeDLCValuesCore(createUndemandedTestData(), {
@@ -432,5 +467,23 @@ describe('computeDLCValuesCore — breakdown demand-scoping + multi-country (#25
     expect(dryvan).toBeDefined();
     expect(dryvan.marginHV).toBe(100);  // max(100 in A, 50 in B)
     expect(dryvan.countries).toBe(2);
+  });
+
+  it('reports a null runner-up when the DLC adds the first trailer for a demanded body type', () => {
+    // Berlin demands silo (`special`); scs has no silo trailer — feldbinder adds
+    // the first. baseHV = 0 → runner-up null, margin = the trailer's full HV, and
+    // the newly-enabled haul raises EV.
+    const results = computeDLCValuesCore(createNewlyEnabledTestData(), {
+      ownedTrailer: [], ownedCargo: [], ownedMap: [],
+      activeGarages: new Set(['berlin']), garageCities: new Set(['berlin']),
+      unowned: [{ id: 'feldbinder', type: 'trailer' as const, name: 'Feldbinder' }],
+      cityDlcMap: {}, combinedCargoDlcMap: {},
+    });
+    const f = results.find(r => r.dlcId === 'feldbinder')!;
+    const silo = f.bodyTypeBreakdown!.find(b => b.bodyType === 'silo')!;
+    expect(silo).toBeDefined();
+    expect(silo.runnerUpTrailerSpec).toBeNull();
+    expect(silo.marginHV).toBe(320);       // special.value 4 × 80 units, no prior trailer
+    expect(f.totalDelta).toBeGreaterThan(0);
   });
 });

--- a/src/frontend/__tests__/dlc-value.test.ts
+++ b/src/frontend/__tests__/dlc-value.test.ts
@@ -325,3 +325,112 @@ describe('computeDLCValuesCore — body-type breakdown (#257)', () => {
     expect(Math.abs(tie.totalDelta)).toBeLessThan(1e-6);
   });
 });
+
+/**
+ * Demand-scoping: Berlin ships only `boxes` (dryvan). `steel` (flatbed) exists in
+ * the dataset (flatbed trailers have HV > 0) but NO company ships it. `kogel` adds
+ * a stronger flatbed trailer. Because Berlin demands no flatbed, the DLC's flatbed
+ * dominance is irrelevant to this profile — it must NOT appear in the breakdown,
+ * and totalDelta is ~0.
+ */
+function createUndemandedTestData(): AllData {
+  const cargo = [
+    { id: 'boxes', name: 'Boxes', value: 2, volume: 1, mass: 100, fragility: 0, fragile: false, high_value: false, adr_class: 0, prob_coef: 1, body_types: ['dryvan'], groups: [], excluded: false },
+    { id: 'steel', name: 'Steel', value: 5, volume: 1, mass: 100, fragility: 0, fragile: false, high_value: false, adr_class: 0, prob_coef: 1, body_types: ['flatbed'], groups: [], excluded: false },
+  ];
+  const trailers = [
+    { id: 'scs.dryvan.s3', name: 'SCS Dryvan', body_type: 'dryvan', volume: 100, chassis_mass: 5000, body_mass: 3000, gross_weight_limit: 40000, length: 13.6, chain_type: 'single', ownable: true },
+    { id: 'scs.flatbed.s3', name: 'SCS Flatbed', body_type: 'flatbed', volume: 100, chassis_mass: 5000, body_mass: 3000, gross_weight_limit: 40000, length: 13.6, chain_type: 'single', ownable: true },
+    { id: 'kogel.flatbed.xl', name: 'Kogel Flatbed XL', body_type: 'flatbed', volume: 200, chassis_mass: 5000, body_mass: 3000, gross_weight_limit: 40000, length: 13.6, chain_type: 'single', ownable: true },
+  ];
+  return {
+    gameDefs: {
+      cities: { berlin: { name: 'Berlin', country: 'germany', has_garage: true } },
+      countries: { germany: { name: 'Germany' } },
+      companies: { co: { name: 'Co', cargo_out: ['boxes'], cargo_in: [], cities: ['berlin'] } },
+      cargo: Object.fromEntries(cargo.map(c => [c.id, { ...c }])),
+      trailers: Object.fromEntries(trailers.map(t => [t.id, { ...t }])),
+      city_companies: { berlin: { co: 2 } },
+      company_cargo: { co: ['boxes'] },
+      cargo_trailers: { boxes: ['scs.dryvan.s3'], steel: ['scs.flatbed.s3', 'kogel.flatbed.xl'] },
+      cargo_trailer_units: { boxes: { 'scs.dryvan.s3': 100 }, steel: { 'scs.flatbed.s3': 100, 'kogel.flatbed.xl': 200 } },
+      economy: { fixed_revenue: 0, revenue_coef_per_km: 1, cargo_market_revenue_coef_per_km: 1 },
+      trucks: [],
+    },
+    observations: null,
+    cities: [{ id: 'berlin', name: 'Berlin', country: 'germany', hasGarage: true }],
+    companies: [{ id: 'co', name: 'Co' }],
+    cargo, trailers,
+  };
+}
+
+/**
+ * Multi-country MAX-margin aggregation. Both Aaa (country_a) and Bbb (country_b)
+ * ship `boxes` (dryvan). `scs.dryvan.big` (HV 250) is valid only in country_b, so
+ * the runner-up there is stronger: krone wins by +100 in A (over scs.dryvan.s3,
+ * HV 200) and by +50 in B (over scs.dryvan.big, HV 250). The breakdown must report
+ * the MAX margin (100), its country's runner-up, and 2 affected countries.
+ */
+function createMultiCountryTestData(): AllData {
+  const cargo = [
+    { id: 'boxes', name: 'Boxes', value: 2, volume: 1, mass: 100, fragility: 0, fragile: false, high_value: false, adr_class: 0, prob_coef: 1, body_types: ['dryvan'], groups: [], excluded: false },
+  ];
+  const trailers = [
+    { id: 'scs.dryvan.s3', name: 'SCS Dryvan', body_type: 'dryvan', volume: 100, chassis_mass: 5000, body_mass: 3000, gross_weight_limit: 40000, length: 13.6, chain_type: 'single', ownable: true },
+    { id: 'scs.dryvan.big', name: 'SCS Dryvan Big', body_type: 'dryvan', volume: 125, chassis_mass: 5000, body_mass: 3000, gross_weight_limit: 40000, length: 13.6, chain_type: 'single', ownable: true, country_validity: ['country_b'] },
+    { id: 'krone.dryvan.xl', name: 'Krone Dryvan XL', body_type: 'dryvan', volume: 150, chassis_mass: 5000, body_mass: 3000, gross_weight_limit: 40000, length: 13.6, chain_type: 'single', ownable: true },
+  ];
+  return {
+    gameDefs: {
+      cities: { aaa: { name: 'Aaa', country: 'country_a', has_garage: true }, bbb: { name: 'Bbb', country: 'country_b', has_garage: true } },
+      countries: { country_a: { name: 'Country A' }, country_b: { name: 'Country B' } },
+      companies: {
+        co_a: { name: 'Co A', cargo_out: ['boxes'], cargo_in: [], cities: ['aaa'] },
+        co_b: { name: 'Co B', cargo_out: ['boxes'], cargo_in: [], cities: ['bbb'] },
+      },
+      cargo: Object.fromEntries(cargo.map(c => [c.id, { ...c }])),
+      trailers: Object.fromEntries(trailers.map(t => [t.id, { ...t }])),
+      city_companies: { aaa: { co_a: 2 }, bbb: { co_b: 2 } },
+      company_cargo: { co_a: ['boxes'], co_b: ['boxes'] },
+      cargo_trailers: { boxes: ['scs.dryvan.s3', 'scs.dryvan.big', 'krone.dryvan.xl'] },
+      cargo_trailer_units: { boxes: { 'scs.dryvan.s3': 100, 'scs.dryvan.big': 125, 'krone.dryvan.xl': 150 } },
+      economy: { fixed_revenue: 0, revenue_coef_per_km: 1, cargo_market_revenue_coef_per_km: 1 },
+      trucks: [],
+    },
+    observations: null,
+    cities: [
+      { id: 'aaa', name: 'Aaa', country: 'country_a', hasGarage: true },
+      { id: 'bbb', name: 'Bbb', country: 'country_b', hasGarage: true },
+    ],
+    companies: [{ id: 'co_a', name: 'Co A' }, { id: 'co_b', name: 'Co B' }],
+    cargo, trailers,
+  };
+}
+
+describe('computeDLCValuesCore — breakdown demand-scoping + multi-country (#257)', () => {
+  it('omits body types the garages do not demand (no false win, ~0 delta)', () => {
+    const results = computeDLCValuesCore(createUndemandedTestData(), {
+      ownedTrailer: [], ownedCargo: [], ownedMap: [],
+      activeGarages: new Set(['berlin']), garageCities: new Set(['berlin']),
+      unowned: [{ id: 'kogel', type: 'trailer' as const, name: 'Kogel' }],
+      cityDlcMap: {}, combinedCargoDlcMap: {},
+    });
+    const kogel = results.find(r => r.dlcId === 'kogel')!;
+    expect(kogel.bodyTypeBreakdown).toBeUndefined(); // flatbed not hauled at Berlin
+    expect(Math.abs(kogel.totalDelta)).toBeLessThan(1e-6);
+  });
+
+  it('reports the MAX margin and country count across multiple garage countries', () => {
+    const results = computeDLCValuesCore(createMultiCountryTestData(), {
+      ownedTrailer: [], ownedCargo: [], ownedMap: [],
+      activeGarages: new Set(['aaa', 'bbb']), garageCities: new Set(['aaa', 'bbb']),
+      unowned: [{ id: 'krone', type: 'trailer' as const, name: 'Krone' }],
+      cityDlcMap: {}, combinedCargoDlcMap: {},
+    });
+    const krone = results.find(r => r.dlcId === 'krone')!;
+    const dryvan = krone.bodyTypeBreakdown!.find(b => b.bodyType === 'dryvan')!;
+    expect(dryvan).toBeDefined();
+    expect(dryvan.marginHV).toBe(100);  // max(100 in A, 50 in B)
+    expect(dryvan.countries).toBe(2);
+  });
+});

--- a/src/frontend/dlc-value.ts
+++ b/src/frontend/dlc-value.ts
@@ -2,11 +2,22 @@
  * DLC Marginal Value Calculator
  *
  * For each unowned DLC, computes the fleet EV delta if the player were to own it.
- * Uses analytical rankings (fast) rather than full MC simulation.
+ * Re-runs the city rankings (reduced-sample MC, seeded per city) per scenario.
+ *
+ * Trailer DLCs additionally carry a per-body-type breakdown (#257): which body
+ * types the DLC's trailers now win, the trailer you'd otherwise use, and the
+ * haul-value margin. This is a STRUCTURAL diagnostic (winner vs runner-up HV
+ * across your garages' countries) — it explains where the value comes from and
+ * intentionally does NOT sum to `totalDelta`, which is garage-scoped EV (folds
+ * in spawn probability + contention) rather than raw HV.
  */
 
-import { applyDLCFilter, buildLookups, getBlockedCities, type AllData } from './data';
-import { calculateCityRankings, clearTrailerInfoCache } from './optimizer';
+import { applyDLCFilter, buildLookups, getBlockedCities, type AllData, type Lookups } from './data';
+import {
+  calculateCityRankings, clearTrailerInfoCache,
+  computeProfileTrailerInfoForCountry, bodyTypeDisplayName,
+  type ProfileTrailerInfo,
+} from './optimizer';
 import {
   TRAILER_DLCS, ALL_DLC_IDS,
   CARGO_DLCS, ALL_CARGO_DLC_IDS,
@@ -17,6 +28,16 @@ import {
   getOwnedGarages,
 } from './storage';
 
+/** A body-type profile a trailer DLC now wins, vs what you'd use without it. */
+export interface BodyTypeWinDelta {
+  bodyType: string;                    // primary body type (profile's first body type)
+  displayName: string;                 // profile display label (multi-body joined with " + ")
+  winnerTrailerSpec: string;           // the DLC trailer that now wins this profile
+  runnerUpTrailerSpec: string | null;  // best non-DLC trailer for this profile (null if none existed)
+  marginHV: number;                    // winner totalHV − runner-up totalHV (max across your garage countries)
+  countries: number;                   // # of your garage countries where the DLC wins this profile
+}
+
 export interface DLCMarginalValue {
   dlcId: string;
   dlcName: string;
@@ -25,12 +46,37 @@ export interface DLCMarginalValue {
   existingGarageDelta: number;
   newCityPotential: number;
   newGarageCities: Array<{ id: string; name: string; score: number }>;
+  /** Trailer DLCs only — structural per-body-type win breakdown (#257). */
+  bodyTypeBreakdown?: BodyTypeWinDelta[];
+}
+
+/** Ownership scenario for the shared core — assembled from storage (main thread) or worker config. */
+export interface DLCValueOwnership {
+  ownedTrailer: string[];
+  ownedCargo: string[];
+  ownedMap: string[];
+  activeGarages: Set<string>;
+  /** All purchasable-garage city ids. Passed in (not read from the storage
+   *  GARAGE_CITIES export) so the worker — where initDlcData never ran — uses
+   *  its config copy. */
+  garageCities: ReadonlySet<string>;
+  unowned: Array<{ id: string; type: 'map' | 'trailer' | 'cargo'; name: string }>;
+  cityDlcMap: Record<string, string[]>;
+  combinedCargoDlcMap: Record<string, string>;
+}
+
+interface ScenarioResult {
+  total: number;
+  perCity: Map<string, number>;
+  filtered: AllData;
+  lookups: Lookups;
 }
 
 /**
  * Compute total garage score and per-city scores for a given DLC ownership scenario.
  * Pure computation — takes all DLC maps as parameters so it works in both
- * the main thread and the Web Worker.
+ * the main thread and the Web Worker. Returns the filtered data + lookups it
+ * builds so callers can diff per-(profile, country) winners across scenarios.
  */
 export function sumGarageScores(
   rawData: AllData,
@@ -40,7 +86,7 @@ export function sumGarageScores(
   garageCityIds: Set<string>,
   cityDlcMap: Record<string, string[]>,
   combinedCargoDlcMap: Record<string, string>,
-): { total: number; perCity: Map<string, number> } {
+): ScenarioResult {
   const blocked = getBlockedCities(ownedMap, cityDlcMap);
   const filtered = applyDLCFilter(rawData, ownedTrailer, ownedCargoAndMap, combinedCargoDlcMap, blocked);
   const lookups = buildLookups(filtered);
@@ -55,81 +101,127 @@ export function sumGarageScores(
       total += r.score;
     }
   }
-  return { total, perCity };
+  return { total, perCity, filtered, lookups };
+}
+
+/** Distinct countries of the active garage cities. */
+function garageCountriesOf(rawData: AllData, activeGarages: Set<string>): string[] {
+  const countries = new Set<string>();
+  for (const c of rawData.cities) {
+    if (activeGarages.has(c.id)) countries.add(c.country);
+  }
+  return [...countries];
 }
 
 /**
- * Compute marginal EV delta for every unowned DLC.
- * Calls onProgress(completed, total) between each DLC evaluation.
+ * Per-body-type breakdown for a trailer DLC: across the player's garage countries,
+ * find profiles whose best trailer's total HV rose when the DLC was added, and
+ * report the DLC winner, the prior best (runner-up), and the HV margin. Diffs the
+ * baseline scenario's per-country winners against the hypothetical's. The only
+ * trailers hypo adds over baseline are this DLC's, so any HV increase is attributable
+ * to it.
  */
-export async function computeAllDLCValues(
-  rawData: AllData,
-  onProgress?: (completed: number, total: number) => void,
-): Promise<DLCMarginalValue[]> {
-  const ownedTrailer = getOwnedTrailerDLCs();
-  const ownedCargo = getOwnedCargoDLCs();
-  const ownedMap = getOwnedMapDLCs();
-  const ownedGarages = new Set(getOwnedGarages());
+function computeBodyTypeBreakdown(
+  baselineProfiles: Map<string, Map<string, ProfileTrailerInfo>>,
+  hypo: ScenarioResult,
+  garageCountries: string[],
+): BodyTypeWinDelta[] {
+  const agg = new Map<string, {
+    bodyTypes: string[]; winnerSpec: string; runnerUpSpec: string | null;
+    maxMargin: number; countries: Set<string>;
+  }>();
 
-  // Garage cities the player currently uses (intersection of owned garages and GARAGE_CITIES)
-  const activeGarages = new Set<string>();
-  for (const g of ownedGarages) {
-    if (GARAGE_CITIES.has(g)) activeGarages.add(g);
+  for (const country of garageCountries) {
+    const baseInfo = baselineProfiles.get(country);
+    if (!baseInfo) continue;
+    const hypoInfo = computeProfileTrailerInfoForCountry(country, hypo.filtered, hypo.lookups);
+    for (const [key, hypoRep] of hypoInfo) {
+      const baseRep = baseInfo.get(key);
+      const baseHV = baseRep ? baseRep.totalHV : 0;
+      const margin = hypoRep.totalHV - baseHV;
+      if (margin <= 1e-6) continue; // DLC didn't raise this profile's best HV here
+
+      let a = agg.get(key);
+      if (!a) {
+        a = { bodyTypes: hypoRep.bodyTypes, winnerSpec: hypoRep.trailerSpec, runnerUpSpec: baseRep?.trailerSpec ?? null, maxMargin: margin, countries: new Set() };
+        agg.set(key, a);
+      }
+      a.countries.add(country);
+      if (margin > a.maxMargin) {
+        a.maxMargin = margin;
+        a.winnerSpec = hypoRep.trailerSpec;
+        a.runnerUpSpec = baseRep?.trailerSpec ?? null;
+      }
+    }
   }
 
-  // Baseline with current DLC ownership
-  const baselineCargoSet = new Set([...ownedCargo, ...ownedMap]);
-  const baseline = sumGarageScores(rawData, ownedTrailer, baselineCargoSet, ownedMap, activeGarages, CITY_DLC_MAP, COMBINED_CARGO_DLC_MAP);
+  const out: BodyTypeWinDelta[] = [];
+  for (const a of agg.values()) {
+    out.push({
+      bodyType: a.bodyTypes[0],
+      displayName: a.bodyTypes.map(bodyTypeDisplayName).join(' + '),
+      winnerTrailerSpec: a.winnerSpec,
+      runnerUpTrailerSpec: a.runnerUpSpec,
+      marginHV: Math.round(a.maxMargin),
+      countries: a.countries.size,
+    });
+  }
+  out.sort((x, y) => y.marginHV - x.marginHV);
+  return out;
+}
 
-  const unownedMap = ALL_MAP_DLC_IDS.filter(id => !ownedMap.includes(id));
-  const unownedTrailer = ALL_DLC_IDS.filter(id => !ownedTrailer.includes(id));
-  const unownedCargo = ALL_CARGO_DLC_IDS.filter(id => !ownedCargo.includes(id));
+/**
+ * Shared per-DLC computation used by both the main-thread calculator and the
+ * Web Worker — the single source of truth for the marginal-value math. Synchronous;
+ * the main-thread fallback wraps it (the worker path is the normal one and doesn't
+ * block the UI).
+ */
+export function computeDLCValuesCore(
+  rawData: AllData,
+  o: DLCValueOwnership,
+  onProgress?: (completed: number, total: number) => void,
+): DLCMarginalValue[] {
+  const baselineCargoSet = new Set([...o.ownedCargo, ...o.ownedMap]);
+  const baseline = sumGarageScores(rawData, o.ownedTrailer, baselineCargoSet, o.ownedMap, o.activeGarages, o.cityDlcMap, o.combinedCargoDlcMap);
 
-  const allUnowned = [
-    ...unownedMap.map(id => ({ id, type: 'map' as const, name: MAP_DLCS[id] })),
-    ...unownedTrailer.map(id => ({ id, type: 'trailer' as const, name: TRAILER_DLCS[id] })),
-    ...unownedCargo.map(id => ({ id, type: 'cargo' as const, name: CARGO_DLCS[id] })),
-  ];
+  const garageCountries = garageCountriesOf(rawData, o.activeGarages);
+  // Baseline per-(profile, country) winners — computed once, diffed against each hypo.
+  const baselineProfiles = new Map<string, Map<string, ProfileTrailerInfo>>();
+  for (const country of garageCountries) {
+    baselineProfiles.set(country, computeProfileTrailerInfoForCountry(country, baseline.filtered, baseline.lookups));
+  }
 
   const results: DLCMarginalValue[] = [];
   let completed = 0;
 
-  for (const dlc of allUnowned) {
-    // Build hypothetical ownership
-    const hypoTrailer = dlc.type === 'trailer' ? [...ownedTrailer, dlc.id] : ownedTrailer;
-    const hypoCargo = dlc.type === 'cargo' ? [...ownedCargo, dlc.id] : ownedCargo;
-    const hypoMap = dlc.type === 'map' ? [...ownedMap, dlc.id] : ownedMap;
+  for (const dlc of o.unowned) {
+    const hypoTrailer = dlc.type === 'trailer' ? [...o.ownedTrailer, dlc.id] : o.ownedTrailer;
+    const hypoCargo = dlc.type === 'cargo' ? [...o.ownedCargo, dlc.id] : o.ownedCargo;
+    const hypoMap = dlc.type === 'map' ? [...o.ownedMap, dlc.id] : o.ownedMap;
     const hypoCargoSet = new Set([...hypoCargo, ...hypoMap]);
 
-    // For map DLCs: new garage cities become available
-    const hypoGarages = new Set(activeGarages);
+    const hypoGarages = new Set(o.activeGarages);
     const newGarageCities: Array<{ id: string; name: string; score: number }> = [];
 
     if (dlc.type === 'map') {
-      const dlcCities = CITY_DLC_MAP[dlc.id] || [];
-      for (const cityId of dlcCities) {
-        if (GARAGE_CITIES.has(cityId)) {
-          hypoGarages.add(cityId);
-        }
+      for (const cityId of o.cityDlcMap[dlc.id] || []) {
+        if (o.garageCities.has(cityId)) hypoGarages.add(cityId);
       }
     }
 
-    const hypo = sumGarageScores(rawData, hypoTrailer, hypoCargoSet, hypoMap, hypoGarages, CITY_DLC_MAP, COMBINED_CARGO_DLC_MAP);
+    const hypo = sumGarageScores(rawData, hypoTrailer, hypoCargoSet, hypoMap, hypoGarages, o.cityDlcMap, o.combinedCargoDlcMap);
 
     // Existing garage delta = improvement at current garages only
     let existingGarageDelta = 0;
-    for (const g of activeGarages) {
-      const baseScore = baseline.perCity.get(g) ?? 0;
-      const hypoScore = hypo.perCity.get(g) ?? 0;
-      existingGarageDelta += hypoScore - baseScore;
+    for (const g of o.activeGarages) {
+      existingGarageDelta += (hypo.perCity.get(g) ?? 0) - (baseline.perCity.get(g) ?? 0);
     }
 
     // New city potential (map DLCs only)
     let newCityPotential = 0;
     if (dlc.type === 'map') {
-      const dlcCities = CITY_DLC_MAP[dlc.id] || [];
-      for (const cityId of dlcCities) {
-        if (GARAGE_CITIES.has(cityId) && !activeGarages.has(cityId)) {
+      for (const cityId of o.cityDlcMap[dlc.id] || []) {
+        if (o.garageCities.has(cityId) && !o.activeGarages.has(cityId)) {
           const score = hypo.perCity.get(cityId) ?? 0;
           newCityPotential += score;
           newGarageCities.push({
@@ -142,7 +234,7 @@ export async function computeAllDLCValues(
       newGarageCities.sort((a, b) => b.score - a.score);
     }
 
-    results.push({
+    const result: DLCMarginalValue = {
       dlcId: dlc.id,
       dlcName: dlc.name,
       dlcType: dlc.type,
@@ -150,20 +242,48 @@ export async function computeAllDLCValues(
       existingGarageDelta,
       newCityPotential,
       newGarageCities,
-    });
+    };
 
-    completed++;
-    onProgress?.(completed, allUnowned.length);
-
-    // Yield to UI between iterations
-    if (completed % 3 === 0) {
-      await new Promise(r => setTimeout(r, 0));
+    if (dlc.type === 'trailer' && garageCountries.length > 0) {
+      const breakdown = computeBodyTypeBreakdown(baselineProfiles, hypo, garageCountries);
+      if (breakdown.length > 0) result.bodyTypeBreakdown = breakdown;
     }
+
+    results.push(result);
+    completed++;
+    onProgress?.(completed, o.unowned.length);
   }
 
-  // Clean up cache state
   clearTrailerInfoCache();
-
   results.sort((a, b) => b.totalDelta - a.totalDelta);
   return results;
+}
+
+/**
+ * Main-thread entry point (synchronous-fallback path when no Web Worker).
+ * Reads ownership from storage and delegates to the shared core.
+ */
+export async function computeAllDLCValues(
+  rawData: AllData,
+  onProgress?: (completed: number, total: number) => void,
+): Promise<DLCMarginalValue[]> {
+  const ownedTrailer = getOwnedTrailerDLCs();
+  const ownedCargo = getOwnedCargoDLCs();
+  const ownedMap = getOwnedMapDLCs();
+
+  const activeGarages = new Set<string>();
+  for (const g of getOwnedGarages()) {
+    if (GARAGE_CITIES.has(g)) activeGarages.add(g);
+  }
+
+  const unowned = [
+    ...ALL_MAP_DLC_IDS.filter(id => !ownedMap.includes(id)).map(id => ({ id, type: 'map' as const, name: MAP_DLCS[id] })),
+    ...ALL_DLC_IDS.filter(id => !ownedTrailer.includes(id)).map(id => ({ id, type: 'trailer' as const, name: TRAILER_DLCS[id] })),
+    ...ALL_CARGO_DLC_IDS.filter(id => !ownedCargo.includes(id)).map(id => ({ id, type: 'cargo' as const, name: CARGO_DLCS[id] })),
+  ];
+
+  return computeDLCValuesCore(rawData, {
+    ownedTrailer, ownedCargo, ownedMap, activeGarages, garageCities: GARAGE_CITIES, unowned,
+    cityDlcMap: CITY_DLC_MAP, combinedCargoDlcMap: COMBINED_CARGO_DLC_MAP,
+  }, onProgress);
 }

--- a/src/frontend/dlc-value.ts
+++ b/src/frontend/dlc-value.ts
@@ -14,7 +14,7 @@
 
 import { applyDLCFilter, buildLookups, getBlockedCities, type AllData, type Lookups } from './data';
 import {
-  calculateCityRankings, clearTrailerInfoCache,
+  calculateCityRankings, clearTrailerInfoCache, buildCityDepotProfiles,
   computeProfileTrailerInfoForCountry, bodyTypeDisplayName,
   type ProfileTrailerInfo,
 } from './optimizer';
@@ -104,13 +104,31 @@ export function sumGarageScores(
   return { total, perCity, filtered, lookups };
 }
 
-/** Distinct countries of the active garage cities. */
-function garageCountriesOf(rawData: AllData, activeGarages: Set<string>): string[] {
-  const countries = new Set<string>();
+/** Active garage city ids grouped by country. */
+function garagesByCountryOf(rawData: AllData, activeGarages: Set<string>): Map<string, string[]> {
+  const byCountry = new Map<string, string[]>();
   for (const c of rawData.cities) {
-    if (activeGarages.has(c.id)) countries.add(c.country);
+    if (!activeGarages.has(c.id)) continue;
+    const list = byCountry.get(c.country);
+    if (list) list.push(c.id); else byCountry.set(c.country, [c.id]);
   }
-  return [...countries];
+  return byCountry;
+}
+
+/** Body types actually demanded at the given garage cities (under a given scenario's
+ *  trailer availability) — the union of bodyHV keys across their depots. */
+function demandedBodyTypes(cities: string[], lookups: Lookups): Set<string> {
+  const demanded = new Set<string>();
+  for (const cityId of cities) {
+    const depots = buildCityDepotProfiles(cityId, lookups);
+    if (!depots) continue;
+    for (const depot of depots) {
+      for (const c of depot.cargo) {
+        for (const bt of Object.keys(c.bodyHV)) demanded.add(bt);
+      }
+    }
+  }
+  return demanded;
 }
 
 /**
@@ -120,22 +138,29 @@ function garageCountriesOf(rawData: AllData, activeGarages: Set<string>): string
  * baseline scenario's per-country winners against the hypothetical's. The only
  * trailers hypo adds over baseline are this DLC's, so any HV increase is attributable
  * to it.
+ *
+ * Scoped to body types the player's garages actually demand (#257: the breakdown
+ * must reflect the operating profile — a DLC that dominates a body type none of
+ * your garages haul is irrelevant noise). A profile is reported only when one of
+ * the country's garages spawns cargo for it.
  */
 function computeBodyTypeBreakdown(
   baselineProfiles: Map<string, Map<string, ProfileTrailerInfo>>,
   hypo: ScenarioResult,
-  garageCountries: string[],
+  garagesByCountry: Map<string, string[]>,
 ): BodyTypeWinDelta[] {
   const agg = new Map<string, {
     bodyTypes: string[]; winnerSpec: string; runnerUpSpec: string | null;
     maxMargin: number; countries: Set<string>;
   }>();
 
-  for (const country of garageCountries) {
+  for (const [country, cities] of garagesByCountry) {
     const baseInfo = baselineProfiles.get(country);
     if (!baseInfo) continue;
+    const demanded = demandedBodyTypes(cities, hypo.lookups);
     const hypoInfo = computeProfileTrailerInfoForCountry(country, hypo.filtered, hypo.lookups);
     for (const [key, hypoRep] of hypoInfo) {
+      if (!hypoRep.bodyTypes.some(bt => demanded.has(bt))) continue; // not hauled at this country's garages
       const baseRep = baseInfo.get(key);
       const baseHV = baseRep ? baseRep.totalHV : 0;
       const margin = hypoRep.totalHV - baseHV;
@@ -184,10 +209,10 @@ export function computeDLCValuesCore(
   const baselineCargoSet = new Set([...o.ownedCargo, ...o.ownedMap]);
   const baseline = sumGarageScores(rawData, o.ownedTrailer, baselineCargoSet, o.ownedMap, o.activeGarages, o.cityDlcMap, o.combinedCargoDlcMap);
 
-  const garageCountries = garageCountriesOf(rawData, o.activeGarages);
+  const garagesByCountry = garagesByCountryOf(rawData, o.activeGarages);
   // Baseline per-(profile, country) winners — computed once, diffed against each hypo.
   const baselineProfiles = new Map<string, Map<string, ProfileTrailerInfo>>();
-  for (const country of garageCountries) {
+  for (const country of garagesByCountry.keys()) {
     baselineProfiles.set(country, computeProfileTrailerInfoForCountry(country, baseline.filtered, baseline.lookups));
   }
 
@@ -244,8 +269,8 @@ export function computeDLCValuesCore(
       newGarageCities,
     };
 
-    if (dlc.type === 'trailer' && garageCountries.length > 0) {
-      const breakdown = computeBodyTypeBreakdown(baselineProfiles, hypo, garageCountries);
+    if (dlc.type === 'trailer' && garagesByCountry.size > 0) {
+      const breakdown = computeBodyTypeBreakdown(baselineProfiles, hypo, garagesByCountry);
       if (breakdown.length > 0) result.bodyTypeBreakdown = breakdown;
     }
 

--- a/src/frontend/dlcs.ts
+++ b/src/frontend/dlcs.ts
@@ -203,7 +203,7 @@ function renderResults(results: DLCMarginalValue[]): void {
     } else if (r.bodyTypeBreakdown && r.bodyTypeBreakdown.length > 0) {
       const lines = r.bodyTypeBreakdown.map(b => {
         const vs = b.runnerUpTrailerSpec ? `over <code>${b.runnerUpTrailerSpec}</code>` : '(no prior trailer)';
-        const where = b.countries > 0 ? ` · ${b.countries} ${b.countries === 1 ? 'country' : 'countries'}` : '';
+        const where = ` · ${b.countries} ${b.countries === 1 ? 'country' : 'countries'}`;
         return `<li><span class="dlc-bt-name">${b.displayName}</span> wins ${vs} by <span class="positive">+${formatEV(b.marginHV)} HV</span>${where}</li>`;
       }).join('');
       const n = r.bodyTypeBreakdown.length;

--- a/src/frontend/dlcs.ts
+++ b/src/frontend/dlcs.ts
@@ -200,6 +200,16 @@ function renderResults(results: DLCMarginalValue[]): void {
         parts.push(`${r.newGarageCities.length} new garages: ${cityList}${more}`);
       }
       detail = parts.length ? `<div class="dlc-value-detail">${parts.join(' · ')}</div>` : '';
+    } else if (r.bodyTypeBreakdown && r.bodyTypeBreakdown.length > 0) {
+      const lines = r.bodyTypeBreakdown.map(b => {
+        const vs = b.runnerUpTrailerSpec ? `over <code>${b.runnerUpTrailerSpec}</code>` : '(no prior trailer)';
+        const where = b.countries > 0 ? ` · ${b.countries} ${b.countries === 1 ? 'country' : 'countries'}` : '';
+        return `<li><span class="dlc-bt-name">${b.displayName}</span> wins ${vs} by <span class="positive">+${formatEV(b.marginHV)} HV</span>${where}</li>`;
+      }).join('');
+      const n = r.bodyTypeBreakdown.length;
+      // Structural breakdown: which body types this DLC wins and the haul-value
+      // margin over the runner-up. Does not sum to the EV delta above (#257).
+      detail = `<details class="dlc-value-detail dlc-breakdown"><summary>Wins ${n} body type${n !== 1 ? 's' : ''} — where the value comes from</summary><ul>${lines}</ul></details>`;
     }
 
     return `

--- a/src/frontend/optimizer-worker.ts
+++ b/src/frontend/optimizer-worker.ts
@@ -15,11 +15,11 @@
  */
 
 import {
-  computeOptimalFleet, calculateCityRankings, clearTrailerInfoCache,
+  computeOptimalFleet, calculateCityRankings,
   type OptimalFleet, type CityRanking,
 } from './optimizer';
 import type { AllData, Lookups } from './types';
-import { sumGarageScores, type DLCMarginalValue } from './dlc-value';
+import { computeDLCValuesCore, type DLCMarginalValue } from './dlc-value';
 
 // ============================================
 // Module-level data store
@@ -72,99 +72,26 @@ function computeDLCValuesInWorker(
   postProgress: (completed: number, total: number) => void,
 ): DLCMarginalValue[] {
   const { ownedTrailer, ownedCargo, ownedMap, ownedGarages } = config;
-  const garageCitiesSet = new Set(config.garageCities);
+  const garageCities = new Set(config.garageCities);
 
   // Active garages = intersection of owned garages and garage cities
   const activeGarages = new Set<string>();
   for (const g of ownedGarages) {
-    if (garageCitiesSet.has(g)) activeGarages.add(g);
+    if (garageCities.has(g)) activeGarages.add(g);
   }
 
-  // Baseline
-  const baselineCargoSet = new Set([...ownedCargo, ...ownedMap]);
-  const baseline = sumGarageScores(
-    rawData, ownedTrailer, baselineCargoSet, ownedMap, activeGarages,
-    config.cityDlcMap, config.combinedCargoDlcMap,
-  );
-
-  const unownedMap = config.allMapDLCIds.filter(id => !ownedMap.includes(id));
-  const unownedTrailer = config.allTrailerDLCIds.filter(id => !ownedTrailer.includes(id));
-  const unownedCargo = config.allCargoDLCIds.filter(id => !ownedCargo.includes(id));
-
-  // Names are patched by the client after results come back
-  const allUnowned = [
-    ...unownedMap.map(id => ({ id, type: 'map' as const })),
-    ...unownedTrailer.map(id => ({ id, type: 'trailer' as const })),
-    ...unownedCargo.map(id => ({ id, type: 'cargo' as const })),
+  // Names are id placeholders — the client patches them after results return
+  // (the worker has no DLC name maps).
+  const unowned = [
+    ...config.allMapDLCIds.filter(id => !ownedMap.includes(id)).map(id => ({ id, type: 'map' as const, name: id })),
+    ...config.allTrailerDLCIds.filter(id => !ownedTrailer.includes(id)).map(id => ({ id, type: 'trailer' as const, name: id })),
+    ...config.allCargoDLCIds.filter(id => !ownedCargo.includes(id)).map(id => ({ id, type: 'cargo' as const, name: id })),
   ];
 
-  const results: DLCMarginalValue[] = [];
-  let completed = 0;
-
-  for (const dlc of allUnowned) {
-    const hypoTrailer = dlc.type === 'trailer' ? [...ownedTrailer, dlc.id] : ownedTrailer;
-    const hypoCargo = dlc.type === 'cargo' ? [...ownedCargo, dlc.id] : ownedCargo;
-    const hypoMap = dlc.type === 'map' ? [...ownedMap, dlc.id] : ownedMap;
-    const hypoCargoSet = new Set([...hypoCargo, ...hypoMap]);
-
-    const hypoGarages = new Set(activeGarages);
-    const newGarageCities: Array<{ id: string; name: string; score: number }> = [];
-
-    if (dlc.type === 'map') {
-      const dlcCities = config.cityDlcMap[dlc.id] || [];
-      for (const cityId of dlcCities) {
-        if (garageCitiesSet.has(cityId)) {
-          hypoGarages.add(cityId);
-        }
-      }
-    }
-
-    const hypo = sumGarageScores(
-      rawData, hypoTrailer, hypoCargoSet, hypoMap, hypoGarages,
-      config.cityDlcMap, config.combinedCargoDlcMap,
-    );
-
-    let existingGarageDelta = 0;
-    for (const g of activeGarages) {
-      const baseScore = baseline.perCity.get(g) ?? 0;
-      const hypoScore = hypo.perCity.get(g) ?? 0;
-      existingGarageDelta += hypoScore - baseScore;
-    }
-
-    let newCityPotential = 0;
-    if (dlc.type === 'map') {
-      const dlcCities = config.cityDlcMap[dlc.id] || [];
-      for (const cityId of dlcCities) {
-        if (garageCitiesSet.has(cityId) && !activeGarages.has(cityId)) {
-          const score = hypo.perCity.get(cityId) ?? 0;
-          newCityPotential += score;
-          newGarageCities.push({
-            id: cityId,
-            name: rawData.cities.find(c => c.id === cityId)?.displayName ?? cityId,
-            score,
-          });
-        }
-      }
-      newGarageCities.sort((a, b) => b.score - a.score);
-    }
-
-    results.push({
-      dlcId: dlc.id,
-      dlcName: dlc.id,  // placeholder — client patches with real name
-      dlcType: dlc.type,
-      totalDelta: hypo.total - baseline.total,
-      existingGarageDelta,
-      newCityPotential,
-      newGarageCities,
-    });
-
-    completed++;
-    postProgress(completed, allUnowned.length);
-  }
-
-  clearTrailerInfoCache();
-  results.sort((a, b) => b.totalDelta - a.totalDelta);
-  return results;
+  return computeDLCValuesCore(rawData, {
+    ownedTrailer, ownedCargo, ownedMap, activeGarages, garageCities, unowned,
+    cityDlcMap: config.cityDlcMap, combinedCargoDlcMap: config.combinedCargoDlcMap,
+  }, postProgress);
 }
 
 // ============================================

--- a/src/frontend/optimizer.ts
+++ b/src/frontend/optimizer.ts
@@ -97,7 +97,7 @@ export interface CityRanking {
 // Display helpers
 // ============================================
 
-function bodyTypeDisplayName(bodyType: string): string {
+export function bodyTypeDisplayName(bodyType: string): string {
   return bodyType.charAt(0).toUpperCase() + bodyType.slice(1).replace(/_/g, ' ');
 }
 
@@ -511,8 +511,19 @@ interface TrailerInfo {
   levelFloor: number;
 }
 
+/**
+ * Best trailer realizing a body-type profile in a country, plus its total haul
+ * value across all compatible cargo. `totalHV` is the comparison key used to
+ * pick the winner; surfaced so the DLC-value calculator can diff winner vs
+ * runner-up across ownership scenarios (#257).
+ */
+export interface ProfileTrailerInfo extends TrailerInfo {
+  bodyTypes: string[];
+  totalHV: number;
+}
+
 /** Cache: country → profileKey → best trailer info matching that exact profile */
-const profileTrailerCache = new Map<string, Map<string, TrailerInfo & { bodyTypes: string[] }>>();
+const profileTrailerCache = new Map<string, Map<string, ProfileTrailerInfo>>();
 
 /** Clear trailer info cache — needed when DLC filter state changes between optimizer runs */
 export function clearTrailerInfoCache(): void {
@@ -527,12 +538,25 @@ export function clearTrailerInfoCache(): void {
  * Also returns the best (cheapest among walked > parser > unpriced) trailer
  * realizing each profile — for display purposes after the optimizer picks.
  */
-function getProfileTrailerInfoForCountry(
+export function getProfileTrailerInfoForCountry(
   country: string, data: AllData, lookups: Lookups,
-): Map<string, TrailerInfo & { bodyTypes: string[] }> {
+): Map<string, ProfileTrailerInfo> {
   const cached = profileTrailerCache.get(country);
   if (cached) return cached;
+  const info = computeProfileTrailerInfoForCountry(country, data, lookups);
+  profileTrailerCache.set(country, info);
+  return info;
+}
 
+/**
+ * Uncached variant of {@link getProfileTrailerInfoForCountry}. The cache is keyed
+ * by country alone, so it returns stale results when called against different
+ * DLC-filtered datasets; the DLC-value calculator (#257) diffs winner vs runner-up
+ * across baseline/hypothetical ownership and must compute fresh per scenario.
+ */
+export function computeProfileTrailerInfoForCountry(
+  country: string, data: AllData, lookups: Lookups,
+): Map<string, ProfileTrailerInfo> {
   // Per profile, track best trailer by total haul value across its body-type slots.
   const bestByProfile = new Map<string, { trailer: Trailer; bodyTypes: string[]; totalHV: number }>();
 
@@ -589,18 +613,18 @@ function getProfileTrailerInfoForCountry(
     }
   }
 
-  const info = new Map<string, TrailerInfo & { bodyTypes: string[] }>();
-  for (const [key, { trailer, bodyTypes }] of bestByProfile) {
+  const info = new Map<string, ProfileTrailerInfo>();
+  for (const [key, { trailer, bodyTypes, totalHV }] of bestByProfile) {
     info.set(key, {
       trailerId: trailer.id,
       trailerSpec: formatTrailerSpec(trailer),
       estimatedPrice: trailer.price,
       levelFloor: trailer.level_floor,
       bodyTypes,
+      totalHV,
     });
   }
 
-  profileTrailerCache.set(country, info);
   return info;
 }
 


### PR DESCRIPTION
Closes #257.

Each trailer DLC row on the DLCs page now expands to a structural breakdown: which body types the DLC's trailers win, the trailer you'd otherwise use, and the haul-value margin — e.g. *"wins Curtainside over `scs.box…` by +161 HV (N countries)"*.

**Rescope** (recorded in the [issue comment](https://github.com/AlexOQ/trucker/issues/257#issuecomment-4741350973)): the ranking is reduced-sample MC seeded deterministically per city, so a DLC that raises no `bodyHV` produces *exactly* 0 — not a fake non-zero delta. (B) tie-break flagging was therefore dropped (cosmetic DLCs already read 0), and (A) is delivered as a runner-up-margin breakdown rather than a fleet-EV diff (which would show greedy-reorder phantom deltas). The breakdown is structural — it explains where value comes from and intentionally does not sum to the EV delta.

Also extracts the per-DLC loop, previously duplicated verbatim across `dlc-value.ts` and `optimizer-worker.ts`, into one shared `computeDLCValuesCore`.

Verified: new tests (a DLC winning one body type and tying another; a pure-tie DLC → no breakdown + ~0 delta) plus full suite + frontend build green. The breakdown's runner-up/margin matches the tie/winner structure `winners-table.cjs` / `all-ties.cjs` print.