### PR TITLE
fix(#298): exclude hidden factory/AI chassis from ATS cheapest-config

### DIFF
--- a/src/frontend/__tests__/trucks-cost.test.ts
+++ b/src/frontend/__tests__/trucks-cost.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import {
-  cheapest, cheapestCabinChassis, computeMinCost,
+  cheapest, cheapestCabinChassis, computeMinCost, isSelectable, UNBUYABLE_UNLOCK_FLOOR,
   brandLabel, modelLabel, displayName,
 } from '../trucks-cost';
 import type { GameDefs } from '../types';
@@ -29,6 +31,25 @@ describe('cheapest', () => {
     const items = [{ price: 10, unlock: 5 }, { price: 10, unlock: 2 }, { price: 10, unlock: 8 }];
     expect(cheapest(items)?.unlock).toBe(2);
   });
+
+  it('excludes hidden factory/AI variants with a sentinel unlock (#298)', () => {
+    // The $0 part would win on price if not filtered; it's a hidden, unbuyable chassis.
+    const items = [{ price: 0, unlock: 13_000_000 }, { price: 30, unlock: 0 }];
+    expect(cheapest(items)?.price).toBe(30);
+  });
+
+  it('returns null when every item is an unbuyable sentinel (#298)', () => {
+    expect(cheapest([{ price: 0, unlock: 13_000_000 }])).toBeNull();
+  });
+});
+
+describe('isSelectable', () => {
+  it('accepts real driver-level unlocks, rejects sentinel floors (#298)', () => {
+    expect(isSelectable({ unlock: 0 })).toBe(true);
+    expect(isSelectable({ unlock: 30 })).toBe(true);
+    expect(isSelectable({ unlock: UNBUYABLE_UNLOCK_FLOOR })).toBe(false);
+    expect(isSelectable({ unlock: 13_000_000 })).toBe(false);
+  });
 });
 
 describe('cheapestCabinChassis', () => {
@@ -56,6 +77,19 @@ describe('cheapestCabinChassis', () => {
       ],
     });
     expect(cheapestCabinChassis(truck)?.chassis.id).toBe('b');
+  });
+
+  it('skips a hidden factory chassis (sentinel unlock), picking the buyable one (#298)', () => {
+    // Mirrors the real ATS W900/389: a $0 chassis hidden via a sentinel unlock
+    // sits alongside the real buyable chassis. Price-first would grab the $0 one.
+    const truck = mkTruck({
+      cabins: [{ id: 'cab', name: '', price: 10, unlock: 0, suitable_for: [] }],
+      chassis: [
+        { id: 'hidden', name: '', axle_config: '6x4', tank_size: 0, price: 0, unlock: 13_000_000 },
+        { id: 'real', name: '', axle_config: '6x4', tank_size: 0, price: 19100, unlock: 0 },
+      ],
+    });
+    expect(cheapestCabinChassis(truck)?.chassis.id).toBe('real');
   });
 
   it('respects suitable_for[] and finds globally cheapest valid pair, not greedy per-cabin', () => {
@@ -152,4 +186,38 @@ describe('computeMinCost', () => {
     expect(r.paint).toBeNull();
     expect(r.total).toBe(15000 + 25000 + 5000 + 4000);
   });
+
+  it('ignores a hidden factory chassis — no impossible levelFloor (#298)', () => {
+    const truck = mkTruck({
+      ...baseTruck,
+      cabins: [{ id: 'cab', name: '', price: 15000, unlock: 0, suitable_for: [] }],
+      chassis: [
+        { id: 'hidden', name: '', axle_config: '6x4', tank_size: 0, price: 0, unlock: 13_000_000 },
+        { id: 'real', name: '', axle_config: '4x2', tank_size: 0, price: 25000, unlock: 0 },
+      ],
+    });
+    const r = computeMinCost(truck)!;
+    expect(r.chassis.id).toBe('real');
+    expect(r.levelFloor).toBeLessThan(UNBUYABLE_UNLOCK_FLOOR);
+  });
+});
+
+// #298: the bundled data must not surface unbuyable builds. A truck whose
+// cheapest config requires a sentinel-unlock (hidden factory/AI) part would show
+// an impossible "min cost … unlock 13,000,000" row. This guards both games'
+// committed game-defs.json against that regression.
+describe('committed data has no unbuyable cheapest config (#298)', () => {
+  for (const game of ['ats', 'ets2'] as const) {
+    it(`${game}: every rendered truck's cheapest config is actually buyable`, () => {
+      const data = JSON.parse(
+        readFileSync(join(process.cwd(), 'public', 'data', game, 'game-defs.json'), 'utf-8'),
+      ) as { trucks: Truck[] };
+      expect(data.trucks.length).toBeGreaterThan(0);
+      for (const truck of data.trucks) {
+        const config = computeMinCost(truck);
+        if (!config) continue; // no buyable config → truck doesn't render; fine
+        expect(config.levelFloor, `${truck.id} levelFloor`).toBeLessThan(UNBUYABLE_UNLOCK_FLOOR);
+      }
+    });
+  }
 });

--- a/src/frontend/trucks-cost.ts
+++ b/src/frontend/trucks-cost.ts
@@ -19,14 +19,33 @@ export interface MinCostConfig {
 }
 
 /**
- * Cheapest item by price, ties broken by lowest unlock level so the
- * earliest-available wins when prices match.
+ * Some chassis are factory/AI-default parts, not player-buyable shop options —
+ * e.g. the ATS Kenworth W900 "medium II 6x4" and the Peterbilt 389 "mid"/"mid2".
+ * SCS hides these from the customization UI with an astronomical `unlock`
+ * sentinel (observed 13,000,000 / 130,000,000) and `price: 0`. Real parts unlock
+ * at driver levels (0–30 across the current ETS2+ATS data; the Truck Simulator
+ * Wiki's W900 chassis list has no separate buyable "medium II"). A part at or
+ * above this floor can't be bought, so it must not win a cheapest-config nor
+ * show in the component listings. (#298 — validated against the def files, the
+ * Truck Simulator Wiki, and the SCS modding docs for accessory_chassis_data.)
+ */
+export const UNBUYABLE_UNLOCK_FLOOR = 1_000_000;
+
+/** False for hidden factory/AI-default variants players can't buy (see UNBUYABLE_UNLOCK_FLOOR). */
+export function isSelectable(c: { unlock: number }): boolean {
+  return c.unlock < UNBUYABLE_UNLOCK_FLOOR;
+}
+
+/**
+ * Cheapest selectable item by price, ties broken by lowest unlock level so the
+ * earliest-available wins when prices match. Disabled sentinels are excluded.
  */
 export function cheapest<T extends { price: number; unlock: number }>(items: T[]): T | null {
-  if (items.length === 0) return null;
-  let best = items[0];
-  for (let i = 1; i < items.length; i++) {
-    const c = items[i];
+  const selectable = items.filter(isSelectable);
+  if (selectable.length === 0) return null;
+  let best = selectable[0];
+  for (let i = 1; i < selectable.length; i++) {
+    const c = selectable[i];
     if (c.price < best.price || (c.price === best.price && c.unlock < best.unlock)) {
       best = c;
     }
@@ -40,10 +59,11 @@ export function cheapest<T extends { price: number; unlock: number }>(items: T[]
  */
 export function cheapestCabinChassis(truck: Truck): { cabin: Cabin; chassis: Chassis } | null {
   let best: { cabin: Cabin; chassis: Chassis; total: number } | null = null;
-  for (const cabin of truck.cabins ?? []) {
-    const fits = cabin.suitable_for.length === 0
+  for (const cabin of (truck.cabins ?? []).filter(isSelectable)) {
+    const compatible = cabin.suitable_for.length === 0
       ? truck.chassis
       : truck.chassis.filter((c) => cabin.suitable_for.includes(c.id));
+    const fits = compatible.filter(isSelectable);
     for (const chassis of fits) {
       const total = cabin.price + chassis.price;
       if (!best || total < best.total) best = { cabin, chassis, total };

--- a/src/frontend/trucks.ts
+++ b/src/frontend/trucks.ts
@@ -12,7 +12,7 @@ import { initPageData, initGameSelector } from './page-init';
 import { getGameMeta } from './game';
 import { normalize, type GameDefs } from './data';
 import { escapeHtml } from './utils';
-import { computeMinCost, brandLabel, modelLabel, displayName, type MinCostConfig } from './trucks-cost';
+import { computeMinCost, isSelectable, brandLabel, modelLabel, displayName, type MinCostConfig } from './trucks-cost';
 
 type Truck = GameDefs['trucks'][number];
 
@@ -149,22 +149,22 @@ function showTruckDetail(truckId: string): void {
       <div class="stat"><div class="stat-value">${config.paint ? `${currency}${config.paint.price.toLocaleString()}` : '—'}</div><div class="stat-label">Paint${config.paint ? ` · ${escapeHtml(displayName(config.paint.name))}` : ''}</div></div>
     </div>
 
-    ${componentTable('Cabins', truck.cabins ?? [], config.cabin.id, [
+    ${componentTable('Cabins', (truck.cabins ?? []).filter(isSelectable), config.cabin.id, [
       { header: 'Fits chassis', render: (c) => c.suitable_for.length === 0 ? 'any' : `${c.suitable_for.length}` },
     ])}
-    ${componentTable('Chassis', truck.chassis, config.chassis.id, [
+    ${componentTable('Chassis', truck.chassis.filter(isSelectable), config.chassis.id, [
       { header: 'Axle', render: (c) => c.axle_config || '?' },
       { header: 'Tank L', render: (c) => `${c.tank_size}` },
     ])}
-    ${componentTable('Engines', truck.engines, config.engine.id, [
+    ${componentTable('Engines', truck.engines.filter(isSelectable), config.engine.id, [
       { header: 'Torque', render: (e) => `${e.torque}` },
       { header: 'Vol L', render: (e) => `${e.volume}` },
     ])}
-    ${componentTable('Transmissions', truck.transmissions, config.transmission.id, [
+    ${componentTable('Transmissions', truck.transmissions.filter(isSelectable), config.transmission.id, [
       { header: 'Gears', render: (t) => `${t.forward_gears}f / ${t.reverse_gears}r` },
       { header: 'Retarder', render: (t) => t.retarder ? 'yes' : '—' },
     ])}
-    ${componentTable('Paints', truck.paints ?? [], config.paint?.id ?? null)}
+    ${componentTable('Paints', (truck.paints ?? []).filter(isSelectable), config.paint?.id ?? null)}
   `;
 }
 


### PR DESCRIPTION
Closes #298.

The ATS trucks page rendered two **unbuyable** "min cost \$65,800 · unlock level 13,000,000" rows — **Kenworth W900** and **Peterbilt 389** — because `cheapest()` selected by price-first and grabbed **\$0 chassis** that no player can buy.

## What these \$0 chassis actually are (validated, per your steer)
Not "disabled" leftovers — **factory/AI-default chassis hidden from the customization shop**:
- **Def files**: `6x4_mid2.sii` is `name: "@@chassis_medium_ii_6x4@@"`, `price: 0`, `unlock: 13000000`, `part_type: factory`; the buyable sibling is `price: 27900, unlock: 22`.
- **[The Truck Simulator Wiki](https://trucksimulator.wiki.gg/wiki/Kenworth_W900)**: the W900's buyable chassis are short/mid/long × {6x2, 6x4, 8x4 liftable, 8x6} — **one "mid 6x4," no separate "medium II."**
- **[SCS Modding Wiki — accessory_chassis_data](https://modding.scssoft.com/wiki/Documentation/Engine/Units/accessory_chassis_data)**: this unit defines chassis for player **and AI** vehicles; `price` defaults to 0. SCS hides non-shop parts behind an astronomical `unlock` sentinel.

Real unlock levels are driver levels (**0–30** across both games' data); the sentinels are **13,000,000 / 130,000,000**. The trucks themselves are fully ownable — all 19 ATS + 26 ETS2 still render.

## Fix
- `trucks-cost.ts`: `isSelectable()` + `UNBUYABLE_UNLOCK_FLOOR` (1,000,000); `cheapest()` and `cheapestCabinChassis()` skip sentinel parts. If a category had only unbuyable parts the truck would stop rendering (correct — it'd have no buyable config); none do today.
- `trucks.ts`: the component-detail tables filter by `isSelectable` too, so a hidden \$0 chassis no longer shows as a phantom "cheapest" option contradicting the selected build.
- Tests: predicate + selector units, a W900/389-shaped `computeMinCost` case, and a **real-data guard** that no committed truck (either game) resolves to a config with a sentinel `levelFloor`.

## Verification
- Before: W900/389 → \$0 chassis, levelFloor 13,000,000 / 130,000,000. After: real chassis, levelFloor 0.
- All 19 ATS + 26 ETS2 trucks still render; ETS2 output unchanged (no sentinels there).
- `npm run lint` clean; `trucks-cost` suite 24/24; production build OK. (The 5 local `nav-render` failures are the known Node-26 jsdom artifact, green on CI Node 20.)