### PR TITLE
docs(#254): streamline manual trailer-pricing intake + contribution path

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,7 @@ Euro Truck Simulator 2 and American Truck Simulator trucking company analyzer - 
 8. Re-run per game on every game update or DLC — full reseed, no incremental merge needed
 9. After re-parsing, update the manual fields in `public/data/<game>/data-version.json` (`game_version`, `coverage_notes`) and run `npm run gen:data-coverage` to refresh the README table + UI footer (see README "Data Coverage"; `--check` gates this in CI)
 
-**Manual trailer pricing**: the parser can't recover `chain_base` (per-brand/chain constant) or per-chassis `body_fee` from the dealer defs, so `mergeManualPrices()` overlays hand-walked prices from `public/data/<game>/manual-prices.json` (keyed by trailer id: `{price, source_pack, last_verified_game_version}`); without it ~245 trailers price as 0. `--audit-walks` lists trailers needing a walk plus orphaned entries; `--diff` flags real dealer-price shifts to re-verify. Canonical methodology, live walk queue, and contribution steps: `docs/manual-prices-audit.md`.
+**Manual trailer pricing**: the parser can't recover `chain_base` (per-brand/chain constant) or per-chassis `body_fee` from the dealer defs, so `mergeManualPrices()` overlays hand-walked prices from `public/data/<game>/manual-prices.json` (keyed by trailer id: `{price, source_pack, last_verified_game_version}`) — without it many trailers are left unpriced or underestimated. `--audit-walks` lists trailers needing a walk plus orphaned entries; `--diff` flags real dealer-price shifts to re-verify. Canonical methodology, live walk queue, and contribution steps: `docs/manual-prices-audit.md`.
 
 **Diff mode**: `npx tsx scripts/parse-game-defs.ts /path/to/def --diff --game <ets2|ats>`
 - Compares freshly parsed data against existing `game-defs.json` without writing

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,8 @@ Euro Truck Simulator 2 and American Truck Simulator trucking company analyzer - 
 8. Re-run per game on every game update or DLC — full reseed, no incremental merge needed
 9. After re-parsing, update the manual fields in `public/data/<game>/data-version.json` (`game_version`, `coverage_notes`) and run `npm run gen:data-coverage` to refresh the README table + UI footer (see README "Data Coverage"; `--check` gates this in CI)
 
+**Manual trailer pricing**: the parser can't recover `chain_base` (per-brand/chain constant) or per-chassis `body_fee` from the dealer defs, so `mergeManualPrices()` overlays hand-walked prices from `public/data/<game>/manual-prices.json` (keyed by trailer id: `{price, source_pack, last_verified_game_version}`); without it ~245 trailers price as 0. `--audit-walks` lists trailers needing a walk plus orphaned entries; `--diff` flags real dealer-price shifts to re-verify. Canonical methodology, live walk queue, and contribution steps: `docs/manual-prices-audit.md`.
+
 **Diff mode**: `npx tsx scripts/parse-game-defs.ts /path/to/def --diff --game <ets2|ats>`
 - Compares freshly parsed data against existing `game-defs.json` without writing
 - Reports added/removed/changed entries for cargo, trailers, companies, cities

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,10 @@ When new DLC or updates add content:
 2. Add new entries following the conventions in [DATA.md](DATA.md)
 3. Submit a PR with all related changes
 
+### 4. Contribute Trailer Price Walks
+
+Multi-trailer (HCT/double) and DLC-brand trailer prices are assembled in the in-game customization screen and can't be read from the game files — they're hand-walked into `public/data/<game>/manual-prices.json`. If you own a trailer DLC that's still missing prices, see the walk methodology, the live "wanted" queue, and step-by-step intake in [docs/manual-prices-audit.md](docs/manual-prices-audit.md#contributing-a-walk).
+
 ## Data Contribution Guidelines
 
 ### City Names

--- a/docs/manual-prices-audit.md
+++ b/docs/manual-prices-audit.md
@@ -62,7 +62,7 @@ Own a trailer DLC the maintainer doesn't (Feldbinder, Kögel, Krone, Schwarzmül
    }
    ```
    The key is the trailer id as it appears in `game-defs.json`. Set `last_verified_game_version` to the current `game_version` in `public/data/ets2/data-version.json`. Use the dealer-screen total (all sections cheapest) as `price`.
-3. Verify: `npx tsx scripts/parse-game-defs.ts <def> --game ets2 --audit-walks` — your key should drop off the "needs walk" list with no orphan warnings; `--diff` should show only your price change.
+3. Verify: `npx tsx scripts/parse-game-defs.ts <def> --game ets2 --diff --audit-walks` (the `--diff` makes it audit **without** rewriting `game-defs.json`) — your key should drop off the "needs walk" list with no orphan warnings, and the diff should show only your price change.
 4. Open a PR. Include the `chassis_fee + body_fee + paint_min + chain_base = total` breakdown in the description so the values can be cross-checked.
 
 ## Suspect entries — assumed-identical body/chassis fees, not walked

--- a/docs/manual-prices-audit.md
+++ b/docs/manual-prices-audit.md
@@ -48,6 +48,23 @@ node scripts/all-ties.cjs ets2       # tie groups, NEEDS WALK markers
 node scripts/winners-table.cjs ets2  # one winner per body_type × country-band
 ```
 
+## Contributing a walk
+
+Own a trailer DLC the maintainer doesn't (Feldbinder, Kögel, Krone, Schwarzmüller, Tirsan — see the **Walk queue** below for the live "wanted" list)? You can contribute its prices:
+
+1. In-game, open the dealer for the trailer and set **every** section (chassis / body / paint / wheels / accessories) to its cheapest option. Record the displayed total per `(chassis, body)`, following the methodology above. Body fees scale per chassis, so walk each chassis variant separately.
+2. Add one entry per trailer key to `public/data/ets2/manual-prices.json` under `prices`:
+   ```json
+   "feldbinder.kip.single_3_60.silo_60_3g": {
+     "price": 137050,
+     "source_pack": "feldbinder",
+     "last_verified_game_version": "1.60.1.0"
+   }
+   ```
+   The key is the trailer id as it appears in `game-defs.json`. Set `last_verified_game_version` to the current `game_version` in `public/data/ets2/data-version.json`. Use the dealer-screen total (all sections cheapest) as `price`.
+3. Verify: `npx tsx scripts/parse-game-defs.ts <def> --game ets2 --audit-walks` — your key should drop off the "needs walk" list with no orphan warnings; `--diff` should show only your price change.
+4. Open a PR. Include the `chassis_fee + body_fee + paint_min + chain_base = total` breakdown in the description so the values can be cross-checked.
+
 ## Suspect entries — assumed-identical body/chassis fees, not walked
 
 Pre-existing entries entered assuming a sibling variant has the same price. Likely wrong post-discovery that body fees vary by chassis.

--- a/docs/manual-prices-audit.md
+++ b/docs/manual-prices-audit.md
@@ -28,7 +28,7 @@ Internal body suffixes in the trailer keys don't match what the in-game dealer s
 
 ### Why the parser alone is insufficient
 
-`extractTrailerPricing()` in `parse-game-defs.ts` walks the dealer-accessory entries in the game defs but cannot recover `chain_base` (a per-brand/chain constant) or the per-chassis `body_fee` scaling — both of which are only visible on the live in-game dealer screen. Without `mergeManualPrices()` applying the walked overrides, ~368 trailers price as 0 and another ~70 underestimate by €5k–€55k. The manual walk queue is load-bearing for any trailer that participates in a winner-tie group.
+`extractTrailerPricing()` in `parse-game-defs.ts` walks the dealer-accessory entries in the game defs but cannot recover `chain_base` (a per-brand/chain constant) or the per-chassis `body_fee` scaling — both of which are only visible on the live in-game dealer screen. Without `mergeManualPrices()` applying the walked overrides, ~429 of 514 trailers price as 0 and 29 more underestimate by up to ~€55k; even with the overlay, 245 remain unpriced (DLC packs not yet walked + non-winner variants). The manual walk queue is load-bearing for any trailer that participates in a winner-tie group. (Counts as of the 1.60.1.0 data — re-check with `node scripts/all-ties.cjs ets2`.)
 
 For each trailer key, record the **cheapest configured-trailer total** the dealer screen shows when every selectable section (chassis / body / paint / wheels / accessories) is set to its lowest-priced option. This becomes the entry's `price`.
 
@@ -53,7 +53,8 @@ node scripts/winners-table.cjs ets2  # one winner per body_type × country-band
 Own a trailer DLC the maintainer doesn't (Feldbinder, Kögel, Krone, Schwarzmüller, Tirsan — see the **Walk queue** below for the live "wanted" list)? You can contribute its prices:
 
 1. In-game, open the dealer for the trailer and set **every** section (chassis / body / paint / wheels / accessories) to its cheapest option. Record the displayed total per `(chassis, body)`, following the methodology above. Body fees scale per chassis, so walk each chassis variant separately.
-2. Add one entry per trailer key to `public/data/ets2/manual-prices.json` under `prices`:
+2. Find the exact trailer keys with `node scripts/all-ties.cjs ets2` — it prints each tie group and marks the ones still `[NEEDS WALK]`. Keys match the ids in `game-defs.json`. Walking the cheapest member of a tie group resolves the whole group.
+3. Add one entry per key to `public/data/ets2/manual-prices.json` under `prices`:
    ```json
    "feldbinder.kip.single_3_60.silo_60_3g": {
      "price": 137050,
@@ -61,9 +62,9 @@ Own a trailer DLC the maintainer doesn't (Feldbinder, Kögel, Krone, Schwarzmül
      "last_verified_game_version": "1.60.1.0"
    }
    ```
-   The key is the trailer id as it appears in `game-defs.json`. Set `last_verified_game_version` to the current `game_version` in `public/data/ets2/data-version.json`. Use the dealer-screen total (all sections cheapest) as `price`.
-3. Verify: `npx tsx scripts/parse-game-defs.ts <def> --game ets2 --diff --audit-walks` (the `--diff` makes it audit **without** rewriting `game-defs.json`) — your key should drop off the "needs walk" list with no orphan warnings, and the diff should show only your price change.
-4. Open a PR. Include the `chassis_fee + body_fee + paint_min + chain_base = total` breakdown in the description so the values can be cross-checked.
+   `price` is the dealer-screen total (all sections cheapest). `source_pack` is the brand (advisory only). `last_verified_game_version` is the version you walked in — i.e. the current `game_version` in `public/data/ets2/data-version.json` for a fresh walk; it records when a price was last hand-walked, not when it was last presumed valid.
+4. Verify with `node scripts/all-ties.cjs ets2` again — your tie group should flip from `[NEEDS WALK …]` to `[RESOLVED → <your key> (walked=<price>)]`. (`node scripts/winners-table.cjs ets2` shows the resulting per-body-type winners.)
+5. Open a PR. Include the `chassis_fee + body_fee + paint_min + chain_base = total` breakdown in the description so the values can be cross-checked.
 
 ## Suspect entries — assumed-identical body/chassis fees, not walked
 

--- a/docs/manual-prices-audit.md
+++ b/docs/manual-prices-audit.md
@@ -28,7 +28,7 @@ Internal body suffixes in the trailer keys don't match what the in-game dealer s
 
 ### Why the parser alone is insufficient
 
-`extractTrailerPricing()` in `parse-game-defs.ts` walks the dealer-accessory entries in the game defs but cannot recover `chain_base` (a per-brand/chain constant) or the per-chassis `body_fee` scaling — both of which are only visible on the live in-game dealer screen. Without `mergeManualPrices()` applying the walked overrides, ~429 of 514 trailers price as 0 and 29 more underestimate by up to ~€55k; even with the overlay, 245 remain unpriced (DLC packs not yet walked + non-winner variants). The manual walk queue is load-bearing for any trailer that participates in a winner-tie group. (Counts as of the 1.60.1.0 data — re-check with `node scripts/all-ties.cjs ets2`.)
+`extractTrailerPricing()` in `parse-game-defs.ts` walks the dealer-accessory entries in the game defs but cannot recover `chain_base` (a per-brand/chain constant) or the per-chassis `body_fee` scaling — both of which are only visible on the live in-game dealer screen. Without `mergeManualPrices()` applying the walked overrides, ~429 of 514 trailers price as 0 and 29 more underestimate by up to ~€75k; even with the overlay, 245 remain unpriced (DLC packs not yet walked + non-winner variants). The manual walk queue is load-bearing for any trailer that participates in a winner-tie group. (Counts as of the 1.60.1.0 data — re-check with `node scripts/all-ties.cjs ets2`.)
 
 For each trailer key, record the **cheapest configured-trailer total** the dealer screen shows when every selectable section (chassis / body / paint / wheels / accessories) is set to its lowest-priced option. This becomes the entry's `price`.
 

--- a/public/data/ets2/manual-prices.json
+++ b/public/data/ets2/manual-prices.json
@@ -6,1067 +6,1067 @@
     "schmitz.scs.single_2.curtain": {
       "price": 41385,
       "source_pack": "schmitz_cargobull",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "schmitz.scs.single_2.curtainp": {
       "price": 41385,
       "source_pack": "schmitz_cargobull",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "schmitz.scs.single_3.curtain": {
       "price": 44385,
       "source_pack": "schmitz_cargobull",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "schmitz.scs.single_3.curtainp": {
       "price": 44385,
       "source_pack": "schmitz_cargobull",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "schmitz.scs.single_3.curtain_ef": {
       "price": 44385,
       "source_pack": "schmitz_cargobull",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "schmitz.scs.single_3.curtain_efp": {
       "price": 44385,
       "source_pack": "schmitz_cargobull",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "schmitz.scs.single_3sp.curtain": {
       "price": 44385,
       "source_pack": "schmitz_cargobull",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "schmitz.scs.single_3sp.curtainp": {
       "price": 44385,
       "source_pack": "schmitz_cargobull",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "schmitz.scs.single_3_15.curtain": {
       "price": 49385,
       "source_pack": "schmitz_cargobull",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "schmitz.scs.single_3_15.curtainp": {
       "price": 49385,
       "source_pack": "schmitz_cargobull",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "schmitz.scs.double_3_2.curtain": {
       "price": 69625,
       "source_pack": "schmitz_cargobull",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "schmitz.scs.double_3_2.curtainp": {
       "price": 69625,
       "source_pack": "schmitz_cargobull",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "schmitz.scs.hct_3_2_3.curtain": {
       "price": 96415,
       "source_pack": "schmitz_cargobull",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "schmitz.scs.hct_3_2_3.curtainp": {
       "price": 96415,
       "source_pack": "schmitz_cargobull",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "schmitz.sbo.single_2.dryvan": {
       "price": 60050,
       "source_pack": "schmitz_cargobull",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "schmitz.sbo.single_3.dryvan": {
       "price": 63050,
       "source_pack": "schmitz_cargobull",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "schmitz.sbo.single_3_15.dryvan": {
       "price": 68050,
       "source_pack": "schmitz_cargobull",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "schmitz.ski.ch_2_dsl.solid": {
       "price": 42910,
       "source_pack": "schmitz_cargobull",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "schmitz.ski.ch_2_dsl.solid_sc": {
       "price": 43910,
       "source_pack": "schmitz_cargobull",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "schmitz.ski.ch_2_dsl.light": {
       "price": 47910,
       "source_pack": "schmitz_cargobull",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "schmitz.ski.ch_2_dsl.light_sc": {
       "price": 49910,
       "source_pack": "schmitz_cargobull",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "schmitz.ski.ch_2_dal.solid": {
       "price": 42910,
       "source_pack": "schmitz_cargobull",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "schmitz.ski.ch_2_dal.solid_sc": {
       "price": 43910,
       "source_pack": "schmitz_cargobull",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "schmitz.ski.ch_2_dal.light": {
       "price": 47910,
       "source_pack": "schmitz_cargobull",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "schmitz.ski.ch_2_dal.light_sc": {
       "price": 49910,
       "source_pack": "schmitz_cargobull",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "schmitz.ski.ch_3_dsl.solid": {
       "price": 46910,
       "source_pack": "schmitz_cargobull",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "schmitz.ski.ch_3_dsl.solid_sc": {
       "price": 47910,
       "source_pack": "schmitz_cargobull",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "schmitz.ski.ch_3_dsl.light": {
       "price": 51910,
       "source_pack": "schmitz_cargobull",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "schmitz.ski.ch_3_dsl.light_sc": {
       "price": 53910,
       "source_pack": "schmitz_cargobull",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "schmitz.ski.ch_3_dal.solid": {
       "price": 46910,
       "source_pack": "schmitz_cargobull",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "schmitz.ski.ch_3_dal.solid_sc": {
       "price": 47910,
       "source_pack": "schmitz_cargobull",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "schmitz.ski.ch_3_dal.light": {
       "price": 51910,
       "source_pack": "schmitz_cargobull",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "schmitz.ski.ch_3_dal.light_sc": {
       "price": 53910,
       "source_pack": "schmitz_cargobull",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "schmitz.ski.ch_3_33_dsl.solid": {
       "price": 46910,
       "source_pack": "schmitz_cargobull",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "schmitz.ski.ch_3_33_dsl.solid_sc": {
       "price": 47910,
       "source_pack": "schmitz_cargobull",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "schmitz.ski.ch_3_33_dsl.light": {
       "price": 51910,
       "source_pack": "schmitz_cargobull",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "schmitz.ski.ch_3_33_dsl.light_sc": {
       "price": 53910,
       "source_pack": "schmitz_cargobull",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "schmitz.ski.ch_3_33_dal.solid": {
       "price": 46910,
       "source_pack": "schmitz_cargobull",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "schmitz.ski.ch_3_33_dal.solid_sc": {
       "price": 47910,
       "source_pack": "schmitz_cargobull",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "schmitz.ski.ch_3_33_dal.light": {
       "price": 51910,
       "source_pack": "schmitz_cargobull",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "schmitz.ski.ch_3_33_dal.light_sc": {
       "price": 53910,
       "source_pack": "schmitz_cargobull",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "schmitz.sko.single_2.reefer": {
       "price": 121650,
       "source_pack": "schmitz_cargobull",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "schmitz.sko.single_2sa.reefer": {
       "price": 122650,
       "source_pack": "schmitz_cargobull",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "schmitz.sko.single_3.reefer": {
       "price": 124650,
       "source_pack": "schmitz_cargobull",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "schmitz.sko.single_3sa.reefer": {
       "price": 126650,
       "source_pack": "schmitz_cargobull",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "schmitz.sko.single_3_15.reefer": {
       "price": 129650,
       "source_pack": "schmitz_cargobull",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "schmitz.sko.double_3_2.reefer": {
       "price": 206620,
       "source_pack": "schmitz_cargobull",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "kassbohrer.scx.hct_3_2_3.curtain": {
       "price": 95600,
       "source_pack": "kassbohrer",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "kassbohrer.scx.hct_3_2_3.curtainp": {
       "price": 97600,
       "source_pack": "kassbohrer",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "kassbohrer.shg.singl_3e_20.container": {
       "price": 70165,
       "source_pack": "kassbohrer",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "kassbohrer.shg.singl_3e_220.container": {
       "price": 70165,
       "source_pack": "kassbohrer",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "kassbohrer.shg.singl_3e_40.container": {
       "price": 70165,
       "source_pack": "kassbohrer",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "kassbohrer.sll.single_2_ln.cont": {
       "price": 97300,
       "source_pack": "kassbohrer",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "kassbohrer.sll.single_2_ln.low": {
       "price": 96300,
       "source_pack": "kassbohrer",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "kassbohrer.sll.single_2_ln.low_wood": {
       "price": 98300,
       "source_pack": "kassbohrer",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "kassbohrer.sll.single_2_sh.cont": {
       "price": 97300,
       "source_pack": "kassbohrer",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "kassbohrer.sll.single_2_sh.low": {
       "price": 96300,
       "source_pack": "kassbohrer",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "kassbohrer.sll.single_2_sh.low_wood": {
       "price": 98300,
       "source_pack": "kassbohrer",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "kassbohrer.sll.single_3_ln.cont": {
       "price": 99300,
       "source_pack": "kassbohrer",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "kassbohrer.sll.single_3_ln.low": {
       "price": 98300,
       "source_pack": "kassbohrer",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "kassbohrer.sll.single_3_ln.low_wood": {
       "price": 100300,
       "source_pack": "kassbohrer",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "kassbohrer.sll.single_3_sh.cont": {
       "price": 99300,
       "source_pack": "kassbohrer",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "kassbohrer.sll.single_3_sh.low": {
       "price": 98300,
       "source_pack": "kassbohrer",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "kassbohrer.sll.single_3_sh.low_wood": {
       "price": 100300,
       "source_pack": "kassbohrer",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.foodtank.single_2.paint": {
       "price": 90700,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.foodtank.single_2.chrome": {
       "price": 95700,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.foodtank.single_3.paint": {
       "price": 93700,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.foodtank.single_3.chrome": {
       "price": 98700,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.gastank.single_2.gastank": {
       "price": 98540,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.gastank.single_3.gastank": {
       "price": 101540,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.fueltank.single_2.fueltank": {
       "price": 99540,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.fueltank.single_3.fueltank": {
       "price": 102540,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.livestock.single_3s.str_pnt": {
       "price": 75570,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.livestock.single_3s.str_stl": {
       "price": 75570,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.livestock.single_3b.belly_pnt": {
       "price": 87570,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.livestock.single_3b.belly_stl": {
       "price": 87570,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.lowbed.single_2s.short": {
       "price": 49560,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.lowbed.single_3.short": {
       "price": 51560,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.lowbed.single_3s.short": {
       "price": 52560,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.lowbed.single_4_ln.long": {
       "price": 58560,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.lowbed.single_4_sh.short": {
       "price": 58560,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.lowbed.single_41_ln.long": {
       "price": 60560,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.lowbed.single_41_sh.short": {
       "price": 60560,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.lowbed.single_5_ln.long": {
       "price": 60560,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.lowbed.single_5_sh.short": {
       "price": 60560,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.lowloader.single_2_ln.long": {
       "price": 53500,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.lowloader.single_2_sh.short": {
       "price": 53500,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.lowloader.single_3_ln.long": {
       "price": 55500,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.lowloader.single_3_sh.short": {
       "price": 55500,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.lowloader.single_3_1.short": {
       "price": 57500,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.lowloader.single_4_ln.long": {
       "price": 58500,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.lowloader.single_4_sh.short": {
       "price": 58500,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.lowloader.single_4_1.short": {
       "price": 59500,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.flatbed.single_2.flatbed_w": {
       "price": 30700,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.flatbed.single_2.flatbed_s": {
       "price": 35700,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.flatbed.single_2.brick": {
       "price": 36700,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.flatbed.single_2.container": {
       "price": 38700,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.flatbed.single_2.brick_crane": {
       "price": 40700,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.flatbed.single_2a.flatbed_w": {
       "price": 31700,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.flatbed.single_2a.flatbed_s": {
       "price": 36700,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.flatbed.single_2a.brick": {
       "price": 37700,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.flatbed.single_2a.container": {
       "price": 39700,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.flatbed.single_2a.brick_crane": {
       "price": 41700,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.flatbed.single_3.flatbed_w": {
       "price": 33700,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.flatbed.single_3.flatbed_s": {
       "price": 38700,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.flatbed.single_3.brick": {
       "price": 39700,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.flatbed.single_3.container": {
       "price": 41700,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.flatbed.single_3.brick_crane": {
       "price": 43700,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.flatbed.single_3s.flatbed_w": {
       "price": 35700,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.flatbed.single_3s.flatbed_s": {
       "price": 40700,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.flatbed.single_3s.brick": {
       "price": 41700,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.flatbed.single_3s.container": {
       "price": 43700,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.flatbed.single_3s.brick_crane": {
       "price": 45700,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.flatbed.single_3sa.flatbed_w": {
       "price": 35700,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.flatbed.single_3sa.flatbed_s": {
       "price": 40700,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.flatbed.single_3sa.brick": {
       "price": 41700,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.flatbed.single_3sa.container": {
       "price": 43700,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.flatbed.single_3sa.brick_crane": {
       "price": 45700,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.flatbed.single_3s2.flatbed_w": {
       "price": 37700,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.flatbed.single_3s2.flatbed_s": {
       "price": 42700,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.flatbed.single_3s2.brick": {
       "price": 43700,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.flatbed.single_3s2.container": {
       "price": 45700,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.flatbed.single_3s2.brick_crane": {
       "price": 47700,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.flatbed.single_4.flatbed_w": {
       "price": 40700,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.flatbed.single_4.flatbed_s": {
       "price": 45700,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.flatbed.single_4.brick": {
       "price": 46700,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.flatbed.single_4.container": {
       "price": 48700,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.flatbed.single_4.brick_crane": {
       "price": 50700,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.box.hct_3_2_3.curtain": {
       "price": 93480,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.box.hct_3_2_3.dryvan": {
       "price": 143480,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.box.hct_3_2_3.dryvan_s": {
       "price": 147480,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.box.hct_3_2_3.dryvan_m": {
       "price": 149480,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.box.hct_3_2_3.insulated": {
       "price": 183480,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.box.hct_3_2_3.insulated_s": {
       "price": 187480,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.box.hct_3_2_3.reefer": {
       "price": 203480,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.box.hct_3_2_3.reefer_s": {
       "price": 207480,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.flatbed.hct_3_2_3.flatbed_w": {
       "price": 87480,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.flatbed.hct_3_2_3.flatbed_s": {
       "price": 97480,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.flatbed.hct_3_2_3.brick": {
       "price": 99480,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.flatbed.hct_3_2_3.brick_crane": {
       "price": 103480,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.flatbed.hct_3_2_3.container": {
       "price": 103480,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.log.hct_3_2_3.wood": {
       "price": 107408,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.log.hct_3_2_3.steel": {
       "price": 111408,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.gooseneck.hct_3_2_3.container": {
       "price": 83880,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.box.single_1.curtain": {
       "price": 19690,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.box.single_1.dryvan": {
       "price": 36690,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.box.single_1.dryvan_s": {
       "price": 38690,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.box.single_1.dryvan_m": {
       "price": 39690,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.box.single_1.insulated": {
       "price": 51690,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.box.single_1.insulated_s": {
       "price": 53690,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.box.single_1.reefer": {
       "price": 58690,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.box.single_1.reefer_s": {
       "price": 58690,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.box.single_3.curtain": {
       "price": 38110,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.box.single_3.dryvan": {
       "price": 63110,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.box.single_3.dryvan_s": {
       "price": 65110,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.box.single_3.dryvan_m": {
       "price": 69110,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.box.single_3.insulated": {
       "price": 83110,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.box.single_3.insulated_s": {
       "price": 85110,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.box.single_3.reefer": {
       "price": 117110,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.box.single_3.reefer_s": {
       "price": 119110,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.box.single_3.reefer_m": {
       "price": 120110,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.box.bdouble_2_2.curtain": {
       "price": 62800,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.box.bdouble_2_2.dryvan": {
       "price": 104800,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.box.bdouble_2_2.dryvan_s": {
       "price": 108800,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.box.bdouble_2_2.dryvan_m": {
       "price": 116800,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.box.bdouble_2_2.insulated": {
       "price": 139800,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.box.bdouble_2_2.insulated_s": {
       "price": 143800,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.box.bdouble_2_2.reefer": {
       "price": 202800,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.box.bdouble_2_2.reefer_s": {
       "price": 206800,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.flatbed.double_3_3.flatbed_w": {
       "price": 65520,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.flatbed.double_3_3.flatbed_s": {
       "price": 74020,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.flatbed.double_3_3.brick": {
       "price": 76020,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.flatbed.double_3_3.container": {
       "price": 79020,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.flatbed.double_3_3.brick_crane": {
       "price": 80020,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.flatbed.double_3_2.flatbed_w": {
       "price": 60310,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.flatbed.double_3_2.flatbed_s": {
       "price": 68810,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.flatbed.double_3_2.brick": {
       "price": 70810,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.flatbed.double_3_2.container": {
       "price": 73810,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.flatbed.double_3_2.brick_crane": {
       "price": 74810,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.flatbed.double_3_1.flatbed_w": {
       "price": 55100,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.flatbed.double_3_1.flatbed_s": {
       "price": 63600,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.flatbed.double_3_1.brick": {
       "price": 65600,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.flatbed.double_3_1.container": {
       "price": 68600,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.flatbed.double_3_1.brick_crane": {
       "price": 69600,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.log.bdouble_3_3.wood": {
       "price": 89620,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.log.bdouble_3_3.steel": {
       "price": 92620,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.flatbed.hct_3_2s_4.flatbed_w": {
       "price": 98690,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.flatbed.hct_3_2s_4.flatbed_s": {
       "price": 108690,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.flatbed.hct_3_2s_4.brick": {
       "price": 110690,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.flatbed.hct_3_2s_4.brick_crane": {
       "price": 114690,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.flatbed.hct_3_2s_4.container": {
       "price": 114690,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "kassbohrer.scx.single_3_15.curtain": {
       "price": 47410,
       "source_pack": "kassbohrer",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "kassbohrer.scx.single_3_15.curtainp": {
       "price": 48410,
       "source_pack": "kassbohrer",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.chemtank.single_3.paint": {
       "price": 67310,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.chemtank.single_3.chrome": {
       "price": 72310,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.dumper.single_3_10.steel": {
       "price": 56470,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.dumper.single_3_10.alu": {
       "price": 63470,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.log.single_3.wood": {
       "price": 47310,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.log.single_3.steel": {
       "price": 49310,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.silo.single_3_10.silo": {
       "price": 73895,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.silo.bdouble_3_3.silo": {
       "price": 127765,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "scs.silo.hct_3_3_2.silo": {
       "price": 173305,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "kassbohrer.scx.hct_3s_2_3.curtain": {
       "price": 99600,
       "source_pack": "kassbohrer",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "kassbohrer.scx.hct_3s_2_3.curtainp": {
       "price": 101600,
       "source_pack": "kassbohrer",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "wielton.strongm.ch_4_sw.strongm": {
       "price": 68200,
       "source_pack": "wielton",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "wielton.dropsidem.single_3.dropside635": {
       "price": 42830,
       "source_pack": "wielton",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "wielton.dropsidem.single_3.dropside835": {
       "price": 43330,
       "source_pack": "wielton",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "wielton.dropsidem.single_3.dropside1035": {
       "price": 43830,
       "source_pack": "wielton",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "wielton.curtainm.single_3.curtain": {
       "price": 41330,
       "source_pack": "wielton",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "wielton.curtainm.single_3.curtain_sb": {
       "price": 42330,
       "source_pack": "wielton",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "wielton.drym.single_3.drym": {
       "price": 65130,
       "source_pack": "wielton",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "wielton.containerm.single_3_220.container": {
       "price": 35170,
       "source_pack": "wielton",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     },
     "wielton.containerm.single_3_40.container": {
       "price": 38970,
       "source_pack": "wielton",
-      "last_verified_game_version": "1.60.1.0"
+      "last_verified_game_version": "1.59"
     }
   }
 }

--- a/public/data/ets2/manual-prices.json
+++ b/public/data/ets2/manual-prices.json
@@ -6,1067 +6,1067 @@
     "schmitz.scs.single_2.curtain": {
       "price": 41385,
       "source_pack": "schmitz_cargobull",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "schmitz.scs.single_2.curtainp": {
       "price": 41385,
       "source_pack": "schmitz_cargobull",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "schmitz.scs.single_3.curtain": {
       "price": 44385,
       "source_pack": "schmitz_cargobull",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "schmitz.scs.single_3.curtainp": {
       "price": 44385,
       "source_pack": "schmitz_cargobull",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "schmitz.scs.single_3.curtain_ef": {
       "price": 44385,
       "source_pack": "schmitz_cargobull",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "schmitz.scs.single_3.curtain_efp": {
       "price": 44385,
       "source_pack": "schmitz_cargobull",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "schmitz.scs.single_3sp.curtain": {
       "price": 44385,
       "source_pack": "schmitz_cargobull",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "schmitz.scs.single_3sp.curtainp": {
       "price": 44385,
       "source_pack": "schmitz_cargobull",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "schmitz.scs.single_3_15.curtain": {
       "price": 49385,
       "source_pack": "schmitz_cargobull",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "schmitz.scs.single_3_15.curtainp": {
       "price": 49385,
       "source_pack": "schmitz_cargobull",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "schmitz.scs.double_3_2.curtain": {
       "price": 69625,
       "source_pack": "schmitz_cargobull",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "schmitz.scs.double_3_2.curtainp": {
       "price": 69625,
       "source_pack": "schmitz_cargobull",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "schmitz.scs.hct_3_2_3.curtain": {
       "price": 96415,
       "source_pack": "schmitz_cargobull",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "schmitz.scs.hct_3_2_3.curtainp": {
       "price": 96415,
       "source_pack": "schmitz_cargobull",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "schmitz.sbo.single_2.dryvan": {
       "price": 60050,
       "source_pack": "schmitz_cargobull",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "schmitz.sbo.single_3.dryvan": {
       "price": 63050,
       "source_pack": "schmitz_cargobull",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "schmitz.sbo.single_3_15.dryvan": {
       "price": 68050,
       "source_pack": "schmitz_cargobull",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "schmitz.ski.ch_2_dsl.solid": {
       "price": 42910,
       "source_pack": "schmitz_cargobull",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "schmitz.ski.ch_2_dsl.solid_sc": {
       "price": 43910,
       "source_pack": "schmitz_cargobull",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "schmitz.ski.ch_2_dsl.light": {
       "price": 47910,
       "source_pack": "schmitz_cargobull",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "schmitz.ski.ch_2_dsl.light_sc": {
       "price": 49910,
       "source_pack": "schmitz_cargobull",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "schmitz.ski.ch_2_dal.solid": {
       "price": 42910,
       "source_pack": "schmitz_cargobull",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "schmitz.ski.ch_2_dal.solid_sc": {
       "price": 43910,
       "source_pack": "schmitz_cargobull",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "schmitz.ski.ch_2_dal.light": {
       "price": 47910,
       "source_pack": "schmitz_cargobull",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "schmitz.ski.ch_2_dal.light_sc": {
       "price": 49910,
       "source_pack": "schmitz_cargobull",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "schmitz.ski.ch_3_dsl.solid": {
       "price": 46910,
       "source_pack": "schmitz_cargobull",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "schmitz.ski.ch_3_dsl.solid_sc": {
       "price": 47910,
       "source_pack": "schmitz_cargobull",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "schmitz.ski.ch_3_dsl.light": {
       "price": 51910,
       "source_pack": "schmitz_cargobull",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "schmitz.ski.ch_3_dsl.light_sc": {
       "price": 53910,
       "source_pack": "schmitz_cargobull",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "schmitz.ski.ch_3_dal.solid": {
       "price": 46910,
       "source_pack": "schmitz_cargobull",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "schmitz.ski.ch_3_dal.solid_sc": {
       "price": 47910,
       "source_pack": "schmitz_cargobull",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "schmitz.ski.ch_3_dal.light": {
       "price": 51910,
       "source_pack": "schmitz_cargobull",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "schmitz.ski.ch_3_dal.light_sc": {
       "price": 53910,
       "source_pack": "schmitz_cargobull",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "schmitz.ski.ch_3_33_dsl.solid": {
       "price": 46910,
       "source_pack": "schmitz_cargobull",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "schmitz.ski.ch_3_33_dsl.solid_sc": {
       "price": 47910,
       "source_pack": "schmitz_cargobull",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "schmitz.ski.ch_3_33_dsl.light": {
       "price": 51910,
       "source_pack": "schmitz_cargobull",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "schmitz.ski.ch_3_33_dsl.light_sc": {
       "price": 53910,
       "source_pack": "schmitz_cargobull",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "schmitz.ski.ch_3_33_dal.solid": {
       "price": 46910,
       "source_pack": "schmitz_cargobull",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "schmitz.ski.ch_3_33_dal.solid_sc": {
       "price": 47910,
       "source_pack": "schmitz_cargobull",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "schmitz.ski.ch_3_33_dal.light": {
       "price": 51910,
       "source_pack": "schmitz_cargobull",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "schmitz.ski.ch_3_33_dal.light_sc": {
       "price": 53910,
       "source_pack": "schmitz_cargobull",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "schmitz.sko.single_2.reefer": {
       "price": 121650,
       "source_pack": "schmitz_cargobull",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "schmitz.sko.single_2sa.reefer": {
       "price": 122650,
       "source_pack": "schmitz_cargobull",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "schmitz.sko.single_3.reefer": {
       "price": 124650,
       "source_pack": "schmitz_cargobull",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "schmitz.sko.single_3sa.reefer": {
       "price": 126650,
       "source_pack": "schmitz_cargobull",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "schmitz.sko.single_3_15.reefer": {
       "price": 129650,
       "source_pack": "schmitz_cargobull",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "schmitz.sko.double_3_2.reefer": {
       "price": 206620,
       "source_pack": "schmitz_cargobull",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "kassbohrer.scx.hct_3_2_3.curtain": {
       "price": 95600,
       "source_pack": "kassbohrer",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "kassbohrer.scx.hct_3_2_3.curtainp": {
       "price": 97600,
       "source_pack": "kassbohrer",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "kassbohrer.shg.singl_3e_20.container": {
       "price": 70165,
       "source_pack": "kassbohrer",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "kassbohrer.shg.singl_3e_220.container": {
       "price": 70165,
       "source_pack": "kassbohrer",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "kassbohrer.shg.singl_3e_40.container": {
       "price": 70165,
       "source_pack": "kassbohrer",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "kassbohrer.sll.single_2_ln.cont": {
       "price": 97300,
       "source_pack": "kassbohrer",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "kassbohrer.sll.single_2_ln.low": {
       "price": 96300,
       "source_pack": "kassbohrer",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "kassbohrer.sll.single_2_ln.low_wood": {
       "price": 98300,
       "source_pack": "kassbohrer",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "kassbohrer.sll.single_2_sh.cont": {
       "price": 97300,
       "source_pack": "kassbohrer",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "kassbohrer.sll.single_2_sh.low": {
       "price": 96300,
       "source_pack": "kassbohrer",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "kassbohrer.sll.single_2_sh.low_wood": {
       "price": 98300,
       "source_pack": "kassbohrer",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "kassbohrer.sll.single_3_ln.cont": {
       "price": 99300,
       "source_pack": "kassbohrer",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "kassbohrer.sll.single_3_ln.low": {
       "price": 98300,
       "source_pack": "kassbohrer",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "kassbohrer.sll.single_3_ln.low_wood": {
       "price": 100300,
       "source_pack": "kassbohrer",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "kassbohrer.sll.single_3_sh.cont": {
       "price": 99300,
       "source_pack": "kassbohrer",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "kassbohrer.sll.single_3_sh.low": {
       "price": 98300,
       "source_pack": "kassbohrer",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "kassbohrer.sll.single_3_sh.low_wood": {
       "price": 100300,
       "source_pack": "kassbohrer",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.foodtank.single_2.paint": {
       "price": 90700,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.foodtank.single_2.chrome": {
       "price": 95700,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.foodtank.single_3.paint": {
       "price": 93700,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.foodtank.single_3.chrome": {
       "price": 98700,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.gastank.single_2.gastank": {
       "price": 98540,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.gastank.single_3.gastank": {
       "price": 101540,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.fueltank.single_2.fueltank": {
       "price": 99540,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.fueltank.single_3.fueltank": {
       "price": 102540,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.livestock.single_3s.str_pnt": {
       "price": 75570,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.livestock.single_3s.str_stl": {
       "price": 75570,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.livestock.single_3b.belly_pnt": {
       "price": 87570,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.livestock.single_3b.belly_stl": {
       "price": 87570,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.lowbed.single_2s.short": {
       "price": 49560,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.lowbed.single_3.short": {
       "price": 51560,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.lowbed.single_3s.short": {
       "price": 52560,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.lowbed.single_4_ln.long": {
       "price": 58560,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.lowbed.single_4_sh.short": {
       "price": 58560,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.lowbed.single_41_ln.long": {
       "price": 60560,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.lowbed.single_41_sh.short": {
       "price": 60560,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.lowbed.single_5_ln.long": {
       "price": 60560,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.lowbed.single_5_sh.short": {
       "price": 60560,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.lowloader.single_2_ln.long": {
       "price": 53500,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.lowloader.single_2_sh.short": {
       "price": 53500,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.lowloader.single_3_ln.long": {
       "price": 55500,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.lowloader.single_3_sh.short": {
       "price": 55500,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.lowloader.single_3_1.short": {
       "price": 57500,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.lowloader.single_4_ln.long": {
       "price": 58500,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.lowloader.single_4_sh.short": {
       "price": 58500,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.lowloader.single_4_1.short": {
       "price": 59500,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.flatbed.single_2.flatbed_w": {
       "price": 30700,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.flatbed.single_2.flatbed_s": {
       "price": 35700,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.flatbed.single_2.brick": {
       "price": 36700,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.flatbed.single_2.container": {
       "price": 38700,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.flatbed.single_2.brick_crane": {
       "price": 40700,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.flatbed.single_2a.flatbed_w": {
       "price": 31700,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.flatbed.single_2a.flatbed_s": {
       "price": 36700,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.flatbed.single_2a.brick": {
       "price": 37700,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.flatbed.single_2a.container": {
       "price": 39700,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.flatbed.single_2a.brick_crane": {
       "price": 41700,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.flatbed.single_3.flatbed_w": {
       "price": 33700,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.flatbed.single_3.flatbed_s": {
       "price": 38700,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.flatbed.single_3.brick": {
       "price": 39700,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.flatbed.single_3.container": {
       "price": 41700,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.flatbed.single_3.brick_crane": {
       "price": 43700,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.flatbed.single_3s.flatbed_w": {
       "price": 35700,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.flatbed.single_3s.flatbed_s": {
       "price": 40700,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.flatbed.single_3s.brick": {
       "price": 41700,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.flatbed.single_3s.container": {
       "price": 43700,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.flatbed.single_3s.brick_crane": {
       "price": 45700,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.flatbed.single_3sa.flatbed_w": {
       "price": 35700,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.flatbed.single_3sa.flatbed_s": {
       "price": 40700,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.flatbed.single_3sa.brick": {
       "price": 41700,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.flatbed.single_3sa.container": {
       "price": 43700,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.flatbed.single_3sa.brick_crane": {
       "price": 45700,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.flatbed.single_3s2.flatbed_w": {
       "price": 37700,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.flatbed.single_3s2.flatbed_s": {
       "price": 42700,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.flatbed.single_3s2.brick": {
       "price": 43700,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.flatbed.single_3s2.container": {
       "price": 45700,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.flatbed.single_3s2.brick_crane": {
       "price": 47700,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.flatbed.single_4.flatbed_w": {
       "price": 40700,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.flatbed.single_4.flatbed_s": {
       "price": 45700,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.flatbed.single_4.brick": {
       "price": 46700,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.flatbed.single_4.container": {
       "price": 48700,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.flatbed.single_4.brick_crane": {
       "price": 50700,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.box.hct_3_2_3.curtain": {
       "price": 93480,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.box.hct_3_2_3.dryvan": {
       "price": 143480,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.box.hct_3_2_3.dryvan_s": {
       "price": 147480,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.box.hct_3_2_3.dryvan_m": {
       "price": 149480,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.box.hct_3_2_3.insulated": {
       "price": 183480,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.box.hct_3_2_3.insulated_s": {
       "price": 187480,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.box.hct_3_2_3.reefer": {
       "price": 203480,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.box.hct_3_2_3.reefer_s": {
       "price": 207480,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.flatbed.hct_3_2_3.flatbed_w": {
       "price": 87480,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.flatbed.hct_3_2_3.flatbed_s": {
       "price": 97480,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.flatbed.hct_3_2_3.brick": {
       "price": 99480,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.flatbed.hct_3_2_3.brick_crane": {
       "price": 103480,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.flatbed.hct_3_2_3.container": {
       "price": 103480,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.log.hct_3_2_3.wood": {
       "price": 107408,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.log.hct_3_2_3.steel": {
       "price": 111408,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.gooseneck.hct_3_2_3.container": {
       "price": 83880,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.box.single_1.curtain": {
       "price": 19690,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.box.single_1.dryvan": {
       "price": 36690,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.box.single_1.dryvan_s": {
       "price": 38690,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.box.single_1.dryvan_m": {
       "price": 39690,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.box.single_1.insulated": {
       "price": 51690,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.box.single_1.insulated_s": {
       "price": 53690,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.box.single_1.reefer": {
       "price": 58690,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.box.single_1.reefer_s": {
       "price": 58690,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.box.single_3.curtain": {
       "price": 38110,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.box.single_3.dryvan": {
       "price": 63110,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.box.single_3.dryvan_s": {
       "price": 65110,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.box.single_3.dryvan_m": {
       "price": 69110,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.box.single_3.insulated": {
       "price": 83110,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.box.single_3.insulated_s": {
       "price": 85110,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.box.single_3.reefer": {
       "price": 117110,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.box.single_3.reefer_s": {
       "price": 119110,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.box.single_3.reefer_m": {
       "price": 120110,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.box.bdouble_2_2.curtain": {
       "price": 62800,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.box.bdouble_2_2.dryvan": {
       "price": 104800,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.box.bdouble_2_2.dryvan_s": {
       "price": 108800,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.box.bdouble_2_2.dryvan_m": {
       "price": 116800,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.box.bdouble_2_2.insulated": {
       "price": 139800,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.box.bdouble_2_2.insulated_s": {
       "price": 143800,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.box.bdouble_2_2.reefer": {
       "price": 202800,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.box.bdouble_2_2.reefer_s": {
       "price": 206800,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.flatbed.double_3_3.flatbed_w": {
       "price": 65520,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.flatbed.double_3_3.flatbed_s": {
       "price": 74020,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.flatbed.double_3_3.brick": {
       "price": 76020,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.flatbed.double_3_3.container": {
       "price": 79020,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.flatbed.double_3_3.brick_crane": {
       "price": 80020,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.flatbed.double_3_2.flatbed_w": {
       "price": 60310,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.flatbed.double_3_2.flatbed_s": {
       "price": 68810,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.flatbed.double_3_2.brick": {
       "price": 70810,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.flatbed.double_3_2.container": {
       "price": 73810,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.flatbed.double_3_2.brick_crane": {
       "price": 74810,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.flatbed.double_3_1.flatbed_w": {
       "price": 55100,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.flatbed.double_3_1.flatbed_s": {
       "price": 63600,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.flatbed.double_3_1.brick": {
       "price": 65600,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.flatbed.double_3_1.container": {
       "price": 68600,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.flatbed.double_3_1.brick_crane": {
       "price": 69600,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.log.bdouble_3_3.wood": {
       "price": 89620,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.log.bdouble_3_3.steel": {
       "price": 92620,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.flatbed.hct_3_2s_4.flatbed_w": {
       "price": 98690,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.flatbed.hct_3_2s_4.flatbed_s": {
       "price": 108690,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.flatbed.hct_3_2s_4.brick": {
       "price": 110690,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.flatbed.hct_3_2s_4.brick_crane": {
       "price": 114690,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.flatbed.hct_3_2s_4.container": {
       "price": 114690,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "kassbohrer.scx.single_3_15.curtain": {
       "price": 47410,
       "source_pack": "kassbohrer",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "kassbohrer.scx.single_3_15.curtainp": {
       "price": 48410,
       "source_pack": "kassbohrer",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.chemtank.single_3.paint": {
       "price": 67310,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.chemtank.single_3.chrome": {
       "price": 72310,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.dumper.single_3_10.steel": {
       "price": 56470,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.dumper.single_3_10.alu": {
       "price": 63470,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.log.single_3.wood": {
       "price": 47310,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.log.single_3.steel": {
       "price": 49310,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.silo.single_3_10.silo": {
       "price": 73895,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.silo.bdouble_3_3.silo": {
       "price": 127765,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "scs.silo.hct_3_3_2.silo": {
       "price": 173305,
       "source_pack": "scs_base",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "kassbohrer.scx.hct_3s_2_3.curtain": {
       "price": 99600,
       "source_pack": "kassbohrer",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "kassbohrer.scx.hct_3s_2_3.curtainp": {
       "price": 101600,
       "source_pack": "kassbohrer",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "wielton.strongm.ch_4_sw.strongm": {
       "price": 68200,
       "source_pack": "wielton",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "wielton.dropsidem.single_3.dropside635": {
       "price": 42830,
       "source_pack": "wielton",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "wielton.dropsidem.single_3.dropside835": {
       "price": 43330,
       "source_pack": "wielton",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "wielton.dropsidem.single_3.dropside1035": {
       "price": 43830,
       "source_pack": "wielton",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "wielton.curtainm.single_3.curtain": {
       "price": 41330,
       "source_pack": "wielton",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "wielton.curtainm.single_3.curtain_sb": {
       "price": 42330,
       "source_pack": "wielton",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "wielton.drym.single_3.drym": {
       "price": 65130,
       "source_pack": "wielton",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "wielton.containerm.single_3_220.container": {
       "price": 35170,
       "source_pack": "wielton",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     },
     "wielton.containerm.single_3_40.container": {
       "price": 38970,
       "source_pack": "wielton",
-      "last_verified_game_version": "1.59"
+      "last_verified_game_version": "1.60.1.0"
     }
   }
 }


### PR DESCRIPTION
Closes #254.

## Context
#254's pricing **infrastructure already shipped** (#258/#263/#265): the `manual-prices.json` schema, `mergeManualPrices()`, and the `--audit-walks`/`--diff` advisories. Verified still load-bearing on 1.60.1.0 — without the overlay ~429 of 514 trailers price as 0 and 29 underestimate. So this PR delivers the issue's *title* — streamline the intake and open a contribution path — as **docs only** (no data/code change).

## Changes
- **CLAUDE.md** — the Game Data Pipeline never mentioned the manual-pricing layer; added a concise note pointing at `docs/manual-prices-audit.md` as canonical.
- **docs/manual-prices-audit.md** — added a step-by-step **Contributing a walk** section (find keys + verify via `node scripts/all-ties.cjs ets2`, which needs no extracted def folder), and corrected the stale "~368 / ~70" figures in *Why the parser alone is insufficient* to the current `~429 / 29` (245 unpriced even with the overlay).
- **CONTRIBUTING.md** — added a *Trailer price walks* entry linking to the new section.

## Adversarial pass (after asylum) caught and fixed
- **Reverted** an attempted `last_verified_game_version` 1.59→1.60.1.0 bump — it asserted a re-walk that never happened (#264's "euro-exact" was a circular merged-output comparison, reverted by #265; the parser can't recover `chain_base`/`body_fee`). The field records the last hand-walk, so it stays 1.59; `game-defs.json` and `manual-prices.json` are unchanged by this PR.
- **Fixed** the walk-verify command — `--audit-walks` emits no "needs walk" list and excludes keys already in `game-defs.json`; the real signal is `all-ties.cjs` (NEEDS WALK → RESOLVED).

## Out of scope
- Walking unowned DLC packs (blocked on ownership — the contribution path enables it; tracked in the walk queue).
- ATS manual pricing (per #254).
- `CONTRIBUTING.md`'s stale 'File Formats' section + `DATA.md` reference — pre-existing docs debt, separate follow-up.

## Test
Docs-only; `git diff main` touches 3 docs files (no data/code). `npm run lint` passes; markdown anchors resolve.